### PR TITLE
Rearrange player controls and add recording format settings

### DIFF
--- a/app/src/main/java/com/opensource/i2pradio/RadioService.kt
+++ b/app/src/main/java/com/opensource/i2pradio/RadioService.kt
@@ -25,6 +25,7 @@ import androidx.media3.datasource.okhttp.OkHttpDataSource
 import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.exoplayer.source.ProgressiveMediaSource
 import okhttp3.OkHttpClient
+import com.opensource.i2pradio.ui.PreferencesHelper
 import java.io.File
 import java.io.FileOutputStream
 import java.io.OutputStream
@@ -118,14 +119,16 @@ class RadioService : Service() {
 
         currentStationName = stationName
         val timestamp = SimpleDateFormat("yyyyMMdd_HHmmss", Locale.getDefault()).format(Date())
-        val fileName = "${stationName.replace(Regex("[^a-zA-Z0-9]"), "_")}_$timestamp.mp3"
+        val format = PreferencesHelper.getRecordingFormat(this)
+        val mimeType = PreferencesHelper.getRecordingFormatMimeType(format)
+        val fileName = "${stationName.replace(Regex("[^a-zA-Z0-9]"), "_")}_$timestamp.$format"
 
         try {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
                 // Use MediaStore for Android 10+
                 val contentValues = ContentValues().apply {
                     put(MediaStore.Audio.Media.DISPLAY_NAME, fileName)
-                    put(MediaStore.Audio.Media.MIME_TYPE, "audio/mpeg")
+                    put(MediaStore.Audio.Media.MIME_TYPE, mimeType)
                     put(MediaStore.Audio.Media.RELATIVE_PATH, "${Environment.DIRECTORY_MUSIC}/I2P Radio")
                     put(MediaStore.Audio.Media.IS_PENDING, 1)
                 }

--- a/app/src/main/java/com/opensource/i2pradio/ui/PreferenceHelper.kt
+++ b/app/src/main/java/com/opensource/i2pradio/ui/PreferenceHelper.kt
@@ -8,6 +8,13 @@ object PreferencesHelper {
     private const val KEY_THEME_MODE = "theme_mode"
     private const val KEY_PRESETS_INITIALIZED = "presets_initialized"
     private const val KEY_MATERIAL_YOU_ENABLED = "material_you_enabled"
+    private const val KEY_RECORDING_FORMAT = "recording_format"
+
+    // Recording format constants
+    const val FORMAT_MP3 = "mp3"
+    const val FORMAT_M4A = "m4a"
+    const val FORMAT_OGG = "ogg"
+    const val FORMAT_WAV = "wav"
 
     fun saveThemeMode(context: Context, mode: Int) {
         context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
@@ -43,5 +50,37 @@ object PreferencesHelper {
     fun arePresetsInitialized(context: Context): Boolean {
         return context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
             .getBoolean(KEY_PRESETS_INITIALIZED, false)
+    }
+
+    fun setRecordingFormat(context: Context, format: String) {
+        context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+            .edit()
+            .putString(KEY_RECORDING_FORMAT, format)
+            .apply()
+    }
+
+    fun getRecordingFormat(context: Context): String {
+        return context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+            .getString(KEY_RECORDING_FORMAT, FORMAT_MP3) ?: FORMAT_MP3
+    }
+
+    fun getRecordingFormatDisplayName(format: String): String {
+        return when (format) {
+            FORMAT_MP3 -> "MP3"
+            FORMAT_M4A -> "M4A (AAC)"
+            FORMAT_OGG -> "OGG (Vorbis)"
+            FORMAT_WAV -> "WAV"
+            else -> "MP3"
+        }
+    }
+
+    fun getRecordingFormatMimeType(format: String): String {
+        return when (format) {
+            FORMAT_MP3 -> "audio/mpeg"
+            FORMAT_M4A -> "audio/mp4"
+            FORMAT_OGG -> "audio/ogg"
+            FORMAT_WAV -> "audio/wav"
+            else -> "audio/mpeg"
+        }
     }
 }

--- a/app/src/main/java/com/opensource/i2pradio/ui/SettingsFragment.kt
+++ b/app/src/main/java/com/opensource/i2pradio/ui/SettingsFragment.kt
@@ -16,6 +16,8 @@ import com.opensource.i2pradio.R
 
 class SettingsFragment : Fragment() {
 
+    private lateinit var recordingFormatButton: MaterialButton
+
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
@@ -27,6 +29,7 @@ class SettingsFragment : Fragment() {
         val githubButton = view.findViewById<MaterialButton>(R.id.githubButton)
         val materialYouSwitch = view.findViewById<MaterialSwitch>(R.id.materialYouSwitch)
         val materialYouContainer = view.findViewById<View>(R.id.materialYouContainer)
+        recordingFormatButton = view.findViewById(R.id.recordingFormatButton)
 
         // Show Material You option only on Android 12+
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
@@ -55,7 +58,39 @@ class SettingsFragment : Fragment() {
             startActivity(intent)
         }
 
+        // Recording format
+        updateRecordingFormatButtonText()
+        recordingFormatButton.setOnClickListener {
+            showRecordingFormatDialog()
+        }
+
         return view
+    }
+
+    private fun updateRecordingFormatButtonText() {
+        val currentFormat = PreferencesHelper.getRecordingFormat(requireContext())
+        recordingFormatButton.text = PreferencesHelper.getRecordingFormatDisplayName(currentFormat)
+    }
+
+    private fun showRecordingFormatDialog() {
+        val formats = arrayOf(
+            PreferencesHelper.FORMAT_MP3,
+            PreferencesHelper.FORMAT_M4A,
+            PreferencesHelper.FORMAT_OGG,
+            PreferencesHelper.FORMAT_WAV
+        )
+        val formatNames = formats.map { PreferencesHelper.getRecordingFormatDisplayName(it) }.toTypedArray()
+        val currentFormat = PreferencesHelper.getRecordingFormat(requireContext())
+        val selectedIndex = formats.indexOf(currentFormat).coerceAtLeast(0)
+
+        AlertDialog.Builder(requireContext())
+            .setTitle("Recording Format")
+            .setSingleChoiceItems(formatNames, selectedIndex) { dialog, which ->
+                PreferencesHelper.setRecordingFormat(requireContext(), formats[which])
+                updateRecordingFormatButtonText()
+                dialog.dismiss()
+            }
+            .show()
     }
 
     private fun updateThemeButtonText(button: MaterialButton) {

--- a/app/src/main/res/layout/fragment_now_playing.xml
+++ b/app/src/main/res/layout/fragment_now_playing.xml
@@ -105,39 +105,20 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/nowPlayingInfoContainer">
 
-        <!-- Volume Control Container (Left) -->
-        <LinearLayout
-            android:id="@+id/volumeContainer"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:orientation="horizontal"
-            android:gravity="center_vertical"
+        <!-- Record Button (Left) -->
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/recordButton"
+            style="@style/Widget.Material3.Button.IconButton.Filled.Tonal"
+            android:layout_width="56dp"
+            android:layout_height="56dp"
+            android:contentDescription="Record"
+            app:icon="@drawable/ic_record"
+            app:iconSize="24dp"
+            app:iconTint="@null"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintEnd_toStartOf="@id/playPauseButton"
             app:layout_constraintTop_toTopOf="@id/playPauseButton"
-            app:layout_constraintBottom_toBottomOf="@id/playPauseButton"
-            android:layout_marginEnd="16dp">
-
-            <ImageView
-                android:id="@+id/volumeIcon"
-                android:layout_width="24dp"
-                android:layout_height="24dp"
-                android:src="@drawable/ic_volume"
-                android:contentDescription="Volume"
-                app:tint="?attr/colorOnSurfaceVariant" />
-
-            <SeekBar
-                android:id="@+id/volumeSeekBar"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:layout_marginStart="8dp"
-                android:max="100"
-                android:progress="100"
-                android:progressTint="?attr/colorPrimary"
-                android:thumbTint="?attr/colorPrimary" />
-
-        </LinearLayout>
+            app:layout_constraintBottom_toBottomOf="@id/playPauseButton" />
 
         <!-- Main Play/Pause FAB - Large and Centered -->
         <com.google.android.material.floatingactionbutton.FloatingActionButton
@@ -155,16 +136,19 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
 
-        <!-- Record Button (Right) - Centered -->
-        <com.google.android.material.button.MaterialButton
-            android:id="@+id/recordButton"
-            style="@style/Widget.Material3.Button.IconButton.Filled.Tonal"
-            android:layout_width="56dp"
-            android:layout_height="56dp"
-            android:contentDescription="Record"
-            app:icon="@drawable/ic_record"
-            app:iconSize="24dp"
-            app:iconTint="@null"
+        <!-- Volume Button (Right) - Large -->
+        <com.google.android.material.floatingactionbutton.FloatingActionButton
+            android:id="@+id/volumeButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:contentDescription="Volume"
+            app:srcCompat="@drawable/ic_volume"
+            app:fabSize="auto"
+            app:fabCustomSize="64dp"
+            app:maxImageSize="28dp"
+            app:backgroundTint="?attr/colorSecondaryContainer"
+            app:tint="?attr/colorOnSecondaryContainer"
+            app:shapeAppearanceOverlay="@style/ShapeAppearance.Material3.Corner.Full"
             app:layout_constraintStart_toEndOf="@id/playPauseButton"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toTopOf="@id/playPauseButton"

--- a/app/src/main/res/layout/fragment_settings.xml
+++ b/app/src/main/res/layout/fragment_settings.xml
@@ -145,6 +145,75 @@
 
         </com.google.android.material.card.MaterialCardView>
 
+        <!-- Recording Section -->
+        <com.google.android.material.card.MaterialCardView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            app:cardCornerRadius="16dp"
+            app:cardElevation="0dp"
+            app:strokeWidth="0dp"
+            app:cardBackgroundColor="?attr/colorSurfaceContainer">
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                android:padding="16dp">
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="Recording"
+                    android:textSize="14sp"
+                    android:textStyle="bold"
+                    android:textColor="?attr/colorPrimary"
+                    android:layout_marginBottom="16dp" />
+
+                <!-- Recording Format -->
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="horizontal"
+                    android:gravity="center_vertical"
+                    android:paddingVertical="8dp">
+
+                    <LinearLayout
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:orientation="vertical">
+
+                        <TextView
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="Recording Format"
+                            android:textSize="16sp"
+                            android:textColor="?attr/colorOnSurface" />
+
+                        <TextView
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="Choose audio format for recordings"
+                            android:textSize="12sp"
+                            android:textColor="?attr/colorOnSurfaceVariant" />
+
+                    </LinearLayout>
+
+                    <com.google.android.material.button.MaterialButton
+                        android:id="@+id/recordingFormatButton"
+                        style="@style/Widget.Material3.Button.TonalButton"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="MP3"
+                        android:textSize="12sp" />
+
+                </LinearLayout>
+
+            </LinearLayout>
+
+        </com.google.android.material.card.MaterialCardView>
+
         <!-- About Section -->
         <com.google.android.material.card.MaterialCardView
             android:layout_width="match_parent"


### PR DESCRIPTION
- Swap record and volume button positions (record now on left, volume on right)
- Replace volume slider with large FAB button that opens volume dialog
- Add Recording section in Settings with format selection (MP3, M4A, OGG, WAV)
- Update RadioService to use selected recording format for file extension and MIME type