### PR TITLE
Add Material You styling to mini player and fix UX issues

### DIFF
--- a/app/src/main/java/com/opensource/i2pradio/ui/MiniPlayerView.kt
+++ b/app/src/main/java/com/opensource/i2pradio/ui/MiniPlayerView.kt
@@ -9,6 +9,7 @@ import android.widget.ImageView
 import android.widget.TextView
 import coil.load
 import com.google.android.material.button.MaterialButton
+import com.google.android.material.card.MaterialCardView
 import com.opensource.i2pradio.R
 import com.opensource.i2pradio.RadioService
 import com.opensource.i2pradio.data.RadioStation
@@ -19,6 +20,7 @@ class MiniPlayerView @JvmOverloads constructor(
     defStyleAttr: Int = 0
 ) : FrameLayout(context, attrs, defStyleAttr) {
 
+    private val card: MaterialCardView
     private val coverImage: ImageView
     private val stationName: TextView
     private val genreText: TextView
@@ -35,21 +37,22 @@ class MiniPlayerView @JvmOverloads constructor(
     init {
         LayoutInflater.from(context).inflate(R.layout.view_mini_player, this, true)
 
+        card = findViewById(R.id.miniPlayerCard)
         coverImage = findViewById(R.id.miniPlayerCoverImage)
         stationName = findViewById(R.id.miniPlayerStationName)
         genreText = findViewById(R.id.miniPlayerGenre)
         playPauseButton = findViewById(R.id.miniPlayerPlayPause)
         closeButton = findViewById(R.id.miniPlayerClose)
 
-        // Click whole view to go to Now Playing with expand animation
-        setOnClickListener {
+        // Click the card to go to Now Playing with expand animation
+        card.setOnClickListener {
             // Scale up animation for expand effect
-            animate()
+            card.animate()
                 .scaleX(1.02f)
                 .scaleY(1.02f)
                 .setDuration(100)
                 .withEndAction {
-                    animate()
+                    card.animate()
                         .scaleX(1f)
                         .scaleY(1f)
                         .alpha(0f)
@@ -84,7 +87,7 @@ class MiniPlayerView @JvmOverloads constructor(
 
         if (station == null) {
             // Fade out animation
-            animate()
+            card.animate()
                 .alpha(0f)
                 .setDuration(200)
                 .withEndAction {
@@ -96,14 +99,14 @@ class MiniPlayerView @JvmOverloads constructor(
 
         // Always ensure we're visible when setting a station
         // Cancel any pending animations first
-        animate().cancel()
+        card.animate().cancel()
 
-        if (visibility != VISIBLE || alpha < 1f) {
-            alpha = 0f
+        if (visibility != VISIBLE || card.alpha < 1f) {
+            card.alpha = 0f
             visibility = VISIBLE
             // Slide up and fade in animation
-            translationY = 50f
-            animate()
+            card.translationY = 50f
+            card.animate()
                 .alpha(1f)
                 .translationY(0f)
                 .setDuration(300)
@@ -115,14 +118,12 @@ class MiniPlayerView @JvmOverloads constructor(
         val proxyIndicator = if (station.useProxy) " • I2P" else ""
         genreText.text = "${station.genre}$proxyIndicator"
 
-        if (station.coverArtUri != null) {
-            coverImage.load(station.coverArtUri) {
-                crossfade(true)
-                placeholder(R.drawable.ic_radio)
-                error(R.drawable.ic_radio)
-            }
-        } else {
-            coverImage.setImageResource(R.drawable.ic_radio)
+        // Always use Coil to load images to properly clear cached state
+        // when switching between stations with/without cover art
+        coverImage.load(station.coverArtUri ?: R.drawable.ic_radio) {
+            crossfade(true)
+            placeholder(R.drawable.ic_radio)
+            error(R.drawable.ic_radio)
         }
     }
 
@@ -161,14 +162,14 @@ class MiniPlayerView @JvmOverloads constructor(
      */
     fun showWithAnimation() {
         if (currentStation != null) {
-            animate().cancel()
+            card.animate().cancel()
             // Always reset state before animating to ensure proper display
-            if (visibility != VISIBLE || alpha < 1f) {
-                alpha = 0f
-                translationY = 30f
+            if (visibility != VISIBLE || card.alpha < 1f) {
+                card.alpha = 0f
+                card.translationY = 30f
                 visibility = VISIBLE
             }
-            animate()
+            card.animate()
                 .alpha(1f)
                 .scaleX(1f)
                 .scaleY(1f)
@@ -183,9 +184,9 @@ class MiniPlayerView @JvmOverloads constructor(
      * Hide mini player without animation (used when navigating to Now Playing)
      */
     fun hideForNowPlaying() {
-        animate().cancel()
-        alpha = 0f
-        translationY = 30f
+        card.animate().cancel()
+        card.alpha = 0f
+        card.translationY = 30f
         visibility = INVISIBLE
     }
 

--- a/app/src/main/java/com/opensource/i2pradio/ui/NowPlayingFragment.kt
+++ b/app/src/main/java/com/opensource/i2pradio/ui/NowPlayingFragment.kt
@@ -178,14 +178,12 @@ class NowPlayingFragment : Fragment() {
                 val proxyIndicator = if (station.useProxy) " • I2P" else ""
                 genreText.text = "${station.genre}$proxyIndicator"
 
-                if (station.coverArtUri != null) {
-                    coverArt.load(station.coverArtUri) {
-                        crossfade(true)
-                        placeholder(R.drawable.ic_radio)
-                        error(R.drawable.ic_radio)
-                    }
-                } else {
-                    coverArt.setImageResource(R.drawable.ic_radio)
+                // Always use Coil to load images to properly clear cached state
+                // when switching between stations with/without cover art
+                coverArt.load(station.coverArtUri ?: R.drawable.ic_radio) {
+                    crossfade(true)
+                    placeholder(R.drawable.ic_radio)
+                    error(R.drawable.ic_radio)
                 }
 
                 metadataText.visibility = View.GONE

--- a/app/src/main/res/layout/view_mini_player.xml
+++ b/app/src/main/res/layout/view_mini_player.xml
@@ -2,11 +2,13 @@
 <com.google.android.material.card.MaterialCardView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/miniPlayerCard"
     android:layout_width="match_parent"
     android:layout_height="72dp"
     android:clickable="true"
     android:focusable="true"
     app:cardElevation="12dp"
+    app:rippleColor="?attr/colorControlHighlight"
     app:shapeAppearanceOverlay="@style/ShapeAppearance.MiniPlayer"
     app:cardBackgroundColor="?attr/colorSurfaceContainer">
 
@@ -73,10 +75,10 @@
 
         </LinearLayout>
 
-        <!-- Play/Pause Button -->
+        <!-- Play/Pause Button - Material You Filled Tonal -->
         <com.google.android.material.button.MaterialButton
             android:id="@+id/miniPlayerPlayPause"
-            style="@style/Widget.Material3.Button.IconButton"
+            style="@style/Widget.Material3.Button.IconButton.Filled.Tonal"
             android:layout_width="48dp"
             android:layout_height="48dp"
             android:contentDescription="Play/Pause"
@@ -87,9 +89,9 @@
             android:padding="0dp"
             app:icon="@drawable/ic_pause"
             app:iconSize="28dp"
-            app:iconTint="?attr/colorOnSurface"
             app:iconGravity="textStart"
             app:iconPadding="0dp"
+            app:shapeAppearanceOverlay="@style/ShapeAppearance.Material3.Corner.Full"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toStartOf="@id/miniPlayerClose"
             app:layout_constraintTop_toTopOf="parent" />


### PR DESCRIPTION
- Update play/pause button to Material You filled tonal style with full corner radius for a more modern, dynamic appearance
- Fix mini player click: set click listener on MaterialCardView instead of parent FrameLayout so clicks navigate to Now Playing view properly
- Add ripple feedback to card for better touch responsiveness
- Fix cover art not updating when switching from station with custom art to one without by always using Coil for image loading