### PR TITLE
Increase AudioTrack and disk write buffers to eliminate audio glitches

### DIFF
--- a/app/src/main/java/com/opensource/i2pradio/RadioService.kt
+++ b/app/src/main/java/com/opensource/i2pradio/RadioService.kt
@@ -703,7 +703,7 @@ class RadioService : Service() {
                 .setContentType(androidx.media3.common.C.AUDIO_CONTENT_TYPE_MUSIC)
                 .build()
 
-            // Create a custom audio sink with a larger buffer to prevent glitching
+            // Create a custom audio sink with a much larger buffer to prevent glitching
             // The default AudioTrack buffer is often too small for streaming radio,
             // causing glitches when there are minor delays in data delivery
             val largeBufferProvider = object : DefaultAudioSink.AudioTrackBufferSizeProvider {
@@ -716,11 +716,12 @@ class RadioService : Service() {
                     bitrate: Int,
                     maxAudioTrackPlaybackSpeed: Double
                 ): Int {
-                    // Use at least 1.5 seconds of audio buffer, or 3x the minimum
-                    // This prevents glitches from minor thread scheduling delays
-                    val targetBufferMs = 1500
+                    // Use at least 3 seconds of audio buffer, or 5x the minimum
+                    // This provides ample headroom for thread scheduling, GC pauses,
+                    // and any momentary delays in the audio pipeline
+                    val targetBufferMs = 3000
                     val targetBufferBytes = (sampleRate * pcmFrameSize * targetBufferMs) / 1000
-                    return maxOf(minBufferSizeInBytes * 3, targetBufferBytes)
+                    return maxOf(minBufferSizeInBytes * 5, targetBufferBytes)
                 }
             }
 

--- a/app/src/main/java/com/opensource/i2pradio/RecordingDataSource.kt
+++ b/app/src/main/java/com/opensource/i2pradio/RecordingDataSource.kt
@@ -142,7 +142,7 @@ class RecordingDataSource(
                 var bufferedStream: BufferedOutputStream? = null
                 var currentOutputStream: OutputStream? = null
                 var bytesWrittenSinceFlush = 0
-                val flushThreshold = 128 * 1024 // Flush every 128KB instead of every empty queue
+                val flushThreshold = 256 * 1024 // Flush every 256KB to reduce disk I/O frequency
 
                 while (true) {
                     try {
@@ -157,7 +157,7 @@ class RecordingDataSource(
                             bytesWrittenSinceFlush = 0
                             currentOutputStream = newOutputStream
                             bufferedStream = if (newOutputStream != null) {
-                                BufferedOutputStream(newOutputStream, 128 * 1024) // 128KB buffer
+                                BufferedOutputStream(newOutputStream, 256 * 1024) // 256KB buffer for efficient disk writes
                             } else {
                                 null
                             }


### PR DESCRIPTION
- Increase AudioTrack buffer from 1.5s to 3s (double the previous value)
- Increase AudioTrack minimum multiplier from 3x to 5x
- Increase disk write buffer from 128KB to 256KB
- Increase flush threshold from 128KB to 256KB to reduce I/O frequency

These larger buffers provide more headroom for thread scheduling, GC pauses, and momentary delays in the audio pipeline.