### PR TITLE
Save recordings to public Music/i2pradio directory using MediaStore

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -11,6 +11,7 @@
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="28" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" android:maxSdkVersion="32" />
     <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
+    <uses-permission android:name="android.permission.READ_MEDIA_AUDIO" />
 
     <application
         android:name=".I2PRadioApplication"


### PR DESCRIPTION
- On Android 10+ (API 29+), use MediaStore API to save recordings to Music/i2pradio/ in shared storage, making them visible to file managers and other apps
- On Android 9 and below, use legacy file access to save to the same public Music directory
- Add READ_MEDIA_AUDIO permission for Android 13+ audio file access
- Previously recordings were saved to app-private directory at /sdcard/Android/data/com.opensource.i2pradio/files/Recordings/ which was not accessible to users or other apps