### PR TITLE
Fix equalizer integration and add UI improvements

### DIFF
--- a/app/src/main/java/com/opensource/i2pradio/data/RadioRepository.kt
+++ b/app/src/main/java/com/opensource/i2pradio/data/RadioRepository.kt
@@ -7,9 +7,10 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
 enum class SortOrder {
-    DEFAULT,      // Liked first, then presets, then by added time
-    NAME,         // Alphabetical by name
-    RECENTLY_PLAYED  // Most recently played first
+    DEFAULT,         // Liked first, then presets, then by added time
+    NAME,            // Alphabetical by name
+    RECENTLY_PLAYED, // Most recently played first
+    LIKED            // Only liked stations
 }
 
 class RadioRepository(context: Context) {
@@ -22,6 +23,7 @@ class RadioRepository(context: Context) {
             SortOrder.DEFAULT -> radioDao.getAllStations()
             SortOrder.NAME -> radioDao.getAllStationsSortedByName()
             SortOrder.RECENTLY_PLAYED -> radioDao.getAllStationsSortedByRecentlyPlayed()
+            SortOrder.LIKED -> radioDao.getLikedStations()
         }
     }
 

--- a/app/src/main/java/com/opensource/i2pradio/ui/NowPlayingFragment.kt
+++ b/app/src/main/java/com/opensource/i2pradio/ui/NowPlayingFragment.kt
@@ -598,12 +598,12 @@ class NowPlayingFragment : Fragment() {
 
     /**
      * Opens the system equalizer or external equalizer app (like Wavelet).
-     * This is the same approach used by Auxio and other music players.
+     * Uses the standard Android AudioEffect intent protocol that apps like Auxio use.
      */
     private fun openSystemEqualizer() {
         val audioSessionId = radioService?.getAudioSessionId() ?: 0
         if (audioSessionId == 0) {
-            Toast.makeText(requireContext(), "Start playing a station first", Toast.LENGTH_SHORT).show()
+            Toast.makeText(requireContext(), getString(R.string.equalizer_no_audio), Toast.LENGTH_SHORT).show()
             return
         }
 
@@ -613,10 +613,15 @@ class NowPlayingFragment : Fragment() {
             putExtra(AudioEffect.EXTRA_CONTENT_TYPE, AudioEffect.CONTENT_TYPE_MUSIC)
         }
 
-        if (intent.resolveActivity(requireContext().packageManager) != null) {
+        try {
             startActivity(intent)
-        } else {
-            Toast.makeText(requireContext(), "No equalizer app found. Install an equalizer like Wavelet.", Toast.LENGTH_LONG).show()
+        } catch (e: Exception) {
+            // No equalizer app found - show helpful message
+            Toast.makeText(
+                requireContext(),
+                getString(R.string.equalizer_not_found),
+                Toast.LENGTH_LONG
+            ).show()
         }
     }
 

--- a/app/src/main/java/com/opensource/i2pradio/ui/RadiosFragment.kt
+++ b/app/src/main/java/com/opensource/i2pradio/ui/RadiosFragment.kt
@@ -108,13 +108,18 @@ class RadiosFragment : Fragment() {
     }
 
     private fun showSortDialog() {
-        val sortOptions = arrayOf("Default", "Name", "Recently Played")
+        val sortOptions = arrayOf(
+            getString(R.string.sort_default),
+            getString(R.string.sort_name),
+            getString(R.string.sort_recent),
+            getString(R.string.sort_liked)
+        )
         val currentIndex = currentSortOrder.ordinal
 
         AlertDialog.Builder(requireContext())
             .setTitle("Sort Stations")
             .setSingleChoiceItems(sortOptions, currentIndex) { dialog, which ->
-                currentSortOrder = SortOrder.values()[which]
+                currentSortOrder = SortOrder.entries[which]
                 PreferencesHelper.setSortOrder(requireContext(), currentSortOrder.name)
                 updateSortButtonText()
                 observeStations()
@@ -125,9 +130,10 @@ class RadiosFragment : Fragment() {
 
     private fun updateSortButtonText() {
         sortButton.text = when (currentSortOrder) {
-            SortOrder.DEFAULT -> "Default"
-            SortOrder.NAME -> "Name"
-            SortOrder.RECENTLY_PLAYED -> "Recent"
+            SortOrder.DEFAULT -> getString(R.string.sort_default)
+            SortOrder.NAME -> getString(R.string.sort_name)
+            SortOrder.RECENTLY_PLAYED -> getString(R.string.sort_recent)
+            SortOrder.LIKED -> getString(R.string.sort_liked)
         }
     }
 

--- a/app/src/main/res/drawable/ic_equalizer.xml
+++ b/app/src/main/res/drawable/ic_equalizer.xml
@@ -2,8 +2,10 @@
     android:width="24dp"
     android:height="24dp"
     android:viewportWidth="24"
-    android:viewportHeight="24">
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+    <!-- Material Design tune/equalizer icon - cleaner and more recognizable -->
     <path
-        android:fillColor="#FF000000"
-        android:pathData="M10,20h4V4h-4v16zM4,20h4v-8H4v8zM16,9v11h4V9h-4z"/>
+        android:fillColor="@android:color/white"
+        android:pathData="M3,17v2h6v-2L3,17zM3,5v2h10L13,5L3,5zM13,21v-2h8v-2h-8v-2h-2v6h2zM7,9v2L3,11v2h4v2h2L9,9L7,9zM21,13v-2L11,11v2h10zM15,9h2L17,7h4L21,5h-4L17,3h-2v6z"/>
 </vector>

--- a/app/src/main/res/layout-land/fragment_now_playing.xml
+++ b/app/src/main/res/layout-land/fragment_now_playing.xml
@@ -23,17 +23,42 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
-    <!-- Recording Indicator - solid background to prevent bleed-through -->
+    <!-- Equalizer Button -->
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/equalizerButton"
+        style="@style/Widget.Material3.Button.IconButton"
+        android:layout_width="48dp"
+        android:layout_height="48dp"
+        android:contentDescription="Equalizer"
+        app:icon="@drawable/ic_equalizer"
+        app:iconTint="?attr/colorOnSurface"
+        app:layout_constraintStart_toEndOf="@id/backButton"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <!-- Like Button -->
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/likeButton"
+        style="@style/Widget.Material3.Button.IconButton"
+        android:layout_width="48dp"
+        android:layout_height="48dp"
+        android:contentDescription="Like"
+        app:icon="@drawable/ic_favorite_border"
+        app:iconTint="?attr/colorOnSurface"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <!-- Recording Indicator - positioned below like button to avoid overlap -->
     <com.google.android.material.card.MaterialCardView
         android:id="@+id/recordingIndicator"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:layout_marginTop="4dp"
         android:visibility="gone"
         app:cardBackgroundColor="?attr/colorErrorContainer"
         app:cardCornerRadius="16dp"
         app:cardElevation="2dp"
         app:strokeWidth="0dp"
-        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/likeButton"
         app:layout_constraintEnd_toEndOf="parent">
 
         <LinearLayout
@@ -155,6 +180,21 @@
                 android:focusableInTouchMode="true"
                 android:visibility="gone"
                 tools:text="Song Name - Artist"
+                tools:visibility="visible" />
+
+            <!-- Stream Info (bitrate/codec) -->
+            <TextView
+                android:id="@+id/nowPlayingStreamInfo"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="4dp"
+                android:paddingHorizontal="8dp"
+                android:gravity="center"
+                android:textSize="11sp"
+                android:textColor="?attr/colorOnSurfaceVariant"
+                android:alpha="0.7"
+                android:visibility="gone"
+                tools:text="128 kbps • MP3"
                 tools:visibility="visible" />
 
         </LinearLayout>

--- a/app/src/main/res/layout/fragment_now_playing.xml
+++ b/app/src/main/res/layout/fragment_now_playing.xml
@@ -220,18 +220,18 @@
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 
-    <!-- Recording Indicator - solid background to prevent bleed-through -->
+    <!-- Recording Indicator - positioned below the like button to avoid overlap -->
     <com.google.android.material.card.MaterialCardView
         android:id="@+id/recordingIndicator"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginTop="8dp"
+        android:layout_marginTop="4dp"
         android:visibility="gone"
         app:cardBackgroundColor="?attr/colorErrorContainer"
         app:cardCornerRadius="16dp"
         app:cardElevation="2dp"
         app:strokeWidth="0dp"
-        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/likeButton"
         app:layout_constraintEnd_toEndOf="parent">
 
         <LinearLayout

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -3,4 +3,15 @@
     <string name="tab_radios">Stations</string>
     <string name="tab_now_playing">Now Playing</string>
     <string name="tab_settings">Settings</string>
+
+    <!-- Equalizer -->
+    <string name="equalizer">Equalizer</string>
+    <string name="equalizer_no_audio">Start playing a station first</string>
+    <string name="equalizer_not_found">No equalizer app found. Install an equalizer app like Wavelet.</string>
+
+    <!-- Sort options -->
+    <string name="sort_default">Default</string>
+    <string name="sort_name">Name</string>
+    <string name="sort_recent">Recent</string>
+    <string name="sort_liked">Liked</string>
 </resources>


### PR DESCRIPTION
- Fix equalizer to properly call system EQ using AudioEffect broadcasts
  - Send ACTION_OPEN_AUDIO_EFFECT_CONTROL_SESSION when playback starts
  - Send ACTION_CLOSE_AUDIO_EFFECT_CONTROL_SESSION when playback stops
  - This follows the standard Android audio effect protocol for external EQs

- Add 'Liked' sort option for stations
  - Users can now filter to show only liked/favorite stations
  - Added to SortOrder enum and sort dialog

- Fix heart icon overlap with recording status indicator
  - Recording indicator now positioned below the like button
  - Prevents overlap in both portrait and landscape orientations

- Update equalizer icon to Material Design tune icon
  - Cleaner, more recognizable icon design

- Add missing UI elements to landscape layout
  - Added equalizer button
  - Added like button
  - Added stream info text view