### PR TITLE
Fix bytesRead variable initialization in RadioService

### DIFF
--- a/app/src/main/java/com/opensource/i2pradio/RadioService.kt
+++ b/app/src/main/java/com/opensource/i2pradio/RadioService.kt
@@ -451,7 +451,7 @@ class RadioService : Service() {
                         )
 
                         val buffer = ByteArray(8192)
-                        var bytesRead: Int
+                        var bytesRead = -1
 
                         while (isRecordingActive.get() &&
                                inputStream?.read(buffer).also { bytesRead = it ?: -1 } != -1) {


### PR DESCRIPTION
Initialize bytesRead to -1 to satisfy Kotlin's requirement that variables must be initialized before use. The compiler couldn't guarantee initialization before the variable is read in the loop body.