### PR TITLE
Fix mini player animation sync and add navigation animation

### DIFF
--- a/app/src/main/java/com/opensource/i2pradio/MainActivity.kt
+++ b/app/src/main/java/com/opensource/i2pradio/MainActivity.kt
@@ -125,6 +125,11 @@ class MainActivity : AppCompatActivity() {
             viewPager.currentItem = 1  // Switch to Now Playing tab
         }
 
+        // Play/pause toggle - update ViewModel to sync state and trigger animation
+        miniPlayerView.setOnPlayPauseToggleListener { isPlaying ->
+            viewModel.setPlaying(isPlaying)
+        }
+
         // Close button hides the mini player
         miniPlayerView.setOnCloseListener {
             miniPlayerManuallyClosed = true
@@ -145,6 +150,22 @@ class MainActivity : AppCompatActivity() {
                 else -> ""
             }
         }.attach()
+
+        // Handle page changes to show/hide mini player
+        viewPager.registerOnPageChangeCallback(object : ViewPager2.OnPageChangeCallback() {
+            override fun onPageSelected(position: Int) {
+                super.onPageSelected(position)
+                if (position == 1) {
+                    // On Now Playing tab - keep mini player hidden
+                    miniPlayerView.hideForNowPlaying()
+                } else {
+                    // On other tabs - show mini player if station is playing
+                    if (viewModel.currentStation.value != null && !miniPlayerManuallyClosed) {
+                        miniPlayerView.showWithAnimation()
+                    }
+                }
+            }
+        })
     }
 
     override fun onDestroy() {


### PR DESCRIPTION
- Fix play/pause button state not syncing between mini player and ViewModel
- Add callback from MiniPlayerView to MainActivity to update ViewModel on toggle
- Add animated play/pause transition to NowPlayingFragment FAB for consistency
- Add expand animation when clicking mini player to navigate to Now Playing
- Auto-hide mini player when on Now Playing tab (avoids redundant UI)
- Show mini player with fade animation when returning to other tabs