### PR TITLE
Fix invalid fabSize attribute value in fragment_now_playing.xml

### DIFF
--- a/app/src/main/res/layout/fragment_now_playing.xml
+++ b/app/src/main/res/layout/fragment_now_playing.xml
@@ -126,7 +126,7 @@
             android:layout_height="wrap_content"
             android:contentDescription="Play/Pause"
             app:srcCompat="@drawable/ic_pause"
-            app:fabSize="large"
+            app:fabSize="auto"
             app:fabCustomSize="72dp"
             app:maxImageSize="32dp"
             app:shapeAppearanceOverlay="@style/ShapeAppearance.Material3.Corner.Full"


### PR DESCRIPTION
Changed fabSize from 'large' (invalid) to 'auto' which allows the fabCustomSize="72dp" to define the button size. The valid fabSize values are: auto, normal, mini.