### PR TITLE
Redesign Now Playing controls and improve mini player UX

### DIFF
--- a/app/src/main/res/drawable/avd_pause_to_play.xml
+++ b/app/src/main/res/drawable/avd_pause_to_play.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<animated-vector xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:aapt="http://schemas.android.com/aapt">
+    <aapt:attr name="android:drawable">
+        <vector
+            android:width="24dp"
+            android:height="24dp"
+            android:viewportWidth="24"
+            android:viewportHeight="24">
+            <group android:name="icon">
+                <path
+                    android:name="icon_path"
+                    android:fillColor="@android:color/white"
+                    android:pathData="M6,19h4V5H6v14zM14,5v14h4V5h-4z"/>
+            </group>
+        </vector>
+    </aapt:attr>
+    <target android:name="icon_path">
+        <aapt:attr name="android:animation">
+            <objectAnimator
+                android:duration="200"
+                android:propertyName="pathData"
+                android:valueFrom="M6,19h4V5H6v14zM14,5v14h4V5h-4z"
+                android:valueTo="M8,5v14l11,-7z"
+                android:valueType="pathType"/>
+        </aapt:attr>
+    </target>
+</animated-vector>

--- a/app/src/main/res/drawable/avd_play_to_pause.xml
+++ b/app/src/main/res/drawable/avd_play_to_pause.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<animated-vector xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:aapt="http://schemas.android.com/aapt">
+    <aapt:attr name="android:drawable">
+        <vector
+            android:width="24dp"
+            android:height="24dp"
+            android:viewportWidth="24"
+            android:viewportHeight="24">
+            <group android:name="icon">
+                <path
+                    android:name="icon_path"
+                    android:fillColor="@android:color/white"
+                    android:pathData="M8,5v14l11,-7z"/>
+            </group>
+        </vector>
+    </aapt:attr>
+    <target android:name="icon_path">
+        <aapt:attr name="android:animation">
+            <objectAnimator
+                android:duration="200"
+                android:propertyName="pathData"
+                android:valueFrom="M8,5v14l11,-7z"
+                android:valueTo="M6,19h4V5H6v14zM14,5v14h4V5h-4z"
+                android:valueType="pathType"/>
+        </aapt:attr>
+    </target>
+</animated-vector>

--- a/app/src/main/res/drawable/ic_volume.xml
+++ b/app/src/main/res/drawable/ic_volume.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M3,9v6h4l5,5V4L7,9H3zM16.5,12c0,-1.77 -1.02,-3.29 -2.5,-4.03v8.05c1.48,-0.73 2.5,-2.25 2.5,-4.02zM14,3.23v2.06c2.89,0.86 5,3.54 5,6.71s-2.11,5.85 -5,6.71v2.06c4.01,-0.91 7,-4.49 7,-8.77s-2.99,-7.86 -7,-8.77z"/>
+</vector>

--- a/app/src/main/res/layout/fragment_now_playing.xml
+++ b/app/src/main/res/layout/fragment_now_playing.xml
@@ -93,31 +93,51 @@
 
     </LinearLayout>
 
-    <!-- Playback Controls - Properly Centered -->
+    <!-- Playback Controls - Centered with Volume, Play/Pause, Record -->
     <androidx.constraintlayout.widget.ConstraintLayout
         android:id="@+id/nowPlayingControlsContainer"
-        android:layout_width="wrap_content"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginBottom="24dp"
+        android:paddingHorizontal="16dp"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/nowPlayingInfoContainer">
 
-        <!-- Record Button -->
-        <com.google.android.material.button.MaterialButton
-            android:id="@+id/recordButton"
-            style="@style/Widget.Material3.Button.IconButton.Filled.Tonal"
-            android:layout_width="56dp"
-            android:layout_height="56dp"
-            android:contentDescription="Record"
-            app:icon="@drawable/ic_record"
-            app:iconSize="24dp"
-            app:iconTint="@null"
-            app:layout_constraintBottom_toBottomOf="@id/playPauseButton"
+        <!-- Volume Control Container (Left) -->
+        <LinearLayout
+            android:id="@+id/volumeContainer"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:gravity="center_vertical"
+            app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintEnd_toStartOf="@id/playPauseButton"
             app:layout_constraintTop_toTopOf="@id/playPauseButton"
-            android:layout_marginEnd="20dp" />
+            app:layout_constraintBottom_toBottomOf="@id/playPauseButton"
+            android:layout_marginEnd="16dp">
+
+            <ImageView
+                android:id="@+id/volumeIcon"
+                android:layout_width="24dp"
+                android:layout_height="24dp"
+                android:src="@drawable/ic_volume"
+                android:contentDescription="Volume"
+                app:tint="?attr/colorOnSurfaceVariant" />
+
+            <SeekBar
+                android:id="@+id/volumeSeekBar"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:layout_marginStart="8dp"
+                android:max="100"
+                android:progress="100"
+                android:progressTint="?attr/colorPrimary"
+                android:thumbTint="?attr/colorPrimary" />
+
+        </LinearLayout>
 
         <!-- Main Play/Pause FAB - Large and Centered -->
         <com.google.android.material.floatingactionbutton.FloatingActionButton
@@ -135,20 +155,20 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
 
-        <!-- Stop Button -->
+        <!-- Record Button (Right) - Centered -->
         <com.google.android.material.button.MaterialButton
-            android:id="@+id/stopButton"
+            android:id="@+id/recordButton"
             style="@style/Widget.Material3.Button.IconButton.Filled.Tonal"
             android:layout_width="56dp"
             android:layout_height="56dp"
-            android:contentDescription="Stop"
-            app:icon="@drawable/ic_stop"
+            android:contentDescription="Record"
+            app:icon="@drawable/ic_record"
             app:iconSize="24dp"
-            app:iconTint="?attr/colorOnSecondaryContainer"
-            app:layout_constraintBottom_toBottomOf="@id/playPauseButton"
+            app:iconTint="@null"
             app:layout_constraintStart_toEndOf="@id/playPauseButton"
+            app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toTopOf="@id/playPauseButton"
-            android:layout_marginStart="20dp" />
+            app:layout_constraintBottom_toBottomOf="@id/playPauseButton" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 


### PR DESCRIPTION
- Replace Now Playing controls with volume slider (left), centered play/pause button, and record button (right)
- Add animated play/pause icon transition for mini player
- Fix close button on mini player to hide it instead of stopping playback
- Mini player only reappears when user selects a new radio station
- Add volume control using system AudioManager