### PR TITLE
Reorganize Now Playing layout, add search and genre filtering to stat…

### DIFF
--- a/app/src/main/java/com/opensource/i2pradio/data/RadioDao.kt
+++ b/app/src/main/java/com/opensource/i2pradio/data/RadioDao.kt
@@ -21,8 +21,37 @@ interface RadioDao {
     @Query("SELECT * FROM radio_stations WHERE isLiked = 1 ORDER BY name ASC")
     fun getLikedStations(): LiveData<List<RadioStation>>
 
+    // Sort by genre (alphabetically by genre, then by station name)
+    @Query("SELECT * FROM radio_stations ORDER BY genre ASC, name ASC")
+    fun getAllStationsSortedByGenre(): LiveData<List<RadioStation>>
+
     @Query("SELECT * FROM radio_stations WHERE genre = :genre ORDER BY addedTimestamp DESC")
     fun getStationsByGenre(genre: String): LiveData<List<RadioStation>>
+
+    // Get stations by genre with different sort orders
+    @Query("SELECT * FROM radio_stations WHERE genre = :genre ORDER BY isLiked DESC, isPreset DESC, addedTimestamp DESC")
+    fun getStationsByGenreDefault(genre: String): LiveData<List<RadioStation>>
+
+    @Query("SELECT * FROM radio_stations WHERE genre = :genre ORDER BY isLiked DESC, name ASC")
+    fun getStationsByGenreSortedByName(genre: String): LiveData<List<RadioStation>>
+
+    @Query("SELECT * FROM radio_stations WHERE genre = :genre ORDER BY isLiked DESC, lastPlayedAt DESC")
+    fun getStationsByGenreSortedByRecentlyPlayed(genre: String): LiveData<List<RadioStation>>
+
+    @Query("SELECT * FROM radio_stations WHERE genre = :genre AND isLiked = 1 ORDER BY name ASC")
+    fun getLikedStationsByGenre(genre: String): LiveData<List<RadioStation>>
+
+    // Get all unique genres
+    @Query("SELECT DISTINCT genre FROM radio_stations ORDER BY genre ASC")
+    fun getAllGenres(): LiveData<List<String>>
+
+    // Synchronous version for immediate access
+    @Query("SELECT DISTINCT genre FROM radio_stations ORDER BY genre ASC")
+    suspend fun getAllGenresSync(): List<String>
+
+    // Get all stations synchronously for search filtering
+    @Query("SELECT * FROM radio_stations ORDER BY isLiked DESC, isPreset DESC, addedTimestamp DESC")
+    suspend fun getAllStationsSync(): List<RadioStation>
 
     @Query("SELECT * FROM radio_stations WHERE id = :id")
     suspend fun getStationById(id: Long): RadioStation?

--- a/app/src/main/java/com/opensource/i2pradio/data/RadioRepository.kt
+++ b/app/src/main/java/com/opensource/i2pradio/data/RadioRepository.kt
@@ -10,7 +10,8 @@ enum class SortOrder {
     DEFAULT,         // Liked first, then presets, then by added time
     NAME,            // Alphabetical by name
     RECENTLY_PLAYED, // Most recently played first
-    LIKED            // Only liked stations
+    LIKED,           // Only liked stations
+    GENRE            // Sorted by genre alphabetically, then by name
 }
 
 class RadioRepository(context: Context) {
@@ -24,6 +25,31 @@ class RadioRepository(context: Context) {
             SortOrder.NAME -> radioDao.getAllStationsSortedByName()
             SortOrder.RECENTLY_PLAYED -> radioDao.getAllStationsSortedByRecentlyPlayed()
             SortOrder.LIKED -> radioDao.getLikedStations()
+            SortOrder.GENRE -> radioDao.getAllStationsSortedByGenre()
+        }
+    }
+
+    fun getStationsByGenreSorted(genre: String, sortOrder: SortOrder): LiveData<List<RadioStation>> {
+        return when (sortOrder) {
+            SortOrder.DEFAULT -> radioDao.getStationsByGenreDefault(genre)
+            SortOrder.NAME -> radioDao.getStationsByGenreSortedByName(genre)
+            SortOrder.RECENTLY_PLAYED -> radioDao.getStationsByGenreSortedByRecentlyPlayed(genre)
+            SortOrder.LIKED -> radioDao.getLikedStationsByGenre(genre)
+            SortOrder.GENRE -> radioDao.getStationsByGenreDefault(genre) // Same as default when filtered by genre
+        }
+    }
+
+    fun getAllGenres(): LiveData<List<String>> = radioDao.getAllGenres()
+
+    suspend fun getAllGenresSync(): List<String> {
+        return withContext(Dispatchers.IO) {
+            radioDao.getAllGenresSync()
+        }
+    }
+
+    suspend fun getAllStationsSync(): List<RadioStation> {
+        return withContext(Dispatchers.IO) {
+            radioDao.getAllStationsSync()
         }
     }
 

--- a/app/src/main/java/com/opensource/i2pradio/ui/AddEditRadioDialog.kt
+++ b/app/src/main/java/com/opensource/i2pradio/ui/AddEditRadioDialog.kt
@@ -84,10 +84,13 @@ class AddEditRadioDialog : DialogFragment() {
         // Check if embedded Tor is enabled
         val isEmbeddedTorEnabled = PreferencesHelper.isEmbeddedTorEnabled(requireContext())
 
-        // Setup genre dropdown
+        // Setup genre dropdown - expanded list sorted alphabetically
         val genres = arrayOf(
-            "News", "Music", "Rock", "Pop", "Jazz", "Classical",
-            "Electronic", "Hip Hop", "Talk", "Sports", "Other"
+            "Alternative", "Ambient", "Blues", "Christian", "Classical",
+            "Comedy", "Country", "Dance", "EDM", "Electronic", "Folk",
+            "Funk", "Gospel", "Hip Hop", "Indie", "Jazz", "K-Pop",
+            "Latin", "Lo-Fi", "Metal", "News", "Oldies", "Pop", "Punk",
+            "R&B", "Reggae", "Rock", "Soul", "Sports", "Talk", "World", "Other"
         )
         val genreAdapter = ArrayAdapter(requireContext(), android.R.layout.simple_dropdown_item_1line, genres)
         genreInput.setAdapter(genreAdapter)

--- a/app/src/main/java/com/opensource/i2pradio/ui/PreferenceHelper.kt
+++ b/app/src/main/java/com/opensource/i2pradio/ui/PreferenceHelper.kt
@@ -18,6 +18,7 @@ object PreferencesHelper {
     private const val KEY_BASS_BOOST_STRENGTH = "bass_boost_strength"
     private const val KEY_VIRTUALIZER_STRENGTH = "virtualizer_strength"
     private const val KEY_RECORDING_DIRECTORY_URI = "recording_directory_uri"
+    private const val KEY_GENRE_FILTER = "genre_filter"
 
     fun saveThemeMode(context: Context, mode: Int) {
         context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
@@ -181,5 +182,18 @@ object PreferencesHelper {
     fun getRecordingDirectoryUri(context: Context): String? {
         return context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
             .getString(KEY_RECORDING_DIRECTORY_URI, null)
+    }
+
+    // Genre filter preferences (null = All Genres)
+    fun setGenreFilter(context: Context, genre: String?) {
+        context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+            .edit()
+            .putString(KEY_GENRE_FILTER, genre)
+            .apply()
+    }
+
+    fun getGenreFilter(context: Context): String? {
+        return context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+            .getString(KEY_GENRE_FILTER, null)
     }
 }

--- a/app/src/main/res/drawable/ic_filter.xml
+++ b/app/src/main/res/drawable/ic_filter.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M10,18h4v-2h-4v2zM3,6v2h18V6H3zM6,13h12v-2H6v2z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_search.xml
+++ b/app/src/main/res/drawable/ic_search.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M15.5,14h-0.79l-0.28,-0.27C15.41,12.59 16,11.11 16,9.5 16,5.91 13.09,3 9.5,3S3,5.91 3,9.5 5.91,16 9.5,16c1.61,0 3.09,-0.59 4.23,-1.57l0.27,0.28v0.79l5,4.99L20.49,19l-4.99,-5zM9.5,14C7.01,14 5,11.99 5,9.5S7.01,5 9.5,5 14,7.01 14,9.5 11.99,14 9.5,14z"/>
+</vector>

--- a/app/src/main/res/layout-land/fragment_now_playing.xml
+++ b/app/src/main/res/layout-land/fragment_now_playing.xml
@@ -199,13 +199,13 @@
 
         </LinearLayout>
 
-        <!-- Playback Controls - Grouped tightly in center -->
+        <!-- Playback Controls - Right below stream info -->
         <androidx.constraintlayout.widget.ConstraintLayout
             android:id="@+id/nowPlayingControlsContainer"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:layout_marginBottom="8dp"
-            app:layout_constraintBottom_toBottomOf="parent"
+            android:layout_marginTop="12dp"
+            app:layout_constraintBottom_toTopOf="@id/bufferBarContainer"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/nowPlayingInfoContainer"
@@ -268,6 +268,73 @@
                 app:layout_constraintTop_toTopOf="@id/playPauseButton" />
 
         </androidx.constraintlayout.widget.ConstraintLayout>
+
+        <!-- Buffer/Progress Bar Section - At the bottom -->
+        <LinearLayout
+            android:id="@+id/bufferBarContainer"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:layout_marginBottom="8dp"
+            android:orientation="vertical"
+            android:visibility="gone"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/nowPlayingControlsContainer">
+
+            <!-- Time and Buffer Progress -->
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal"
+                android:gravity="center_vertical"
+                android:paddingHorizontal="4dp">
+
+                <!-- Elapsed Time -->
+                <TextView
+                    android:id="@+id/playbackElapsedTime"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="00:00"
+                    android:textSize="12sp"
+                    android:fontFamily="monospace"
+                    android:textColor="?attr/colorOnSurfaceVariant" />
+
+                <!-- Spacer -->
+                <View
+                    android:layout_width="0dp"
+                    android:layout_height="0dp"
+                    android:layout_weight="1" />
+
+                <!-- Live indicator -->
+                <TextView
+                    android:id="@+id/liveIndicator"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="LIVE"
+                    android:textSize="10sp"
+                    android:textStyle="bold"
+                    android:textColor="?attr/colorError"
+                    android:visibility="visible" />
+
+            </LinearLayout>
+
+            <!-- Progress Bar -->
+            <com.google.android.material.progressindicator.LinearProgressIndicator
+                android:id="@+id/bufferProgressBar"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                app:indicatorColor="?attr/colorPrimary"
+                app:trackColor="?attr/colorSurfaceContainerHighest"
+                app:trackCornerRadius="2dp"
+                app:trackThickness="4dp"
+                android:indeterminate="false"
+                android:progress="0"
+                android:max="100" />
+
+        </LinearLayout>
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/app/src/main/res/layout/fragment_now_playing.xml
+++ b/app/src/main/res/layout/fragment_now_playing.xml
@@ -153,82 +153,16 @@
 
     </LinearLayout>
 
-    <!-- Buffer/Progress Bar Section -->
-    <LinearLayout
-        android:id="@+id/bufferBarContainer"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="16dp"
-        android:orientation="vertical"
-        android:visibility="gone"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/nowPlayingInfoContainer"
-        app:layout_constraintBottom_toTopOf="@id/nowPlayingControlsContainer">
-
-        <!-- Time and Buffer Progress -->
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:orientation="horizontal"
-            android:gravity="center_vertical"
-            android:paddingHorizontal="4dp">
-
-            <!-- Elapsed Time -->
-            <TextView
-                android:id="@+id/playbackElapsedTime"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="00:00"
-                android:textSize="12sp"
-                android:fontFamily="monospace"
-                android:textColor="?attr/colorOnSurfaceVariant" />
-
-            <!-- Spacer -->
-            <View
-                android:layout_width="0dp"
-                android:layout_height="0dp"
-                android:layout_weight="1" />
-
-            <!-- Live indicator -->
-            <TextView
-                android:id="@+id/liveIndicator"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="LIVE"
-                android:textSize="10sp"
-                android:textStyle="bold"
-                android:textColor="?attr/colorError"
-                android:visibility="visible" />
-
-        </LinearLayout>
-
-        <!-- Progress Bar -->
-        <com.google.android.material.progressindicator.LinearProgressIndicator
-            android:id="@+id/bufferProgressBar"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="8dp"
-            app:indicatorColor="?attr/colorPrimary"
-            app:trackColor="?attr/colorSurfaceContainerHighest"
-            app:trackCornerRadius="2dp"
-            app:trackThickness="4dp"
-            android:indeterminate="false"
-            android:progress="0"
-            android:max="100" />
-
-    </LinearLayout>
-
-    <!-- Playback Controls - Grouped tightly in center for tablet/foldable support -->
+    <!-- Playback Controls - Now positioned right below stream info -->
     <androidx.constraintlayout.widget.ConstraintLayout
         android:id="@+id/nowPlayingControlsContainer"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_marginBottom="24dp"
-        app:layout_constraintBottom_toBottomOf="parent"
+        android:layout_marginTop="16dp"
+        app:layout_constraintBottom_toTopOf="@id/bufferBarContainer"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/bufferBarContainer"
+        app:layout_constraintTop_toBottomOf="@id/nowPlayingInfoContainer"
         app:layout_constraintWidth_max="320dp">
 
         <!-- Record Button (Left) - Default blue, changes to red when recording -->
@@ -288,6 +222,73 @@
             app:layout_constraintTop_toTopOf="@id/playPauseButton" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
+
+    <!-- Buffer/Progress Bar Section - Now at the bottom -->
+    <LinearLayout
+        android:id="@+id/bufferBarContainer"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="24dp"
+        android:layout_marginBottom="16dp"
+        android:orientation="vertical"
+        android:visibility="gone"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/nowPlayingControlsContainer">
+
+        <!-- Time and Buffer Progress -->
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:gravity="center_vertical"
+            android:paddingHorizontal="4dp">
+
+            <!-- Elapsed Time -->
+            <TextView
+                android:id="@+id/playbackElapsedTime"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="00:00"
+                android:textSize="12sp"
+                android:fontFamily="monospace"
+                android:textColor="?attr/colorOnSurfaceVariant" />
+
+            <!-- Spacer -->
+            <View
+                android:layout_width="0dp"
+                android:layout_height="0dp"
+                android:layout_weight="1" />
+
+            <!-- Live indicator -->
+            <TextView
+                android:id="@+id/liveIndicator"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="LIVE"
+                android:textSize="10sp"
+                android:textStyle="bold"
+                android:textColor="?attr/colorError"
+                android:visibility="visible" />
+
+        </LinearLayout>
+
+        <!-- Progress Bar -->
+        <com.google.android.material.progressindicator.LinearProgressIndicator
+            android:id="@+id/bufferProgressBar"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            app:indicatorColor="?attr/colorPrimary"
+            app:trackColor="?attr/colorSurfaceContainerHighest"
+            app:trackCornerRadius="2dp"
+            app:trackThickness="4dp"
+            android:indeterminate="false"
+            android:progress="0"
+            android:max="100" />
+
+    </LinearLayout>
 
     <!-- Recording Indicator - positioned below the like button to avoid overlap -->
     <com.google.android.material.card.MaterialCardView

--- a/app/src/main/res/layout/fragment_radios.xml
+++ b/app/src/main/res/layout/fragment_radios.xml
@@ -5,38 +5,86 @@
     android:layout_height="match_parent"
     android:background="?attr/colorSurface">
 
-    <!-- Radio Stations List - placed first so sort header is drawn on top -->
+    <!-- Radio Stations List - placed first so header is drawn on top -->
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/radiosRecyclerView"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:clipToPadding="false"
-        android:paddingTop="56dp"
+        android:paddingTop="112dp"
         android:paddingBottom="100dp"
         android:scrollbars="vertical"
         app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager" />
 
-    <!-- Sort Button Header - placed after RecyclerView so it's on top and receives touch events -->
+    <!-- Header with Search and Filter/Sort options -->
     <LinearLayout
-        android:id="@+id/sortHeader"
+        android:id="@+id/headerContainer"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:orientation="horizontal"
-        android:gravity="end"
-        android:paddingHorizontal="8dp"
-        android:paddingTop="8dp"
+        android:orientation="vertical"
         android:background="?attr/colorSurface"
         android:elevation="2dp">
 
-        <com.google.android.material.button.MaterialButton
-            android:id="@+id/sortButton"
-            style="@style/Widget.Material3.Button.TextButton.Icon"
-            android:layout_width="wrap_content"
+        <!-- Search Bar -->
+        <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/searchInputLayout"
+            style="@style/Widget.Material3.TextInputLayout.OutlinedBox.Dense"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="Default"
-            android:textSize="12sp"
-            app:icon="@drawable/ic_sort"
-            app:iconSize="18dp" />
+            android:layout_marginHorizontal="12dp"
+            android:layout_marginTop="8dp"
+            app:startIconDrawable="@drawable/ic_search"
+            app:endIconMode="clear_text"
+            app:boxCornerRadiusTopStart="24dp"
+            app:boxCornerRadiusTopEnd="24dp"
+            app:boxCornerRadiusBottomStart="24dp"
+            app:boxCornerRadiusBottomEnd="24dp"
+            android:hint="@string/search_stations">
+
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/searchInput"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:inputType="text"
+                android:imeOptions="actionSearch"
+                android:maxLines="1" />
+
+        </com.google.android.material.textfield.TextInputLayout>
+
+        <!-- Sort and Genre Filter Row -->
+        <LinearLayout
+            android:id="@+id/sortHeader"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:gravity="start"
+            android:paddingHorizontal="4dp"
+            android:paddingTop="4dp"
+            android:paddingBottom="4dp">
+
+            <!-- Genre Filter Button -->
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/genreFilterButton"
+                style="@style/Widget.Material3.Button.TextButton.Icon"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/genre_all"
+                android:textSize="12sp"
+                app:icon="@drawable/ic_filter"
+                app:iconSize="18dp" />
+
+            <!-- Sort Button -->
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/sortButton"
+                style="@style/Widget.Material3.Button.TextButton.Icon"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Default"
+                android:textSize="12sp"
+                app:icon="@drawable/ic_sort"
+                app:iconSize="18dp" />
+
+        </LinearLayout>
 
     </LinearLayout>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -20,4 +20,12 @@
     <string name="sort_name">Name</string>
     <string name="sort_recent">Recent</string>
     <string name="sort_liked">Liked</string>
+    <string name="sort_genre">Genre</string>
+
+    <!-- Search -->
+    <string name="search_stations">Search stations</string>
+
+    <!-- Genre filter -->
+    <string name="genre_all">All Genres</string>
+    <string name="filter_by_genre">Filter by Genre</string>
 </resources>


### PR DESCRIPTION
…ions

- Move playback controls (record/play/pause/volume) below stream info
- Move buffer bar with playback time to bottom of Now Playing screen
- Update both portrait and landscape layouts for consistency
- Add search bar to filter stations by name or genre
- Add genre filter dropdown with expanded genre list (32 genres)
- Search works within the current genre filter context
- Sort by genre option added (alphabetical by genre, then by name)
- Persist genre filter preference across sessions
- Add ic_search and ic_filter drawable icons