### PR TITLE
Fix radio audio static scratches and UI bugs

### DIFF
--- a/app/src/main/java/com/opensource/i2pradio/ui/MiniPlayerView.kt
+++ b/app/src/main/java/com/opensource/i2pradio/ui/MiniPlayerView.kt
@@ -287,11 +287,15 @@ class MiniPlayerView @JvmOverloads constructor(
             }
             context.startService(intent)
         } else {
+            val proxyType = station.getProxyTypeEnum()
             val intent = Intent(context, RadioService::class.java).apply {
                 action = RadioService.ACTION_PLAY
                 putExtra("stream_url", station.streamUrl)
+                putExtra("station_name", station.name)
                 putExtra("proxy_host", if (station.useProxy) station.proxyHost else "")
                 putExtra("proxy_port", station.proxyPort)
+                putExtra("proxy_type", proxyType.name)
+                putExtra("cover_art_uri", station.coverArtUri)
             }
             context.startService(intent)
         }

--- a/app/src/main/java/com/opensource/i2pradio/ui/NowPlayingFragment.kt
+++ b/app/src/main/java/com/opensource/i2pradio/ui/NowPlayingFragment.kt
@@ -376,11 +376,15 @@ class NowPlayingFragment : Fragment() {
                 requireContext().startService(intent)
                 viewModel.setPlaying(false)
             } else if (station != null) {
+                val proxyType = station.getProxyTypeEnum()
                 val intent = Intent(requireContext(), RadioService::class.java).apply {
                     action = RadioService.ACTION_PLAY
                     putExtra("stream_url", station.streamUrl)
+                    putExtra("station_name", station.name)
                     putExtra("proxy_host", if (station.useProxy) station.proxyHost else "")
                     putExtra("proxy_port", station.proxyPort)
+                    putExtra("proxy_type", proxyType.name)
+                    putExtra("cover_art_uri", station.coverArtUri)
                 }
                 requireContext().startService(intent)
                 viewModel.setPlaying(true)

--- a/app/src/main/res/layout/fragment_radios.xml
+++ b/app/src/main/res/layout/fragment_radios.xml
@@ -5,7 +5,18 @@
     android:layout_height="match_parent"
     android:background="?attr/colorSurface">
 
-    <!-- Sort Button Header -->
+    <!-- Radio Stations List - placed first so sort header is drawn on top -->
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/radiosRecyclerView"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:clipToPadding="false"
+        android:paddingTop="56dp"
+        android:paddingBottom="100dp"
+        android:scrollbars="vertical"
+        app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager" />
+
+    <!-- Sort Button Header - placed after RecyclerView so it's on top and receives touch events -->
     <LinearLayout
         android:id="@+id/sortHeader"
         android:layout_width="match_parent"
@@ -13,7 +24,9 @@
         android:orientation="horizontal"
         android:gravity="end"
         android:paddingHorizontal="8dp"
-        android:paddingTop="8dp">
+        android:paddingTop="8dp"
+        android:background="?attr/colorSurface"
+        android:elevation="2dp">
 
         <com.google.android.material.button.MaterialButton
             android:id="@+id/sortButton"
@@ -26,17 +39,6 @@
             app:iconSize="18dp" />
 
     </LinearLayout>
-
-    <!-- Radio Stations List -->
-    <androidx.recyclerview.widget.RecyclerView
-        android:id="@+id/radiosRecyclerView"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:clipToPadding="false"
-        android:paddingTop="56dp"
-        android:paddingBottom="100dp"
-        android:scrollbars="vertical"
-        app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager" />
 
     <!-- Empty State (Centered and styled) -->
     <LinearLayout


### PR DESCRIPTION
- Add proper AudioFocusChangeListener to RadioService to handle audio focus interruptions gracefully (ducking on transient loss, resume on regain). This fixes random static scratches caused by system audio events not being handled properly.

- Fix sort button on RadiosFragment not responding to clicks by moving sortHeader after RecyclerView in XML (later elements are drawn on top and receive touch events in CoordinatorLayout). Added background and elevation to sortHeader for proper visual separation.

- Fix missing intent extras when resuming playback from NowPlayingFragment and MiniPlayerView (proxy_type, station_name, cover_art_uri were missing, causing wrong proxy type and "Unknown Station" in notifications).