### PR TITLE
Fix Tor status detection, recording reconnect, cover art duplication,…

### DIFF
--- a/app/src/main/java/com/opensource/i2pradio/RecordingDataSource.kt
+++ b/app/src/main/java/com/opensource/i2pradio/RecordingDataSource.kt
@@ -5,14 +5,18 @@ import androidx.media3.datasource.DataSource
 import androidx.media3.datasource.DataSpec
 import androidx.media3.datasource.TransferListener
 import java.io.OutputStream
+import java.util.concurrent.atomic.AtomicReference
 
 /**
  * A DataSource wrapper that tees (copies) all read data to an output stream
  * for recording purposes while passing it through to the player.
+ *
+ * The recording output stream can be dynamically set/cleared without
+ * recreating the player, allowing seamless recording toggle.
  */
 class RecordingDataSource(
     private val upstream: DataSource,
-    private val recordingOutputStream: OutputStream?
+    private val outputStreamHolder: AtomicReference<OutputStream?>
 ) : DataSource {
 
     private var dataSpec: DataSpec? = null
@@ -29,9 +33,11 @@ class RecordingDataSource(
     override fun read(buffer: ByteArray, offset: Int, length: Int): Int {
         val bytesRead = upstream.read(buffer, offset, length)
 
-        if (bytesRead > 0 && recordingOutputStream != null) {
+        // Get the current output stream (may be null if not recording)
+        val outputStream = outputStreamHolder.get()
+        if (bytesRead > 0 && outputStream != null) {
             try {
-                recordingOutputStream.write(buffer, offset, bytesRead)
+                outputStream.write(buffer, offset, bytesRead)
             } catch (e: Exception) {
                 android.util.Log.e("RecordingDataSource", "Error writing to recording file", e)
             }
@@ -48,17 +54,19 @@ class RecordingDataSource(
     }
 
     /**
-     * Factory for creating RecordingDataSource instances
+     * Factory for creating RecordingDataSource instances.
+     * Uses a shared AtomicReference for the output stream, allowing
+     * recording to be toggled without recreating the player.
      */
     class Factory(
         private val upstreamFactory: DataSource.Factory,
-        private val getRecordingOutputStream: () -> OutputStream?
+        private val outputStreamHolder: AtomicReference<OutputStream?>
     ) : DataSource.Factory {
 
         override fun createDataSource(): DataSource {
             return RecordingDataSource(
                 upstreamFactory.createDataSource(),
-                getRecordingOutputStream()
+                outputStreamHolder
             )
         }
     }

--- a/app/src/main/res/drawable/ic_radio.xml
+++ b/app/src/main/res/drawable/ic_radio.xml
@@ -3,8 +3,9 @@
     android:width="24dp"
     android:height="24dp"
     android:viewportWidth="24"
-    android:viewportHeight="24">
+    android:viewportHeight="24"
+    android:tint="?attr/colorOnSurfaceVariant">
     <path
-        android:fillColor="@android:color/white"
+        android:fillColor="#FFFFFF"
         android:pathData="M3.24,6.15C2.51,6.43 2,7.17 2,8v12c0,1.1 0.89,2 2,2h16c1.11,0 2,-0.9 2,-2V8c0,-1.11 -0.89,-2 -2,-2H8.3l8.26,-3.34L15.88,1 3.24,6.15zM7,20c-1.66,0 -3,-1.34 -3,-3s1.34,-3 3,-3 3,1.34 3,3 -1.34,3 -3,3zM20,12H4V8h16v4z"/>
 </vector>


### PR DESCRIPTION
… and Material You icon

- Fix Tor status not updating when Tor is turned off by:
  - Using RECEIVER_EXPORTED to receive Orbot broadcasts on Android 13+
  - Improving socket check to properly detect disconnection

- Fix recording reconnecting stream by:
  - Using AtomicReference for output stream in RecordingDataSource
  - Always wrapping data source with RecordingDataSource (null stream when not recording)
  - Toggling recording by setting/clearing stream reference without player restart

- Fix duplicate cover art icon bug by:
  - Adding stable IDs (setHasStableIds) to RadioStationAdapter
  - Using DiffUtil for efficient list updates
  - Disposing Coil image loads and clearing images on rebind

- Add Material You support for default radio icon by:
  - Using android:tint="?attr/colorOnSurfaceVariant" for theme-aware coloring