### PR TITLE
Improve recording button style and buffer bar accuracy

### DIFF
--- a/app/src/main/java/com/opensource/i2pradio/RadioService.kt
+++ b/app/src/main/java/com/opensource/i2pradio/RadioService.kt
@@ -182,6 +182,7 @@ class RadioService : Service() {
         const val BROADCAST_PLAYBACK_TIME_UPDATE = "com.opensource.i2pradio.PLAYBACK_TIME_UPDATE"
         const val EXTRA_PLAYBACK_ELAPSED_MS = "playback_elapsed_ms"
         const val EXTRA_BUFFERED_POSITION_MS = "buffered_position_ms"
+        const val EXTRA_CURRENT_POSITION_MS = "current_position_ms"
     }
 
     inner class RadioBinder : Binder() {
@@ -1488,10 +1489,12 @@ class RadioService : Service() {
         } else 0L
 
         val bufferedPositionMs = player?.bufferedPosition ?: 0L
+        val currentPositionMs = player?.currentPosition ?: 0L
 
         val intent = Intent(BROADCAST_PLAYBACK_TIME_UPDATE).apply {
             putExtra(EXTRA_PLAYBACK_ELAPSED_MS, elapsedMs)
             putExtra(EXTRA_BUFFERED_POSITION_MS, bufferedPositionMs)
+            putExtra(EXTRA_CURRENT_POSITION_MS, currentPositionMs)
         }
         LocalBroadcastManager.getInstance(this).sendBroadcast(intent)
     }

--- a/app/src/main/res/layout-land/fragment_now_playing.xml
+++ b/app/src/main/res/layout-land/fragment_now_playing.xml
@@ -47,12 +47,12 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
-    <!-- Recording Indicator - positioned below like button with breathing room -->
+    <!-- Recording Indicator - positioned directly below the like button -->
     <com.google.android.material.card.MaterialCardView
         android:id="@+id/recordingIndicator"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginTop="12dp"
+        android:layout_marginTop="4dp"
         android:visibility="gone"
         app:cardBackgroundColor="?attr/colorErrorContainer"
         app:cardCornerRadius="16dp"
@@ -211,7 +211,7 @@
             app:layout_constraintTop_toBottomOf="@id/nowPlayingInfoContainer"
             app:layout_constraintWidth_max="280dp">
 
-            <!-- Record Button (Left) - Tertiary container for consistency with volume -->
+            <!-- Record Button (Left) - Primary container for Material You consistency -->
             <com.google.android.material.floatingactionbutton.FloatingActionButton
                 android:id="@+id/recordButton"
                 android:layout_width="wrap_content"
@@ -222,8 +222,8 @@
                 app:fabSize="auto"
                 app:fabCustomSize="56dp"
                 app:maxImageSize="24dp"
-                app:tint="?attr/colorOnTertiaryContainer"
-                app:backgroundTint="?attr/colorTertiaryContainer"
+                app:tint="?attr/colorOnPrimaryContainer"
+                app:backgroundTint="?attr/colorPrimaryContainer"
                 app:shapeAppearanceOverlay="@style/ShapeAppearance.Material3.Corner.Full"
                 app:elevation="2dp"
                 app:layout_constraintBottom_toBottomOf="@id/playPauseButton"
@@ -248,7 +248,7 @@
                 app:layout_constraintStart_toEndOf="@id/recordButton"
                 app:layout_constraintTop_toTopOf="parent" />
 
-            <!-- Volume Button (Right) - Tertiary container for consistency with record -->
+            <!-- Volume Button (Right) - Primary container for Material You consistency -->
             <com.google.android.material.floatingactionbutton.FloatingActionButton
                 android:id="@+id/volumeButton"
                 android:layout_width="wrap_content"
@@ -259,8 +259,8 @@
                 app:fabSize="auto"
                 app:fabCustomSize="56dp"
                 app:maxImageSize="24dp"
-                app:backgroundTint="?attr/colorTertiaryContainer"
-                app:tint="?attr/colorOnTertiaryContainer"
+                app:backgroundTint="?attr/colorPrimaryContainer"
+                app:tint="?attr/colorOnPrimaryContainer"
                 app:shapeAppearanceOverlay="@style/ShapeAppearance.Material3.Corner.Full"
                 app:elevation="2dp"
                 app:layout_constraintBottom_toBottomOf="@id/playPauseButton"

--- a/app/src/main/res/layout/fragment_now_playing.xml
+++ b/app/src/main/res/layout/fragment_now_playing.xml
@@ -165,7 +165,7 @@
         app:layout_constraintTop_toBottomOf="@id/nowPlayingInfoContainer"
         app:layout_constraintWidth_max="320dp">
 
-        <!-- Record Button (Left) - Tertiary container for consistency with volume -->
+        <!-- Record Button (Left) - Primary container for Material You consistency -->
         <com.google.android.material.floatingactionbutton.FloatingActionButton
             android:id="@+id/recordButton"
             android:layout_width="wrap_content"
@@ -176,8 +176,8 @@
             app:fabSize="auto"
             app:fabCustomSize="64dp"
             app:maxImageSize="28dp"
-            app:tint="?attr/colorOnTertiaryContainer"
-            app:backgroundTint="?attr/colorTertiaryContainer"
+            app:tint="?attr/colorOnPrimaryContainer"
+            app:backgroundTint="?attr/colorPrimaryContainer"
             app:shapeAppearanceOverlay="@style/ShapeAppearance.Material3.Corner.Full"
             app:elevation="2dp"
             app:layout_constraintBottom_toBottomOf="@id/playPauseButton"
@@ -202,7 +202,7 @@
             app:layout_constraintStart_toEndOf="@id/recordButton"
             app:layout_constraintTop_toTopOf="parent" />
 
-        <!-- Volume Button (Right) - Tertiary container for consistency with record -->
+        <!-- Volume Button (Right) - Primary container for Material You consistency -->
         <com.google.android.material.floatingactionbutton.FloatingActionButton
             android:id="@+id/volumeButton"
             android:layout_width="wrap_content"
@@ -213,8 +213,8 @@
             app:fabSize="auto"
             app:fabCustomSize="64dp"
             app:maxImageSize="28dp"
-            app:backgroundTint="?attr/colorTertiaryContainer"
-            app:tint="?attr/colorOnTertiaryContainer"
+            app:backgroundTint="?attr/colorPrimaryContainer"
+            app:tint="?attr/colorOnPrimaryContainer"
             app:shapeAppearanceOverlay="@style/ShapeAppearance.Material3.Corner.Full"
             app:elevation="2dp"
             app:layout_constraintBottom_toBottomOf="@id/playPauseButton"
@@ -291,12 +291,12 @@
 
     </LinearLayout>
 
-    <!-- Recording Indicator - positioned below the like button with breathing room -->
+    <!-- Recording Indicator - positioned directly below the like button -->
     <com.google.android.material.card.MaterialCardView
         android:id="@+id/recordingIndicator"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginTop="12dp"
+        android:layout_marginTop="4dp"
         android:visibility="gone"
         app:cardBackgroundColor="?attr/colorErrorContainer"
         app:cardCornerRadius="16dp"


### PR DESCRIPTION
- Remove bouncing/pulse animation from recording button
- Update record and volume button colors to use primary container (matching play/pause button) for Material You consistency
- Move recording status indicator closer to like button (4dp margin)
- Fix buffer bar to show real ExoPlayer buffer health instead of fake animation loop (shows actual buffered seconds as percentage)