### PR TITLE
Add complete equalizer UI with Bass Booster and Surround Sound

### DIFF
--- a/app/src/main/java/com/opensource/i2pradio/ui/EqualizerBottomSheet.kt
+++ b/app/src/main/java/com/opensource/i2pradio/ui/EqualizerBottomSheet.kt
@@ -12,13 +12,14 @@ import android.widget.TextView
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import com.google.android.material.button.MaterialButton
 import com.google.android.material.materialswitch.MaterialSwitch
+import com.google.android.material.slider.Slider
 import com.google.android.material.textfield.TextInputLayout
 import com.opensource.i2pradio.R
 import com.opensource.i2pradio.audio.EqualizerManager
 
 /**
  * Bottom sheet dialog for the built-in equalizer.
- * Displays band sliders, presets, and enable/disable toggle.
+ * Displays band sliders, presets, bass boost, surround sound, and enable/disable toggle.
  */
 class EqualizerBottomSheet(
     private val equalizerManager: EqualizerManager
@@ -30,9 +31,15 @@ class EqualizerBottomSheet(
     private lateinit var resetButton: MaterialButton
     private lateinit var minDbLabel: TextView
     private lateinit var maxDbLabel: TextView
+    private lateinit var dbScaleContainer: LinearLayout
+
+    // Bass Boost and Surround Sound
+    private lateinit var bassBoostContainer: LinearLayout
+    private lateinit var bassBoostSlider: Slider
+    private lateinit var surroundSoundContainer: LinearLayout
+    private lateinit var surroundSoundSlider: Slider
 
     private val bandSliders = mutableListOf<SeekBar>()
-    private val bandDbValues = mutableListOf<TextView>()
 
     // Flag to prevent feedback loops when updating UI from preset
     private var isUpdatingFromPreset = false
@@ -54,10 +61,19 @@ class EqualizerBottomSheet(
         resetButton = view.findViewById(R.id.resetButton)
         minDbLabel = view.findViewById(R.id.minDbLabel)
         maxDbLabel = view.findViewById(R.id.maxDbLabel)
+        dbScaleContainer = view.findViewById(R.id.dbScaleContainer)
+
+        // Bass Boost and Surround Sound
+        bassBoostContainer = view.findViewById(R.id.bassBoostContainer)
+        bassBoostSlider = view.findViewById(R.id.bassBoostSlider)
+        surroundSoundContainer = view.findViewById(R.id.surroundSoundContainer)
+        surroundSoundSlider = view.findViewById(R.id.surroundSoundSlider)
 
         setupEnableSwitch()
         setupPresetDropdown()
         setupBandSliders()
+        setupBassBoostSlider()
+        setupSurroundSoundSlider()
         setupResetButton()
         setupDbLabels()
         updateUIState()
@@ -106,7 +122,6 @@ class EqualizerBottomSheet(
     private fun setupBandSliders() {
         bandSlidersContainer.removeAllViews()
         bandSliders.clear()
-        bandDbValues.clear()
 
         val inflater = LayoutInflater.from(context)
         val levelRange = equalizerManager.bandLevelRange
@@ -118,20 +133,16 @@ class EqualizerBottomSheet(
             val bandView = inflater.inflate(R.layout.item_equalizer_band, bandSlidersContainer, false)
 
             val slider = bandView.findViewById<SeekBar>(R.id.bandSlider)
-            val dbValue = bandView.findViewById<TextView>(R.id.bandDbValue)
             val freqLabel = bandView.findViewById<TextView>(R.id.bandFrequency)
 
             // Set frequency label
             val freq = equalizerManager.centerFrequencies.getOrNull(band) ?: 0
-            freqLabel.text = equalizerManager.formatFrequency(freq)
+            freqLabel.text = formatFrequencyLabel(freq)
 
             // Configure slider
             slider.max = range
             val currentLevel = equalizerManager.getBandLevel(band.toShort()).toInt()
             slider.progress = currentLevel - minLevel
-
-            // Update dB display
-            updateDbDisplay(dbValue, currentLevel)
 
             // Set listener
             slider.setOnSeekBarChangeListener(object : SeekBar.OnSeekBarChangeListener {
@@ -139,7 +150,6 @@ class EqualizerBottomSheet(
                     if (fromUser && !isUpdatingFromPreset) {
                         val level = (minLevel + progress).toShort()
                         equalizerManager.setBandLevel(band.toShort(), level)
-                        updateDbDisplay(dbValue, level.toInt())
                         // Set dropdown to "Custom" when user manually adjusts
                         presetDropdown.setText(getString(R.string.equalizer_custom), false)
                     }
@@ -150,8 +160,41 @@ class EqualizerBottomSheet(
             })
 
             bandSliders.add(slider)
-            bandDbValues.add(dbValue)
             bandSlidersContainer.addView(bandView)
+        }
+    }
+
+    private fun setupBassBoostSlider() {
+        // Hide if not supported
+        if (!equalizerManager.isBassBoostSupported) {
+            bassBoostContainer.visibility = View.GONE
+            return
+        }
+
+        bassBoostContainer.visibility = View.VISIBLE
+        bassBoostSlider.value = equalizerManager.getBassBoostStrength().toFloat()
+
+        bassBoostSlider.addOnChangeListener { _, value, fromUser ->
+            if (fromUser) {
+                equalizerManager.setBassBoostStrength(value.toInt().toShort())
+            }
+        }
+    }
+
+    private fun setupSurroundSoundSlider() {
+        // Hide if not supported
+        if (!equalizerManager.isVirtualizerSupported) {
+            surroundSoundContainer.visibility = View.GONE
+            return
+        }
+
+        surroundSoundContainer.visibility = View.VISIBLE
+        surroundSoundSlider.value = equalizerManager.getVirtualizerStrength().toFloat()
+
+        surroundSoundSlider.addOnChangeListener { _, value, fromUser ->
+            if (fromUser) {
+                equalizerManager.setVirtualizerStrength(value.toInt().toShort())
+            }
         }
     }
 
@@ -160,6 +203,16 @@ class EqualizerBottomSheet(
             equalizerManager.resetToFlat()
             updateBandSliders()
             presetDropdown.setText(getString(R.string.equalizer_custom), false)
+
+            // Reset bass boost and surround sound
+            if (equalizerManager.isBassBoostSupported) {
+                equalizerManager.setBassBoostStrength(0)
+                bassBoostSlider.value = 0f
+            }
+            if (equalizerManager.isVirtualizerSupported) {
+                equalizerManager.setVirtualizerStrength(0)
+                surroundSoundSlider.value = 0f
+            }
         }
     }
 
@@ -179,18 +232,18 @@ class EqualizerBottomSheet(
         for (band in 0 until equalizerManager.numberOfBands) {
             val currentLevel = equalizerManager.getBandLevel(band.toShort()).toInt()
             bandSliders.getOrNull(band)?.progress = currentLevel - minLevel
-            bandDbValues.getOrNull(band)?.let { updateDbDisplay(it, currentLevel) }
         }
     }
 
-    private fun updateDbDisplay(textView: TextView, levelMillibels: Int) {
-        val db = levelMillibels / 100f
-        val text = if (db >= 0) {
-            String.format("+%.0f dB", db)
+    /**
+     * Format frequency for display with proper spacing
+     */
+    private fun formatFrequencyLabel(freqHz: Int): String {
+        return if (freqHz >= 1000) {
+            "${freqHz / 1000} kHz"
         } else {
-            String.format("%.0f dB", db)
+            "$freqHz Hz"
         }
-        textView.text = text
     }
 
     private fun updateUIState() {
@@ -201,10 +254,15 @@ class EqualizerBottomSheet(
         val alpha = if (isEnabled) 1f else 0.5f
         view?.findViewById<TextInputLayout>(R.id.presetInputLayout)?.alpha = alpha
         bandSlidersContainer.alpha = alpha
+        dbScaleContainer.alpha = alpha
+        bassBoostContainer.alpha = alpha
+        surroundSoundContainer.alpha = alpha
         resetButton.alpha = alpha
 
         // Enable/disable all sliders
         bandSliders.forEach { it.isEnabled = isEnabled }
+        bassBoostSlider.isEnabled = isEnabled
+        surroundSoundSlider.isEnabled = isEnabled
     }
 
     companion object {

--- a/app/src/main/java/com/opensource/i2pradio/ui/PreferenceHelper.kt
+++ b/app/src/main/java/com/opensource/i2pradio/ui/PreferenceHelper.kt
@@ -15,6 +15,8 @@ object PreferencesHelper {
     private const val KEY_EQUALIZER_ENABLED = "equalizer_enabled"
     private const val KEY_EQUALIZER_PRESET = "equalizer_preset"
     private const val KEY_EQUALIZER_BANDS = "equalizer_bands"
+    private const val KEY_BASS_BOOST_STRENGTH = "bass_boost_strength"
+    private const val KEY_VIRTUALIZER_STRENGTH = "virtualizer_strength"
 
     fun saveThemeMode(context: Context, mode: Int) {
         context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
@@ -139,5 +141,31 @@ object PreferencesHelper {
     fun getEqualizerBands(context: Context): String? {
         return context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
             .getString(KEY_EQUALIZER_BANDS, null)
+    }
+
+    // Bass Boost preferences
+    fun setBassBoostStrength(context: Context, strength: Short) {
+        context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+            .edit()
+            .putInt(KEY_BASS_BOOST_STRENGTH, strength.toInt())
+            .apply()
+    }
+
+    fun getBassBoostStrength(context: Context): Short {
+        return context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+            .getInt(KEY_BASS_BOOST_STRENGTH, 0).toShort()
+    }
+
+    // Virtualizer (Surround Sound) preferences
+    fun setVirtualizerStrength(context: Context, strength: Short) {
+        context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+            .edit()
+            .putInt(KEY_VIRTUALIZER_STRENGTH, strength.toInt())
+            .apply()
+    }
+
+    fun getVirtualizerStrength(context: Context): Short {
+        return context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+            .getInt(KEY_VIRTUALIZER_STRENGTH, 0).toShort()
     }
 }

--- a/app/src/main/res/layout/bottom_sheet_equalizer.xml
+++ b/app/src/main/res/layout/bottom_sheet_equalizer.xml
@@ -51,64 +51,141 @@
 
     </com.google.android.material.textfield.TextInputLayout>
 
-    <!-- Band sliders container -->
-    <HorizontalScrollView
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:scrollbars="none"
-        android:fillViewport="true">
-
-        <LinearLayout
-            android:id="@+id/bandSlidersContainer"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:orientation="horizontal"
-            android:gravity="center"
-            android:minHeight="200dp"
-            android:paddingHorizontal="8dp" />
-
-    </HorizontalScrollView>
-
-    <!-- dB labels -->
+    <!-- EQ Bands Section with dB scale on left -->
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        android:gravity="center"
-        android:paddingTop="4dp">
+        android:gravity="center_vertical">
 
-        <TextView
-            android:id="@+id/minDbLabel"
+        <!-- dB Scale on the left -->
+        <LinearLayout
+            android:id="@+id/dbScaleContainer"
             android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:textSize="11sp"
-            android:textColor="?attr/colorOnSurfaceVariant"
-            tools:text="-15 dB" />
+            android:layout_height="180dp"
+            android:orientation="vertical"
+            android:gravity="center_vertical"
+            android:paddingEnd="8dp">
 
-        <View
+            <TextView
+                android:id="@+id/maxDbLabel"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:textSize="11sp"
+                android:textColor="?attr/colorOnSurfaceVariant"
+                tools:text="+10 dB" />
+
+            <View
+                android:layout_width="1dp"
+                android:layout_height="0dp"
+                android:layout_weight="1" />
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="0 dB"
+                android:textSize="11sp"
+                android:textColor="?attr/colorOnSurfaceVariant" />
+
+            <View
+                android:layout_width="1dp"
+                android:layout_height="0dp"
+                android:layout_weight="1" />
+
+            <TextView
+                android:id="@+id/minDbLabel"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:textSize="11sp"
+                android:textColor="?attr/colorOnSurfaceVariant"
+                tools:text="-10 dB" />
+
+        </LinearLayout>
+
+        <!-- Band sliders container -->
+        <HorizontalScrollView
             android:layout_width="0dp"
-            android:layout_height="1dp"
-            android:layout_weight="1" />
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:scrollbars="none"
+            android:fillViewport="true">
+
+            <LinearLayout
+                android:id="@+id/bandSlidersContainer"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal"
+                android:gravity="center" />
+
+        </HorizontalScrollView>
+
+    </LinearLayout>
+
+    <!-- Bass Booster Section -->
+    <LinearLayout
+        android:id="@+id/bassBoostContainer"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:gravity="center_vertical"
+        android:layout_marginTop="24dp"
+        android:paddingVertical="8dp">
 
         <TextView
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="0 dB"
-            android:textSize="11sp"
-            android:textColor="?attr/colorOnSurfaceVariant" />
+            android:text="@string/equalizer_bass_boost"
+            android:textSize="14sp"
+            android:textStyle="bold"
+            android:textColor="?attr/colorOnSurface"
+            android:minWidth="140dp" />
 
-        <View
+        <com.google.android.material.slider.Slider
+            android:id="@+id/bassBoostSlider"
             android:layout_width="0dp"
-            android:layout_height="1dp"
-            android:layout_weight="1" />
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:valueFrom="0"
+            android:valueTo="1000"
+            android:stepSize="10"
+            app:trackColorActive="?attr/colorPrimary"
+            app:trackColorInactive="?attr/colorSurfaceVariant"
+            app:thumbColor="?attr/colorPrimary"
+            app:labelBehavior="gone" />
+
+    </LinearLayout>
+
+    <!-- Surround Sound Section -->
+    <LinearLayout
+        android:id="@+id/surroundSoundContainer"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:gravity="center_vertical"
+        android:layout_marginTop="8dp"
+        android:paddingVertical="8dp">
 
         <TextView
-            android:id="@+id/maxDbLabel"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:textSize="11sp"
-            android:textColor="?attr/colorOnSurfaceVariant"
-            tools:text="+15 dB" />
+            android:text="@string/equalizer_surround_sound"
+            android:textSize="14sp"
+            android:textStyle="bold"
+            android:textColor="?attr/colorOnSurface"
+            android:minWidth="140dp" />
+
+        <com.google.android.material.slider.Slider
+            android:id="@+id/surroundSoundSlider"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:valueFrom="0"
+            android:valueTo="1000"
+            android:stepSize="10"
+            app:trackColorActive="?attr/colorPrimary"
+            app:trackColorInactive="?attr/colorSurfaceVariant"
+            app:thumbColor="?attr/colorPrimary"
+            app:labelBehavior="gone" />
 
     </LinearLayout>
 

--- a/app/src/main/res/layout/item_equalizer_band.xml
+++ b/app/src/main/res/layout/item_equalizer_band.xml
@@ -5,18 +5,7 @@
     android:layout_height="wrap_content"
     android:orientation="vertical"
     android:gravity="center_horizontal"
-    android:paddingHorizontal="8dp">
-
-    <!-- dB value display -->
-    <TextView
-        android:id="@+id/bandDbValue"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:textSize="11sp"
-        android:textColor="?attr/colorPrimary"
-        android:minWidth="40dp"
-        android:gravity="center"
-        tools:text="+3 dB" />
+    android:paddingHorizontal="12dp">
 
     <!-- Vertical slider (using SeekBar rotated) -->
     <SeekBar
@@ -24,8 +13,8 @@
         android:layout_width="180dp"
         android:layout_height="48dp"
         android:rotation="270"
-        android:layout_marginTop="60dp"
-        android:layout_marginBottom="60dp"
+        android:layout_marginTop="66dp"
+        android:layout_marginBottom="66dp"
         android:progress="50"
         android:max="100"
         android:progressTint="?attr/colorPrimary"
@@ -36,10 +25,10 @@
         android:id="@+id/bandFrequency"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:textSize="11sp"
+        android:textSize="12sp"
         android:textColor="?attr/colorOnSurfaceVariant"
-        android:minWidth="40dp"
+        android:minWidth="48dp"
         android:gravity="center"
-        tools:text="1kHz" />
+        tools:text="1 kHz" />
 
 </LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -12,6 +12,8 @@
     <string name="equalizer_custom">Custom</string>
     <string name="equalizer_reset">Reset to Flat</string>
     <string name="equalizer_init_failed">Could not initialize equalizer</string>
+    <string name="equalizer_bass_boost">Bass Booster</string>
+    <string name="equalizer_surround_sound">Surround Sound</string>
 
     <!-- Sort options -->
     <string name="sort_default">Default</string>


### PR DESCRIPTION
- Add BassBoost and Virtualizer (Surround Sound) audio effects to EqualizerManager
- Update equalizer layout to match reference design with dB scale on left side
- Add horizontal sliders for Bass Booster and Surround Sound controls
- Remove per-band dB value displays, keep frequency labels below sliders
- Add preferences for storing Bass Boost and Virtualizer strength settings
- Auto-hide Bass Boost/Surround Sound controls if device doesn't support them
- Reset button now also resets Bass Boost and Surround Sound to zero