### PR TITLE
Add real-time cover art updates, buffer bar with playback time, and b…

### DIFF
--- a/app/src/main/java/com/opensource/i2pradio/ui/MiniPlayerView.kt
+++ b/app/src/main/java/com/opensource/i2pradio/ui/MiniPlayerView.kt
@@ -12,6 +12,7 @@ import android.widget.ImageView
 import android.widget.TextView
 import androidx.core.content.ContextCompat
 import coil.load
+import coil.request.CachePolicy
 import com.google.android.material.button.MaterialButton
 import com.google.android.material.card.MaterialCardView
 import com.google.android.material.progressindicator.LinearProgressIndicator
@@ -104,6 +105,28 @@ class MiniPlayerView @JvmOverloads constructor(
                 }
             )
         }
+    }
+
+    /**
+     * Update cover art with cache invalidation for real-time updates.
+     */
+    fun updateCoverArt(coverArtUri: String?) {
+        if (coverArtUri != null) {
+            coverImage.load(coverArtUri) {
+                crossfade(true)
+                // Force refresh by disabling cache for this request
+                memoryCachePolicy(CachePolicy.WRITE_ONLY)
+                diskCachePolicy(CachePolicy.WRITE_ONLY)
+                placeholder(R.drawable.ic_radio)
+                error(R.drawable.ic_radio)
+            }
+        } else {
+            coverImage.load(R.drawable.ic_radio) {
+                crossfade(true)
+            }
+        }
+        // Update the current station's cover art reference
+        currentStation = currentStation?.copy(coverArtUri = coverArtUri)
     }
 
     fun setStation(station: RadioStation?) {

--- a/app/src/main/res/layout/fragment_now_playing.xml
+++ b/app/src/main/res/layout/fragment_now_playing.xml
@@ -153,6 +153,72 @@
 
     </LinearLayout>
 
+    <!-- Buffer/Progress Bar Section -->
+    <LinearLayout
+        android:id="@+id/bufferBarContainer"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:orientation="vertical"
+        android:visibility="gone"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/nowPlayingInfoContainer"
+        app:layout_constraintBottom_toTopOf="@id/nowPlayingControlsContainer">
+
+        <!-- Time and Buffer Progress -->
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:gravity="center_vertical"
+            android:paddingHorizontal="4dp">
+
+            <!-- Elapsed Time -->
+            <TextView
+                android:id="@+id/playbackElapsedTime"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="00:00"
+                android:textSize="12sp"
+                android:fontFamily="monospace"
+                android:textColor="?attr/colorOnSurfaceVariant" />
+
+            <!-- Spacer -->
+            <View
+                android:layout_width="0dp"
+                android:layout_height="0dp"
+                android:layout_weight="1" />
+
+            <!-- Live indicator -->
+            <TextView
+                android:id="@+id/liveIndicator"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="LIVE"
+                android:textSize="10sp"
+                android:textStyle="bold"
+                android:textColor="?attr/colorError"
+                android:visibility="visible" />
+
+        </LinearLayout>
+
+        <!-- Progress Bar -->
+        <com.google.android.material.progressindicator.LinearProgressIndicator
+            android:id="@+id/bufferProgressBar"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            app:indicatorColor="?attr/colorPrimary"
+            app:trackColor="?attr/colorSurfaceContainerHighest"
+            app:trackCornerRadius="2dp"
+            app:trackThickness="4dp"
+            android:indeterminate="false"
+            android:progress="0"
+            android:max="100" />
+
+    </LinearLayout>
+
     <!-- Playback Controls - Grouped tightly in center for tablet/foldable support -->
     <androidx.constraintlayout.widget.ConstraintLayout
         android:id="@+id/nowPlayingControlsContainer"
@@ -162,7 +228,7 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/nowPlayingInfoContainer"
+        app:layout_constraintTop_toBottomOf="@id/bufferBarContainer"
         app:layout_constraintWidth_max="320dp">
 
         <!-- Record Button (Left) - Default blue, changes to red when recording -->

--- a/app/src/main/res/layout/fragment_settings.xml
+++ b/app/src/main/res/layout/fragment_settings.xml
@@ -412,7 +412,7 @@
                         <TextView
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
-                            android:text="Open system or external equalizer"
+                            android:text="Adjust audio frequency bands and effects"
                             android:textSize="12sp"
                             android:textColor="?attr/colorOnSurfaceVariant" />
 


### PR DESCRIPTION
…uilt-in equalizer access

Features:
- Real-time cover art updates across miniplayer, now playing, and station list via broadcasts
- Buffer bar in Now Playing showing elapsed playback time (MM:SS format) with LIVE indicator
- Equalizer accessible from Settings tab even without active playback (preview mode)
- EqualizerManager now supports preview mode for configuring settings before playback

Technical changes:
- Added BROADCAST_COVER_ART_CHANGED and BROADCAST_PLAYBACK_TIME_UPDATE broadcasts to RadioService
- Added CoverArtUpdate data class to RadioViewModel for propagating cover art changes
- MiniPlayerView.updateCoverArt() with cache invalidation for immediate updates
- NowPlayingFragment now handles cover art and playback time broadcasts
- EqualizerManager.initializeForPreview() allows equalizer UI without audio session
- Settings equalizer button now opens built-in equalizer instead of system equalizer