### PR TITLE
Fix startup crashes: remove AVD animations and fix database migration

### DIFF
--- a/app/src/main/java/com/opensource/i2pradio/data/RadioDatabase.kt
+++ b/app/src/main/java/com/opensource/i2pradio/data/RadioDatabase.kt
@@ -38,7 +38,7 @@ abstract class RadioDatabase : RoomDatabase() {
                     "radio_database"
                 )
                     .addMigrations(MIGRATION_1_2)
-                    .fallbackToDestructiveMigrationOnDowngrade()
+                    .fallbackToDestructiveMigration()  // Handles both upgrades and downgrades if migration not found
                     .build()
                 INSTANCE = instance
                 instance

--- a/app/src/main/java/com/opensource/i2pradio/ui/MiniPlayerView.kt
+++ b/app/src/main/java/com/opensource/i2pradio/ui/MiniPlayerView.kt
@@ -7,7 +7,6 @@ import android.view.LayoutInflater
 import android.widget.FrameLayout
 import android.widget.ImageView
 import android.widget.TextView
-import androidx.vectordrawable.graphics.drawable.AnimatedVectorDrawableCompat
 import coil.load
 import com.google.android.material.button.MaterialButton
 import com.opensource.i2pradio.R
@@ -128,37 +127,25 @@ class MiniPlayerView @JvmOverloads constructor(
     }
 
     fun setPlayingState(playing: Boolean) {
+        val newIconRes = if (playing) R.drawable.ic_pause else R.drawable.ic_play
+
         // Only animate if state actually changed
         if (previousPlayingState != null && previousPlayingState != playing) {
-            try {
-                val animDrawable = if (playing) {
-                    AnimatedVectorDrawableCompat.create(context, R.drawable.avd_play_to_pause)
-                } else {
-                    AnimatedVectorDrawableCompat.create(context, R.drawable.avd_pause_to_play)
+            // Simple fade animation for icon transition
+            playPauseButton.animate()
+                .alpha(0f)
+                .setDuration(100)
+                .withEndAction {
+                    playPauseButton.setIconResource(newIconRes)
+                    playPauseButton.animate()
+                        .alpha(1f)
+                        .setDuration(100)
+                        .start()
                 }
-
-                animDrawable?.let {
-                    playPauseButton.icon = it
-                    it.start()
-                } ?: run {
-                    // Fallback to static icon if AVD creation fails
-                    playPauseButton.setIconResource(
-                        if (playing) R.drawable.ic_pause else R.drawable.ic_play
-                    )
-                }
-            } catch (e: Exception) {
-                // Fallback to static icon on AVD inflation error (e.g., path morph issues on some Android versions)
-                android.util.Log.w("MiniPlayerView", "AVD animation failed, using static icon", e)
-                playPauseButton.setIconResource(
-                    if (playing) R.drawable.ic_pause else R.drawable.ic_play
-                )
-            }
+                .start()
         } else {
             // Initial state - no animation
-            playPauseButton.setIconResource(
-                if (playing) R.drawable.ic_pause
-                else R.drawable.ic_play
-            )
+            playPauseButton.setIconResource(newIconRes)
         }
 
         isPlaying = playing

--- a/app/src/main/java/com/opensource/i2pradio/ui/NowPlayingFragment.kt
+++ b/app/src/main/java/com/opensource/i2pradio/ui/NowPlayingFragment.kt
@@ -17,7 +17,6 @@ import android.widget.Toast
 import androidx.appcompat.app.AlertDialog
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
-import androidx.vectordrawable.graphics.drawable.AnimatedVectorDrawableCompat
 import coil.load
 import com.google.android.material.button.MaterialButton
 import com.google.android.material.floatingactionbutton.FloatingActionButton
@@ -324,36 +323,25 @@ class NowPlayingFragment : Fragment() {
     }
 
     private fun updatePlayPauseButton(isPlaying: Boolean) {
+        val newIconRes = if (isPlaying) R.drawable.ic_pause else R.drawable.ic_play
+
         // Only animate if state actually changed
         if (previousPlayingState != null && previousPlayingState != isPlaying) {
-            try {
-                val animDrawable = if (isPlaying) {
-                    AnimatedVectorDrawableCompat.create(requireContext(), R.drawable.avd_play_to_pause)
-                } else {
-                    AnimatedVectorDrawableCompat.create(requireContext(), R.drawable.avd_pause_to_play)
+            // Simple fade animation for icon transition
+            playPauseButton.animate()
+                .alpha(0f)
+                .setDuration(100)
+                .withEndAction {
+                    playPauseButton.setImageResource(newIconRes)
+                    playPauseButton.animate()
+                        .alpha(1f)
+                        .setDuration(100)
+                        .start()
                 }
-
-                animDrawable?.let {
-                    playPauseButton.setImageDrawable(it)
-                    it.start()
-                } ?: run {
-                    // Fallback to static icon if AVD creation fails
-                    playPauseButton.setImageResource(
-                        if (isPlaying) R.drawable.ic_pause else R.drawable.ic_play
-                    )
-                }
-            } catch (e: Exception) {
-                // Fallback to static icon on AVD inflation error
-                android.util.Log.w("NowPlayingFragment", "AVD animation failed, using static icon", e)
-                playPauseButton.setImageResource(
-                    if (isPlaying) R.drawable.ic_pause else R.drawable.ic_play
-                )
-            }
+                .start()
         } else {
             // Initial state - no animation
-            playPauseButton.setImageResource(
-                if (isPlaying) R.drawable.ic_pause else R.drawable.ic_play
-            )
+            playPauseButton.setImageResource(newIconRes)
         }
 
         previousPlayingState = isPlaying


### PR DESCRIPTION
- Replace AnimatedVectorDrawable animations with simple fade transitions to fix path morphing crashes on Android 16+ (the AVD paths caused "Can't morph" errors on some Android versions)
- Use fallbackToDestructiveMigration() instead of deprecated fallbackToDestructiveMigrationOnDowngrade() to properly handle database version mismatches during app upgrades/downgrades
- Remove unused AnimatedVectorDrawableCompat imports