### PR TITLE
Add Tor proxy support and Now Playing card for TV

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -43,6 +43,7 @@ dependencies {
 
     implementation("androidx.media3:media3-exoplayer:1.2.1")
     implementation("androidx.media3:media3-datasource-okhttp:1.2.1")
+    implementation("androidx.media3:media3-session:1.2.1")
 
     implementation("com.squareup.okhttp3:okhttp:4.12.0")
 

--- a/app/src/main/java/com/opensource/i2pradio/data/RadioDatabase.kt
+++ b/app/src/main/java/com/opensource/i2pradio/data/RadioDatabase.kt
@@ -4,8 +4,10 @@ import android.content.Context
 import androidx.room.Database
 import androidx.room.Room
 import androidx.room.RoomDatabase
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
 
-@Database(entities = [RadioStation::class], version = 1, exportSchema = false)
+@Database(entities = [RadioStation::class], version = 2, exportSchema = false)
 abstract class RadioDatabase : RoomDatabase() {
     abstract fun radioDao(): RadioDao
 
@@ -13,13 +15,30 @@ abstract class RadioDatabase : RoomDatabase() {
         @Volatile
         private var INSTANCE: RadioDatabase? = null
 
+        // Migration from version 1 to 2: Add proxyType column
+        private val MIGRATION_1_2 = object : Migration(1, 2) {
+            override fun migrate(database: SupportSQLiteDatabase) {
+                // Add proxyType column with default value "NONE"
+                // For existing stations with useProxy=true, set proxyType to "I2P"
+                database.execSQL(
+                    "ALTER TABLE radio_stations ADD COLUMN proxyType TEXT NOT NULL DEFAULT 'NONE'"
+                )
+                // Update existing proxy stations to use I2P type
+                database.execSQL(
+                    "UPDATE radio_stations SET proxyType = 'I2P' WHERE useProxy = 1"
+                )
+            }
+        }
+
         fun getDatabase(context: Context): RadioDatabase {
             return INSTANCE ?: synchronized(this) {
                 val instance = Room.databaseBuilder(
                     context.applicationContext,
                     RadioDatabase::class.java,
                     "radio_database"
-                ).build()
+                )
+                    .addMigrations(MIGRATION_1_2)
+                    .build()
                 INSTANCE = instance
                 instance
             }

--- a/app/src/main/java/com/opensource/i2pradio/data/RadioStation.kt
+++ b/app/src/main/java/com/opensource/i2pradio/data/RadioStation.kt
@@ -3,6 +3,43 @@ package com.opensource.i2pradio.data
 import androidx.room.Entity
 import androidx.room.PrimaryKey
 
+/**
+ * Proxy type for radio streams
+ * - NONE: Direct connection without proxy
+ * - I2P: HTTP proxy (default port 4444)
+ * - TOR: SOCKS5 proxy (default port 9050)
+ */
+enum class ProxyType {
+    NONE,
+    I2P,
+    TOR;
+
+    companion object {
+        fun fromString(value: String?): ProxyType {
+            return when (value?.uppercase()) {
+                "I2P" -> I2P
+                "TOR" -> TOR
+                else -> NONE
+            }
+        }
+    }
+
+    fun getDefaultPort(): Int {
+        return when (this) {
+            NONE -> 0
+            I2P -> 4444
+            TOR -> 9050
+        }
+    }
+
+    fun getDefaultHost(): String {
+        return when (this) {
+            NONE -> ""
+            I2P, TOR -> "127.0.0.1"
+        }
+    }
+}
+
 @Entity(tableName = "radio_stations")
 data class RadioStation(
     @PrimaryKey(autoGenerate = true)
@@ -12,8 +49,19 @@ data class RadioStation(
     val proxyHost: String = "",
     val proxyPort: Int = 4444,
     val useProxy: Boolean = false,
+    val proxyType: String = ProxyType.NONE.name, // Store as String for Room compatibility
     val genre: String = "Other",
     val coverArtUri: String? = null,
     val isPreset: Boolean = false,
     val addedTimestamp: Long = System.currentTimeMillis()
-)
+) {
+    /**
+     * Get the ProxyType enum from the stored string
+     */
+    fun getProxyTypeEnum(): ProxyType = ProxyType.fromString(proxyType)
+
+    /**
+     * Check if this station uses any proxy (I2P or Tor)
+     */
+    fun usesProxy(): Boolean = useProxy && getProxyTypeEnum() != ProxyType.NONE
+}

--- a/app/src/main/java/com/opensource/i2pradio/ui/RadiosFragment.kt
+++ b/app/src/main/java/com/opensource/i2pradio/ui/RadiosFragment.kt
@@ -16,6 +16,7 @@ import com.google.android.material.button.MaterialButton
 import com.google.android.material.floatingactionbutton.FloatingActionButton
 import com.opensource.i2pradio.R
 import com.opensource.i2pradio.RadioService
+import com.opensource.i2pradio.data.ProxyType
 import com.opensource.i2pradio.data.RadioStation
 import com.opensource.i2pradio.data.RadioRepository
 import kotlinx.coroutines.CoroutineScope
@@ -76,11 +77,15 @@ class RadiosFragment : Fragment() {
         viewModel.setCurrentStation(station)
         viewModel.setPlaying(true)
 
+        val proxyType = station.getProxyTypeEnum()
         val intent = Intent(requireContext(), RadioService::class.java).apply {
             action = RadioService.ACTION_PLAY
             putExtra("stream_url", station.streamUrl)
+            putExtra("station_name", station.name)
             putExtra("proxy_host", if (station.useProxy) station.proxyHost else "")
             putExtra("proxy_port", station.proxyPort)
+            putExtra("proxy_type", proxyType.name)
+            putExtra("cover_art_uri", station.coverArtUri)
         }
         requireContext().startService(intent)
     }
@@ -153,7 +158,14 @@ class RadioStationAdapter(
         fun bind(station: RadioStation) {
             stationName.text = station.name
 
-            val proxyIndicator = if (station.useProxy) " • I2P" else ""
+            // Show proxy type indicator (I2P or Tor)
+            val proxyIndicator = if (station.useProxy) {
+                when (station.getProxyTypeEnum()) {
+                    ProxyType.I2P -> " • I2P"
+                    ProxyType.TOR -> " • Tor"
+                    ProxyType.NONE -> ""
+                }
+            } else ""
             genreText.text = "${station.genre}$proxyIndicator"
 
             if (station.coverArtUri != null) {

--- a/app/src/main/res/layout/dialog_add_edit_radio.xml
+++ b/app/src/main/res/layout/dialog_add_edit_radio.xml
@@ -65,14 +65,22 @@
 
         </com.google.android.material.textfield.TextInputLayout>
 
-        <!-- Use Proxy Checkbox -->
-        <com.google.android.material.checkbox.MaterialCheckBox
-            android:id="@+id/useProxyCheckbox"
+        <!-- Proxy Type Dropdown -->
+        <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/proxyTypeInputLayout"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginTop="16dp"
-            android:text="Use I2P Proxy"
-            android:checked="false" />
+            android:hint="Proxy Type"
+            style="@style/Widget.Material3.TextInputLayout.OutlinedBox.ExposedDropdownMenu">
+
+            <AutoCompleteTextView
+                android:id="@+id/proxyTypeInput"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:inputType="none" />
+
+        </com.google.android.material.textfield.TextInputLayout>
 
         <!-- Proxy Settings (Initially Hidden) -->
         <LinearLayout


### PR DESCRIPTION
- Add ProxyType enum (NONE, I2P, TOR) to RadioStation model
- Support SOCKS5 proxy for Tor and HTTP proxy for I2P
- Update AddEditRadioDialog with proxy type dropdown (None/I2P/Tor)
- Add database migration to preserve existing I2P stations
- Implement MediaSession for Now Playing card on Android TV
- Set session activity for returning to app from Now Playing card
- Handle transport controls (play, pause, stop) via MediaSession
- Auto-deactivate session after 5 minutes when paused
- Update notification to use MediaSession token