### PR TITLE
Fix audio hitching during recording and update recording button styling

### DIFF
--- a/app/src/main/java/com/opensource/i2pradio/RecordingDataSource.kt
+++ b/app/src/main/java/com/opensource/i2pradio/RecordingDataSource.kt
@@ -4,19 +4,27 @@ import android.net.Uri
 import androidx.media3.datasource.DataSource
 import androidx.media3.datasource.DataSpec
 import androidx.media3.datasource.TransferListener
+import java.io.BufferedOutputStream
 import java.io.OutputStream
+import java.util.concurrent.ArrayBlockingQueue
+import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicReference
 
 /**
  * A DataSource wrapper that tees (copies) all read data to an output stream
  * for recording purposes while passing it through to the player.
  *
+ * Uses an async write queue to prevent audio hitching - stream data is queued
+ * and written to disk on a background thread, ensuring audio playback is never
+ * blocked by disk I/O.
+ *
  * The recording output stream can be dynamically set/cleared without
  * recreating the player, allowing seamless recording toggle.
  */
 class RecordingDataSource(
     private val upstream: DataSource,
-    private val outputStreamHolder: AtomicReference<OutputStream?>
+    private val writeQueue: ArrayBlockingQueue<ByteArray>,
+    private val isRecordingActive: AtomicBoolean
 ) : DataSource {
 
     private var dataSpec: DataSpec? = null
@@ -33,13 +41,20 @@ class RecordingDataSource(
     override fun read(buffer: ByteArray, offset: Int, length: Int): Int {
         val bytesRead = upstream.read(buffer, offset, length)
 
-        // Get the current output stream (may be null if not recording)
-        val outputStream = outputStreamHolder.get()
-        if (bytesRead > 0 && outputStream != null) {
+        // Queue data for async writing if recording is active
+        if (bytesRead > 0 && isRecordingActive.get()) {
             try {
-                outputStream.write(buffer, offset, bytesRead)
+                // Copy the data to avoid buffer reuse issues
+                val dataCopy = ByteArray(bytesRead)
+                System.arraycopy(buffer, offset, dataCopy, 0, bytesRead)
+                // Use offer() which is non-blocking - if queue is full, drop this chunk
+                // This prevents audio hitching at the cost of potentially losing some data
+                // Queue size is large enough (1000 chunks) that this should rarely happen
+                if (!writeQueue.offer(dataCopy)) {
+                    android.util.Log.w("RecordingDataSource", "Write queue full, dropping chunk")
+                }
             } catch (e: Exception) {
-                android.util.Log.e("RecordingDataSource", "Error writing to recording file", e)
+                android.util.Log.e("RecordingDataSource", "Error queueing recording data", e)
             }
         }
 
@@ -55,19 +70,88 @@ class RecordingDataSource(
 
     /**
      * Factory for creating RecordingDataSource instances.
-     * Uses a shared AtomicReference for the output stream, allowing
-     * recording to be toggled without recreating the player.
+     * Uses a shared write queue for async disk writes, preventing audio hitching.
      */
     class Factory(
         private val upstreamFactory: DataSource.Factory,
-        private val outputStreamHolder: AtomicReference<OutputStream?>
+        private val writeQueue: ArrayBlockingQueue<ByteArray>,
+        private val isRecordingActive: AtomicBoolean
     ) : DataSource.Factory {
 
         override fun createDataSource(): DataSource {
             return RecordingDataSource(
                 upstreamFactory.createDataSource(),
-                outputStreamHolder
+                writeQueue,
+                isRecordingActive
             )
+        }
+    }
+
+    companion object {
+        /**
+         * Creates and starts a background writer thread that drains the write queue
+         * and writes data to the output stream.
+         */
+        fun startWriterThread(
+            writeQueue: ArrayBlockingQueue<ByteArray>,
+            outputStreamHolder: AtomicReference<OutputStream?>,
+            isRecordingActive: AtomicBoolean
+        ): Thread {
+            return Thread({
+                android.util.Log.d("RecordingDataSource", "Writer thread started")
+                var bufferedStream: BufferedOutputStream? = null
+                var currentOutputStream: OutputStream? = null
+
+                while (true) {
+                    try {
+                        // Poll with timeout to check if we should exit
+                        val data = writeQueue.poll(100, java.util.concurrent.TimeUnit.MILLISECONDS)
+
+                        // Check if output stream has changed
+                        val newOutputStream = outputStreamHolder.get()
+                        if (newOutputStream != currentOutputStream) {
+                            // Flush and update the buffered stream
+                            bufferedStream?.flush()
+                            currentOutputStream = newOutputStream
+                            bufferedStream = if (newOutputStream != null) {
+                                BufferedOutputStream(newOutputStream, 64 * 1024) // 64KB buffer
+                            } else {
+                                null
+                            }
+                        }
+
+                        if (data != null && bufferedStream != null) {
+                            bufferedStream.write(data)
+                        }
+
+                        // Periodic flush to ensure data is written (every ~1 second worth of data)
+                        if (writeQueue.isEmpty() && bufferedStream != null) {
+                            bufferedStream.flush()
+                        }
+
+                        // Exit if recording stopped and queue is drained
+                        if (!isRecordingActive.get() && writeQueue.isEmpty() && outputStreamHolder.get() == null) {
+                            android.util.Log.d("RecordingDataSource", "Writer thread exiting - recording stopped")
+                            break
+                        }
+                    } catch (e: InterruptedException) {
+                        android.util.Log.d("RecordingDataSource", "Writer thread interrupted")
+                        break
+                    } catch (e: Exception) {
+                        android.util.Log.e("RecordingDataSource", "Error in writer thread", e)
+                    }
+                }
+
+                // Final flush
+                try {
+                    bufferedStream?.flush()
+                } catch (e: Exception) {
+                    android.util.Log.e("RecordingDataSource", "Error flushing final buffer", e)
+                }
+                android.util.Log.d("RecordingDataSource", "Writer thread ended")
+            }, "RecordingWriter").apply {
+                priority = Thread.MIN_PRIORITY // Low priority to not interfere with audio
+            }
         }
     }
 }

--- a/app/src/main/java/com/opensource/i2pradio/ui/NowPlayingFragment.kt
+++ b/app/src/main/java/com/opensource/i2pradio/ui/NowPlayingFragment.kt
@@ -350,16 +350,16 @@ class NowPlayingFragment : Fragment() {
             recordingHandler.removeCallbacks(recordingUpdateRunnable)
             recordingHandler.post(recordingUpdateRunnable)
         } else {
-            // Restore record icon
+            // Restore record icon with default blue/primary color
             recordButton.setImageResource(R.drawable.ic_fiber_manual_record)
             // Get colors from the current theme context to reflect theme changes properly
             // Using requireContext() ensures we get colors from the recreated activity's theme
             val ctx = requireContext()
             recordButton.imageTintList = android.content.res.ColorStateList.valueOf(
-                com.google.android.material.color.MaterialColors.getColor(ctx, com.google.android.material.R.attr.colorError, android.graphics.Color.RED)
+                com.google.android.material.color.MaterialColors.getColor(ctx, com.google.android.material.R.attr.colorOnPrimaryContainer, android.graphics.Color.WHITE)
             )
             recordButton.backgroundTintList = android.content.res.ColorStateList.valueOf(
-                com.google.android.material.color.MaterialColors.getColor(ctx, com.google.android.material.R.attr.colorSurfaceContainerHighest, android.graphics.Color.GRAY)
+                com.google.android.material.color.MaterialColors.getColor(ctx, com.google.android.material.R.attr.colorPrimaryContainer, android.graphics.Color.BLUE)
             )
 
             // Stop blinking animation

--- a/app/src/main/res/drawable/ic_fiber_manual_record.xml
+++ b/app/src/main/res/drawable/ic_fiber_manual_record.xml
@@ -4,7 +4,8 @@
     android:height="24dp"
     android:viewportWidth="24"
     android:viewportHeight="24">
+    <!-- Using white (#FFFFFF) as base color so FAB tint can properly color it -->
     <path
-        android:fillColor="#F44336"
+        android:fillColor="#FFFFFF"
         android:pathData="M12,12m-10,0a10,10 0,1 1,20 0a10,10 0,1 1,-20 0"/>
 </vector>

--- a/app/src/main/res/layout/fragment_now_playing.xml
+++ b/app/src/main/res/layout/fragment_now_playing.xml
@@ -121,7 +121,7 @@
         app:layout_constraintTop_toBottomOf="@id/nowPlayingInfoContainer"
         app:layout_constraintWidth_max="320dp">
 
-        <!-- Record Button (Left) -->
+        <!-- Record Button (Left) - Default blue, changes to red when recording -->
         <com.google.android.material.floatingactionbutton.FloatingActionButton
             android:id="@+id/recordButton"
             android:layout_width="wrap_content"
@@ -132,8 +132,8 @@
             app:fabSize="auto"
             app:fabCustomSize="64dp"
             app:maxImageSize="28dp"
-            app:tint="?attr/colorError"
-            app:backgroundTint="?attr/colorSurfaceContainerHighest"
+            app:tint="?attr/colorOnPrimaryContainer"
+            app:backgroundTint="?attr/colorPrimaryContainer"
             app:shapeAppearanceOverlay="@style/ShapeAppearance.Material3.Corner.Full"
             app:elevation="0dp"
             app:layout_constraintBottom_toBottomOf="@id/playPauseButton"


### PR DESCRIPTION
- Replace synchronous disk writes with async buffered queue to prevent audio hitching when recording. Uses a background writer thread with 64KB buffered writes, allowing playback to continue uninterrupted.
- Add proper cleanup for writer thread and queue on recording stop
- Change recording button to use primary/blue color by default, switching to red error container when actively recording
- Update ic_fiber_manual_record icon to use white fill so FAB tint can properly color it based on theme