### PR TITLE
Add Force Tor settings and improve recording indicator layout

### DIFF
--- a/app/src/main/java/com/opensource/i2pradio/I2PRadioApplication.kt
+++ b/app/src/main/java/com/opensource/i2pradio/I2PRadioApplication.kt
@@ -1,11 +1,26 @@
 package com.opensource.i2pradio
 
 import android.app.Application
+import com.opensource.i2pradio.tor.TorManager
+import com.opensource.i2pradio.tor.TorService
+import com.opensource.i2pradio.ui.PreferencesHelper
 
 class I2PRadioApplication : Application() {
     override fun onCreate() {
         super.onCreate()
         // Dynamic colors are now applied at Activity level in MainActivity
         // to allow toggling Material You on/off without requiring app restart
+
+        // Initialize TorManager early if Tor is enabled
+        // This ensures Force Tor settings work immediately on app launch
+        if (PreferencesHelper.isEmbeddedTorEnabled(this)) {
+            TorManager.initialize(this)
+            // Auto-start Tor if enabled and not already connected
+            if (PreferencesHelper.isAutoStartTorEnabled(this) &&
+                TorManager.state != TorManager.TorState.CONNECTED &&
+                TorManager.state != TorManager.TorState.STARTING) {
+                TorService.start(this)
+            }
+        }
     }
 }

--- a/app/src/main/java/com/opensource/i2pradio/ui/PreferenceHelper.kt
+++ b/app/src/main/java/com/opensource/i2pradio/ui/PreferenceHelper.kt
@@ -19,6 +19,8 @@ object PreferencesHelper {
     private const val KEY_VIRTUALIZER_STRENGTH = "virtualizer_strength"
     private const val KEY_RECORDING_DIRECTORY_URI = "recording_directory_uri"
     private const val KEY_GENRE_FILTER = "genre_filter"
+    private const val KEY_FORCE_TOR_ALL = "force_tor_all"
+    private const val KEY_FORCE_TOR_EXCEPT_I2P = "force_tor_except_i2p"
 
     fun saveThemeMode(context: Context, mode: Int) {
         context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
@@ -195,5 +197,51 @@ object PreferencesHelper {
     fun getGenreFilter(context: Context): String? {
         return context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
             .getString(KEY_GENRE_FILTER, null)
+    }
+
+    // Force Tor settings - bulletproof mode for maximum privacy
+    // These are mutually exclusive: only one can be enabled at a time
+
+    /**
+     * Force ALL traffic through Tor - no exceptions, no leaks.
+     * When enabled, all network traffic goes through Tor SOCKS proxy.
+     * If Tor is not connected, network requests will FAIL (no fallback to clearnet).
+     */
+    fun setForceTorAll(context: Context, enabled: Boolean) {
+        context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+            .edit()
+            .putBoolean(KEY_FORCE_TOR_ALL, enabled)
+            .apply()
+        // If enabling this, disable the other option (mutual exclusivity)
+        if (enabled) {
+            setForceTorExceptI2P(context, false)
+        }
+    }
+
+    fun isForceTorAll(context: Context): Boolean {
+        return context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+            .getBoolean(KEY_FORCE_TOR_ALL, false)
+    }
+
+    /**
+     * Force ALL traffic through Tor EXCEPT I2P traffic.
+     * I2P traffic uses the I2P HTTP proxy directly.
+     * All other traffic (clearnet) goes through Tor SOCKS proxy.
+     * If Tor is not connected, non-I2P requests will FAIL (no fallback).
+     */
+    fun setForceTorExceptI2P(context: Context, enabled: Boolean) {
+        context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+            .edit()
+            .putBoolean(KEY_FORCE_TOR_EXCEPT_I2P, enabled)
+            .apply()
+        // If enabling this, disable the other option (mutual exclusivity)
+        if (enabled) {
+            setForceTorAll(context, false)
+        }
+    }
+
+    fun isForceTorExceptI2P(context: Context): Boolean {
+        return context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+            .getBoolean(KEY_FORCE_TOR_EXCEPT_I2P, false)
     }
 }

--- a/app/src/main/res/layout-land/fragment_now_playing.xml
+++ b/app/src/main/res/layout-land/fragment_now_playing.xml
@@ -47,19 +47,20 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
-    <!-- Recording Indicator - positioned directly below the like button -->
+    <!-- Recording Indicator - positioned on toolbar row, left of like button -->
     <com.google.android.material.card.MaterialCardView
         android:id="@+id/recordingIndicator"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginTop="4dp"
+        android:layout_marginEnd="8dp"
         android:visibility="gone"
         app:cardBackgroundColor="?attr/colorErrorContainer"
         app:cardCornerRadius="16dp"
         app:cardElevation="2dp"
         app:strokeWidth="0dp"
-        app:layout_constraintTop_toBottomOf="@id/likeButton"
-        app:layout_constraintEnd_toEndOf="parent">
+        app:layout_constraintTop_toTopOf="@id/likeButton"
+        app:layout_constraintEnd_toStartOf="@id/likeButton"
+        app:layout_constraintBottom_toBottomOf="@id/likeButton">
 
         <LinearLayout
             android:layout_width="wrap_content"

--- a/app/src/main/res/layout/fragment_now_playing.xml
+++ b/app/src/main/res/layout/fragment_now_playing.xml
@@ -291,19 +291,21 @@
 
     </LinearLayout>
 
-    <!-- Recording Indicator - positioned directly below the like button -->
+    <!-- Recording Indicator - positioned on toolbar row, left of like button -->
     <com.google.android.material.card.MaterialCardView
         android:id="@+id/recordingIndicator"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginTop="4dp"
+        android:layout_marginTop="8dp"
+        android:layout_marginEnd="8dp"
         android:visibility="gone"
         app:cardBackgroundColor="?attr/colorErrorContainer"
         app:cardCornerRadius="16dp"
         app:cardElevation="2dp"
         app:strokeWidth="0dp"
-        app:layout_constraintTop_toBottomOf="@id/likeButton"
-        app:layout_constraintEnd_toEndOf="parent">
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintEnd_toStartOf="@id/likeButton"
+        app:layout_constraintBottom_toBottomOf="@id/likeButton">
 
         <LinearLayout
             android:layout_width="wrap_content"

--- a/app/src/main/res/layout/fragment_settings.xml
+++ b/app/src/main/res/layout/fragment_settings.xml
@@ -260,12 +260,94 @@
 
                 </LinearLayout>
 
+                <!-- Force Tor Over Everything -->
+                <LinearLayout
+                    android:id="@+id/forceTorAllContainer"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="horizontal"
+                    android:gravity="center_vertical"
+                    android:paddingVertical="8dp"
+                    android:layout_marginTop="16dp"
+                    android:background="?attr/selectableItemBackground">
+
+                    <LinearLayout
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:orientation="vertical">
+
+                        <TextView
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="Force Tor Over Everything"
+                            android:textSize="16sp"
+                            android:textStyle="bold"
+                            android:textColor="?attr/colorError" />
+
+                        <TextView
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="BULLETPROOF: ALL traffic through Tor. Zero leaks. Fails if Tor disconnected."
+                            android:textSize="12sp"
+                            android:textColor="?attr/colorOnSurfaceVariant" />
+
+                    </LinearLayout>
+
+                    <com.google.android.material.materialswitch.MaterialSwitch
+                        android:id="@+id/forceTorAllSwitch"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content" />
+
+                </LinearLayout>
+
+                <!-- Force Tor Except I2P -->
+                <LinearLayout
+                    android:id="@+id/forceTorExceptI2pContainer"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="horizontal"
+                    android:gravity="center_vertical"
+                    android:paddingVertical="8dp"
+                    android:layout_marginTop="8dp"
+                    android:background="?attr/selectableItemBackground">
+
+                    <LinearLayout
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:orientation="vertical">
+
+                        <TextView
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="Force Tor Except I2P"
+                            android:textSize="16sp"
+                            android:textStyle="bold"
+                            android:textColor="?attr/colorError" />
+
+                        <TextView
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="All traffic via Tor EXCEPT I2P streams (use I2P proxy directly). Zero clearnet leaks."
+                            android:textSize="12sp"
+                            android:textColor="?attr/colorOnSurfaceVariant" />
+
+                    </LinearLayout>
+
+                    <com.google.android.material.materialswitch.MaterialSwitch
+                        android:id="@+id/forceTorExceptI2pSwitch"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content" />
+
+                </LinearLayout>
+
                 <!-- Tor Info -->
                 <TextView
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:layout_marginTop="8dp"
-                    android:text="Requires Orbot (free from Play Store or F-Droid). Tap the Tor icon in the toolbar for quick access to connection controls."
+                    android:layout_marginTop="16dp"
+                    android:text="Requires Orbot (free from Play Store or F-Droid). Tap the Tor icon in the toolbar for quick access to connection controls.\n\n⚠️ Force Tor modes are STRICT: if Tor is disconnected, streams will fail rather than leak to clearnet."
                     android:textSize="12sp"
                     android:textColor="?attr/colorOnSurfaceVariant"
                     android:lineSpacingExtra="2dp" />


### PR DESCRIPTION
- Move recording indicator to toolbar row (left of like button) for better spacing
- Add "Force Tor Over Everything" setting - bulletproof, zero leaks mode
- Add "Force Tor Except I2P" setting - routes all traffic through Tor except I2P
- Both Force Tor settings are mutually exclusive toggles
- Implement Force Tor enforcement in RadioService playStream and recording
- Streams are BLOCKED (not leaked to clearnet) if Tor is disconnected when Force Tor is enabled
- Initialize TorManager early in Application class for immediate Force Tor support
- Fix Tor initialization bug when app restarts with Tor already enabled