### PR TITLE
Fix audio buffer underrun and UI bugs

### DIFF
--- a/app/src/main/res/layout/fragment_now_playing.xml
+++ b/app/src/main/res/layout/fragment_now_playing.xml
@@ -255,7 +255,7 @@
                 android:layout_marginStart="8dp"
                 android:text="00:00"
                 android:textSize="14sp"
-                android:fontFamily="sans-serif-medium"
+                android:fontFamily="monospace"
                 android:textColor="?attr/colorOnErrorContainer" />
 
         </LinearLayout>


### PR DESCRIPTION
- Increase ExoPlayer buffer settings to prevent audio glitches:
  - Min buffer: 50s (was 30s)
  - Max buffer: 120s (was 60s)
  - Playback buffer: 5s (was 2.5s)
  - Rebuffer threshold: 10s (was 5s)
- Add 30s back buffer for smoother playback
- Add AudioAttributes with music content type for proper audio routing
- Enable wake mode to keep CPU/network active during playback
- Connect NowPlayingFragment to playback state broadcasts for buffering UI
- Sync playing state from service broadcasts to ViewModel
- Use monospace font for recording timer for stable width