### PR TITLE
Fix app crash on database downgrade

### DIFF
--- a/app/src/main/java/com/opensource/i2pradio/data/RadioDatabase.kt
+++ b/app/src/main/java/com/opensource/i2pradio/data/RadioDatabase.kt
@@ -38,6 +38,7 @@ abstract class RadioDatabase : RoomDatabase() {
                     "radio_database"
                 )
                     .addMigrations(MIGRATION_1_2)
+                    .fallbackToDestructiveMigrationOnDowngrade()
                     .build()
                 INSTANCE = instance
                 instance


### PR DESCRIPTION
Add fallbackToDestructiveMigrationOnDowngrade() to Room database builder to handle cases where users downgrade from a newer database version to an older one. This prevents IllegalStateException crashes when migration from version 2 to 1 is required but not found.