### PR TITLE
Fix recording to properly write files with separate OkHttp connection

### DIFF
--- a/app/src/main/java/com/opensource/i2pradio/ui/RadioViewModel.kt
+++ b/app/src/main/java/com/opensource/i2pradio/ui/RadioViewModel.kt
@@ -99,6 +99,14 @@ class RadioViewModel(application: Application) : AndroidViewModel(application) {
     }
 
     /**
+     * Called when a recording error occurs (from service broadcast).
+     * Resets the recording state so the UI can update.
+     */
+    fun onRecordingError() {
+        _recordingState.value = RecordingState(isRecording = false, startTimeMillis = 0L)
+    }
+
+    /**
      * Get the recording elapsed time in milliseconds.
      * Returns 0 if not recording.
      */


### PR DESCRIPTION
- Move file creation after successful HTTP connection to avoid empty files
- Add connection retry logic with exponential backoff (3 retries)
- Add proper error handling and broadcasting for recording errors/completion
- Add BROADCAST_RECORDING_ERROR and BROADCAST_RECORDING_COMPLETE actions
- UI now shows toast messages for recording errors and completion
- Recording uses completely separate OkHttpClient with own connection pool
- Better cleanup and state management when recording fails
- Smaller read buffer (8KB) for more responsive stopping
- More frequent flushing (64KB) for data safety