### PR TITLE
Fix Tor image loading leak and add station import/export

### DIFF
--- a/app/src/main/java/com/opensource/i2pradio/I2PRadioApplication.kt
+++ b/app/src/main/java/com/opensource/i2pradio/I2PRadioApplication.kt
@@ -4,8 +4,16 @@ import android.app.Application
 import com.opensource.i2pradio.tor.TorManager
 import com.opensource.i2pradio.tor.TorService
 import com.opensource.i2pradio.ui.PreferencesHelper
+import com.opensource.i2pradio.util.SecureImageLoader
 
 class I2PRadioApplication : Application() {
+
+    private val torStateListener: (TorManager.TorState) -> Unit = { _ ->
+        // Invalidate image loader cache when Tor state changes
+        // This ensures images use the correct proxy settings
+        SecureImageLoader.invalidateCache()
+    }
+
     override fun onCreate() {
         super.onCreate()
         // Dynamic colors are now applied at Activity level in MainActivity
@@ -15,6 +23,8 @@ class I2PRadioApplication : Application() {
         // This ensures Force Tor settings work immediately on app launch
         if (PreferencesHelper.isEmbeddedTorEnabled(this)) {
             TorManager.initialize(this)
+            // Add listener to invalidate image loader when Tor state changes
+            TorManager.addStateListener(torStateListener)
             // Auto-start Tor if enabled and not already connected
             if (PreferencesHelper.isAutoStartTorEnabled(this) &&
                 TorManager.state != TorManager.TorState.CONNECTED &&

--- a/app/src/main/java/com/opensource/i2pradio/RadioService.kt
+++ b/app/src/main/java/com/opensource/i2pradio/RadioService.kt
@@ -32,7 +32,6 @@ import androidx.media3.exoplayer.DefaultLoadControl
 import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.exoplayer.source.ProgressiveMediaSource
 import androidx.media3.extractor.metadata.icy.IcyInfo
-import coil.ImageLoader
 import coil.request.ImageRequest
 import coil.request.SuccessResult
 import kotlinx.coroutines.CoroutineScope
@@ -42,6 +41,7 @@ import okhttp3.OkHttpClient
 import com.opensource.i2pradio.data.ProxyType
 import com.opensource.i2pradio.tor.TorManager
 import com.opensource.i2pradio.ui.PreferencesHelper
+import com.opensource.i2pradio.util.SecureImageLoader
 import okhttp3.Call
 import okhttp3.Request
 import okhttp3.Response
@@ -267,13 +267,14 @@ class RadioService : Service() {
         if (!coverArtUri.isNullOrEmpty()) {
             CoroutineScope(Dispatchers.IO).launch {
                 try {
-                    val imageLoader = ImageLoader(this@RadioService)
+                    // Use SecureImageLoader to route remote URLs through Tor when Force Tor is enabled
+                    // Local content URIs (file://, content://) bypass the proxy automatically
                     val request = ImageRequest.Builder(this@RadioService)
                         .data(coverArtUri)
                         .allowHardware(false)
                         .build()
 
-                    val result = imageLoader.execute(request)
+                    val result = SecureImageLoader.execute(this@RadioService, request)
                     if (result is SuccessResult) {
                         val bitmap = (result.drawable as? BitmapDrawable)?.bitmap
                         if (bitmap != null) {

--- a/app/src/main/java/com/opensource/i2pradio/ui/AddEditRadioDialog.kt
+++ b/app/src/main/java/com/opensource/i2pradio/ui/AddEditRadioDialog.kt
@@ -11,6 +11,7 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AlertDialog
 import androidx.fragment.app.DialogFragment
 import coil.load
+import com.opensource.i2pradio.util.loadSecure
 import com.google.android.material.button.MaterialButton
 import com.google.android.material.card.MaterialCardView
 import com.google.android.material.textfield.TextInputEditText
@@ -233,7 +234,9 @@ class AddEditRadioDialog : DialogFragment() {
     }
 
     private fun updateImagePreview(uri: String) {
-        coverArtPreview?.load(uri) {
+        // Use loadSecure to route remote URLs through Tor when Force Tor is enabled
+        // Local content URIs (file://, content://) bypass the proxy automatically
+        coverArtPreview?.loadSecure(uri) {
             crossfade(true)
             error(R.drawable.ic_radio)
         }

--- a/app/src/main/java/com/opensource/i2pradio/ui/MiniPlayerView.kt
+++ b/app/src/main/java/com/opensource/i2pradio/ui/MiniPlayerView.kt
@@ -13,6 +13,7 @@ import android.widget.TextView
 import androidx.core.content.ContextCompat
 import coil.load
 import coil.request.CachePolicy
+import com.opensource.i2pradio.util.loadSecure
 import com.google.android.material.button.MaterialButton
 import com.google.android.material.card.MaterialCardView
 import com.google.android.material.progressindicator.LinearProgressIndicator
@@ -109,10 +110,11 @@ class MiniPlayerView @JvmOverloads constructor(
 
     /**
      * Update cover art with cache invalidation for real-time updates.
+     * Uses loadSecure to route remote URLs through Tor when Force Tor is enabled.
      */
     fun updateCoverArt(coverArtUri: String?) {
         if (coverArtUri != null) {
-            coverImage.load(coverArtUri) {
+            coverImage.loadSecure(coverArtUri) {
                 crossfade(true)
                 // Force refresh by disabling cache for this request
                 memoryCachePolicy(CachePolicy.WRITE_ONLY)
@@ -175,8 +177,9 @@ class MiniPlayerView @JvmOverloads constructor(
         updateLikeState(station.isLiked)
 
         // Handle cover art update properly - clear old image when switching stations
+        // Use loadSecure to route remote URLs through Tor when Force Tor is enabled
         if (station.coverArtUri != null) {
-            coverImage.load(station.coverArtUri) {
+            coverImage.loadSecure(station.coverArtUri) {
                 crossfade(true)
                 placeholder(R.drawable.ic_radio)
                 error(R.drawable.ic_radio)

--- a/app/src/main/java/com/opensource/i2pradio/ui/NowPlayingFragment.kt
+++ b/app/src/main/java/com/opensource/i2pradio/ui/NowPlayingFragment.kt
@@ -36,6 +36,7 @@ import androidx.fragment.app.activityViewModels
 import androidx.localbroadcastmanager.content.LocalBroadcastManager
 import coil.load
 import coil.request.CachePolicy
+import com.opensource.i2pradio.util.loadSecure
 import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.google.android.material.button.MaterialButton
 import com.google.android.material.card.MaterialCardView
@@ -388,8 +389,9 @@ class NowPlayingFragment : Fragment() {
                 }
 
                 // Handle cover art update properly - switch scaleType based on content
+                // Use loadSecure to route remote URLs through Tor when Force Tor is enabled
                 if (station.coverArtUri != null) {
-                    coverArt.load(station.coverArtUri) {
+                    coverArt.loadSecure(station.coverArtUri) {
                         crossfade(true)
                         memoryCachePolicy(CachePolicy.ENABLED)
                         placeholder(R.drawable.ic_radio)
@@ -817,10 +819,11 @@ class NowPlayingFragment : Fragment() {
 
     /**
      * Update the cover art image with cache invalidation for real-time updates.
+     * Uses loadSecure to route remote URLs through Tor when Force Tor is enabled.
      */
     private fun updateCoverArt(coverArtUri: String?) {
         if (coverArtUri != null) {
-            coverArt.load(coverArtUri) {
+            coverArt.loadSecure(coverArtUri) {
                 crossfade(true)
                 // Force refresh by disabling cache for this request
                 memoryCachePolicy(coil.request.CachePolicy.WRITE_ONLY)

--- a/app/src/main/java/com/opensource/i2pradio/ui/RadiosFragment.kt
+++ b/app/src/main/java/com/opensource/i2pradio/ui/RadiosFragment.kt
@@ -20,8 +20,8 @@ import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.LiveData
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.RecyclerView
-import coil.load
 import coil.request.Disposable
+import com.opensource.i2pradio.util.loadSecure
 import com.google.android.material.button.MaterialButton
 import com.google.android.material.floatingactionbutton.FloatingActionButton
 import com.google.android.material.textfield.TextInputEditText
@@ -393,8 +393,9 @@ class RadioStationAdapter(
             imageLoadDisposable?.dispose()
             coverArt.setImageResource(R.drawable.ic_radio)
 
+            // Use loadSecure to route remote URLs through Tor when Force Tor is enabled
             if (station.coverArtUri != null) {
-                imageLoadDisposable = coverArt.load(station.coverArtUri) {
+                imageLoadDisposable = coverArt.loadSecure(station.coverArtUri) {
                     crossfade(true)
                     placeholder(R.drawable.ic_radio)
                     error(R.drawable.ic_radio)

--- a/app/src/main/java/com/opensource/i2pradio/util/SecureImageLoader.kt
+++ b/app/src/main/java/com/opensource/i2pradio/util/SecureImageLoader.kt
@@ -1,0 +1,142 @@
+package com.opensource.i2pradio.util
+
+import android.content.Context
+import android.widget.ImageView
+import coil.ImageLoader
+import coil.load
+import coil.request.Disposable
+import coil.request.ImageRequest
+import coil.request.ImageResult
+import com.opensource.i2pradio.tor.TorManager
+import com.opensource.i2pradio.ui.PreferencesHelper
+import okhttp3.OkHttpClient
+import java.net.InetSocketAddress
+import java.net.Proxy
+
+/**
+ * Secure image loading utility that routes HTTP/HTTPS requests through Tor
+ * when Force Tor settings are enabled.
+ *
+ * Local content (file://, content://) is loaded directly without proxy.
+ * Remote URLs (http://, https://) are routed through Tor proxy when configured.
+ */
+object SecureImageLoader {
+
+    private var cachedImageLoader: ImageLoader? = null
+    private var cachedProxyConfig: ProxyConfig? = null
+
+    private data class ProxyConfig(
+        val useTor: Boolean,
+        val host: String,
+        val port: Int
+    )
+
+    /**
+     * Get an ImageLoader configured based on current Tor settings.
+     * Local content URIs bypass the proxy; remote URLs use Tor when enabled.
+     */
+    fun getImageLoader(context: Context): ImageLoader {
+        val currentConfig = getCurrentProxyConfig(context)
+
+        // Return cached loader if config hasn't changed
+        if (cachedImageLoader != null && cachedProxyConfig == currentConfig) {
+            return cachedImageLoader!!
+        }
+
+        // Build new loader with current config
+        val loader = buildImageLoader(context, currentConfig)
+        cachedImageLoader = loader
+        cachedProxyConfig = currentConfig
+
+        return loader
+    }
+
+    /**
+     * Execute an image request with proxy-aware loading.
+     * Automatically determines if proxy should be used based on URI scheme.
+     */
+    suspend fun execute(context: Context, request: ImageRequest): ImageResult {
+        val loader = getImageLoader(context)
+        return loader.execute(request)
+    }
+
+    /**
+     * Check if a URI should be loaded through proxy.
+     * Local content (file://, content://) should bypass proxy.
+     */
+    fun shouldUseProxy(uri: String?): Boolean {
+        if (uri.isNullOrEmpty()) return false
+        val lowerUri = uri.lowercase()
+        return lowerUri.startsWith("http://") || lowerUri.startsWith("https://")
+    }
+
+    /**
+     * Invalidate cached loader to force rebuild on next request.
+     * Call this when Tor settings change.
+     */
+    fun invalidateCache() {
+        cachedImageLoader = null
+        cachedProxyConfig = null
+    }
+
+    private fun getCurrentProxyConfig(context: Context): ProxyConfig {
+        val torEnabled = PreferencesHelper.isEmbeddedTorEnabled(context)
+        val forceTorAll = PreferencesHelper.isForceTorAll(context)
+        val forceTorExceptI2p = PreferencesHelper.isForceTorExceptI2P(context)
+        val torConnected = TorManager.isConnected()
+
+        // Use Tor proxy if:
+        // 1. Tor is enabled AND connected
+        // 2. AND either Force Tor All or Force Tor Except I2P is enabled
+        val useTor = torEnabled && torConnected && (forceTorAll || forceTorExceptI2p)
+
+        return ProxyConfig(
+            useTor = useTor,
+            host = if (useTor) TorManager.socksHost else "",
+            port = if (useTor) TorManager.socksPort else 0
+        )
+    }
+
+    private fun buildImageLoader(context: Context, config: ProxyConfig): ImageLoader {
+        val builder = ImageLoader.Builder(context)
+
+        if (config.useTor && config.host.isNotEmpty() && config.port > 0) {
+            // Build OkHttpClient with SOCKS proxy for Tor
+            val proxy = Proxy(
+                Proxy.Type.SOCKS,
+                InetSocketAddress(config.host, config.port)
+            )
+
+            val okHttpClient = OkHttpClient.Builder()
+                .proxy(proxy)
+                .build()
+
+            builder.okHttpClient(okHttpClient)
+
+            android.util.Log.d("SecureImageLoader",
+                "Created image loader with Tor proxy: ${config.host}:${config.port}")
+        } else {
+            android.util.Log.d("SecureImageLoader",
+                "Created image loader without proxy (Tor not active or not required)")
+        }
+
+        return builder.build()
+    }
+}
+
+/**
+ * Extension function to load images securely through Tor when enabled.
+ * Uses SecureImageLoader for remote URLs (http/https).
+ * Local content URIs (file://, content://) and drawable resources bypass proxy.
+ *
+ * @param data The image source (URL string, Uri, DrawableRes, etc.)
+ * @param builder Optional builder to customize the image request
+ * @return Disposable to cancel the request if needed
+ */
+fun ImageView.loadSecure(
+    data: Any?,
+    builder: ImageRequest.Builder.() -> Unit = {}
+): Disposable {
+    val imageLoader = SecureImageLoader.getImageLoader(context)
+    return this.load(data, imageLoader, builder)
+}

--- a/app/src/main/java/com/opensource/i2pradio/util/StationImportExport.kt
+++ b/app/src/main/java/com/opensource/i2pradio/util/StationImportExport.kt
@@ -1,0 +1,595 @@
+package com.opensource.i2pradio.util
+
+import android.content.Context
+import android.net.Uri
+import com.opensource.i2pradio.data.ProxyType
+import com.opensource.i2pradio.data.RadioStation
+import org.json.JSONArray
+import org.json.JSONObject
+import java.io.BufferedReader
+import java.io.InputStreamReader
+import java.io.OutputStream
+
+/**
+ * Utility class for importing and exporting radio stations in various formats.
+ * Supports CSV, JSON, M3U, and PLS formats.
+ */
+object StationImportExport {
+
+    /**
+     * Supported file formats for import/export
+     */
+    enum class FileFormat(val extension: String, val mimeType: String, val displayName: String) {
+        CSV("csv", "text/csv", "CSV"),
+        JSON("json", "application/json", "JSON"),
+        M3U("m3u", "audio/x-mpegurl", "M3U Playlist"),
+        PLS("pls", "audio/x-scpls", "PLS Playlist")
+    }
+
+    /**
+     * Result of an import operation
+     */
+    data class ImportResult(
+        val stations: List<RadioStation>,
+        val errors: List<String>,
+        val format: FileFormat?
+    )
+
+    // ==================== EXPORT FUNCTIONS ====================
+
+    /**
+     * Export stations to CSV format
+     */
+    fun exportToCsv(stations: List<RadioStation>, outputStream: OutputStream) {
+        outputStream.bufferedWriter().use { writer ->
+            // Header row
+            writer.write("name,url,proxyType,proxyHost,proxyPort,genre,coverArtUri,isLiked\n")
+
+            for (station in stations) {
+                val proxyType = if (station.useProxy) station.proxyType else "NONE"
+                val line = listOf(
+                    escapeCsvField(station.name),
+                    escapeCsvField(station.streamUrl),
+                    proxyType,
+                    escapeCsvField(station.proxyHost),
+                    station.proxyPort.toString(),
+                    escapeCsvField(station.genre),
+                    escapeCsvField(station.coverArtUri ?: ""),
+                    if (station.isLiked) "true" else "false"
+                ).joinToString(",")
+                writer.write("$line\n")
+            }
+        }
+    }
+
+    /**
+     * Export stations to JSON format
+     */
+    fun exportToJson(stations: List<RadioStation>, outputStream: OutputStream) {
+        val jsonArray = JSONArray()
+
+        for (station in stations) {
+            val jsonObj = JSONObject().apply {
+                put("name", station.name)
+                put("streamUrl", station.streamUrl)
+                put("proxyType", if (station.useProxy) station.proxyType else "NONE")
+                put("proxyHost", station.proxyHost)
+                put("proxyPort", station.proxyPort)
+                put("genre", station.genre)
+                put("coverArtUri", station.coverArtUri ?: JSONObject.NULL)
+                put("isLiked", station.isLiked)
+            }
+            jsonArray.put(jsonObj)
+        }
+
+        val rootObj = JSONObject().apply {
+            put("version", 1)
+            put("app", "I2P Radio")
+            put("stations", jsonArray)
+        }
+
+        outputStream.bufferedWriter().use { writer ->
+            writer.write(rootObj.toString(2))
+        }
+    }
+
+    /**
+     * Export stations to M3U format
+     */
+    fun exportToM3u(stations: List<RadioStation>, outputStream: OutputStream) {
+        outputStream.bufferedWriter().use { writer ->
+            writer.write("#EXTM3U\n")
+            writer.write("# I2P Radio Station Export\n\n")
+
+            for (station in stations) {
+                // Extended M3U info: #EXTINF:duration,title
+                // For streams, duration is -1 (unknown/live)
+                val proxyInfo = if (station.useProxy) {
+                    when (ProxyType.fromString(station.proxyType)) {
+                        ProxyType.I2P -> " [I2P]"
+                        ProxyType.TOR -> " [Tor]"
+                        ProxyType.NONE -> ""
+                    }
+                } else ""
+
+                writer.write("#EXTINF:-1,${station.name}$proxyInfo\n")
+
+                // Add custom attributes as comments for import compatibility
+                writer.write("#I2PRADIO:genre=${station.genre}\n")
+                if (station.useProxy) {
+                    writer.write("#I2PRADIO:proxyType=${station.proxyType}\n")
+                    writer.write("#I2PRADIO:proxyHost=${station.proxyHost}\n")
+                    writer.write("#I2PRADIO:proxyPort=${station.proxyPort}\n")
+                }
+                if (!station.coverArtUri.isNullOrEmpty()) {
+                    writer.write("#I2PRADIO:coverArt=${station.coverArtUri}\n")
+                }
+                if (station.isLiked) {
+                    writer.write("#I2PRADIO:liked=true\n")
+                }
+
+                writer.write("${station.streamUrl}\n\n")
+            }
+        }
+    }
+
+    /**
+     * Export stations to PLS format
+     */
+    fun exportToPls(stations: List<RadioStation>, outputStream: OutputStream) {
+        outputStream.bufferedWriter().use { writer ->
+            writer.write("[playlist]\n")
+            writer.write("NumberOfEntries=${stations.size}\n\n")
+
+            stations.forEachIndexed { index, station ->
+                val num = index + 1
+                writer.write("File$num=${station.streamUrl}\n")
+
+                val proxyInfo = if (station.useProxy) {
+                    when (ProxyType.fromString(station.proxyType)) {
+                        ProxyType.I2P -> " [I2P]"
+                        ProxyType.TOR -> " [Tor]"
+                        ProxyType.NONE -> ""
+                    }
+                } else ""
+                writer.write("Title$num=${station.name}$proxyInfo\n")
+                writer.write("Length$num=-1\n")
+
+                // Add custom attributes as comments
+                writer.write("; I2PRADIO:genre=${station.genre}\n")
+                if (station.useProxy) {
+                    writer.write("; I2PRADIO:proxyType=${station.proxyType}\n")
+                    writer.write("; I2PRADIO:proxyHost=${station.proxyHost}\n")
+                    writer.write("; I2PRADIO:proxyPort=${station.proxyPort}\n")
+                }
+                if (!station.coverArtUri.isNullOrEmpty()) {
+                    writer.write("; I2PRADIO:coverArt=${station.coverArtUri}\n")
+                }
+                if (station.isLiked) {
+                    writer.write("; I2PRADIO:liked=true\n")
+                }
+                writer.write("\n")
+            }
+
+            writer.write("Version=2\n")
+        }
+    }
+
+    // ==================== IMPORT FUNCTIONS ====================
+
+    /**
+     * Import stations from a file, auto-detecting format
+     */
+    fun importFromUri(context: Context, uri: Uri): ImportResult {
+        val errors = mutableListOf<String>()
+
+        // Try to detect format from content
+        val content = try {
+            context.contentResolver.openInputStream(uri)?.use { inputStream ->
+                BufferedReader(InputStreamReader(inputStream)).readText()
+            } ?: return ImportResult(emptyList(), listOf("Could not open file"), null)
+        } catch (e: Exception) {
+            return ImportResult(emptyList(), listOf("Error reading file: ${e.message}"), null)
+        }
+
+        // Detect format
+        val format = detectFormat(content, uri.toString())
+
+        return when (format) {
+            FileFormat.CSV -> importFromCsv(content, errors)
+            FileFormat.JSON -> importFromJson(content, errors)
+            FileFormat.M3U -> importFromM3u(content, errors)
+            FileFormat.PLS -> importFromPls(content, errors)
+            null -> ImportResult(emptyList(), listOf("Unknown file format"), null)
+        }
+    }
+
+    /**
+     * Detect file format from content
+     */
+    private fun detectFormat(content: String, filename: String): FileFormat? {
+        val lowerFilename = filename.lowercase()
+        val trimmedContent = content.trim()
+
+        // Check by file extension first
+        when {
+            lowerFilename.endsWith(".csv") -> return FileFormat.CSV
+            lowerFilename.endsWith(".json") -> return FileFormat.JSON
+            lowerFilename.endsWith(".m3u") || lowerFilename.endsWith(".m3u8") -> return FileFormat.M3U
+            lowerFilename.endsWith(".pls") -> return FileFormat.PLS
+        }
+
+        // Detect by content
+        return when {
+            trimmedContent.startsWith("{") || trimmedContent.startsWith("[") -> FileFormat.JSON
+            trimmedContent.startsWith("#EXTM3U") ||
+                (trimmedContent.contains("#EXTINF:") && trimmedContent.contains("http")) -> FileFormat.M3U
+            trimmedContent.startsWith("[playlist]", ignoreCase = true) -> FileFormat.PLS
+            trimmedContent.contains(",") &&
+                (trimmedContent.lowercase().contains("name,url") ||
+                 trimmedContent.lowercase().contains("name,stream")) -> FileFormat.CSV
+            else -> null
+        }
+    }
+
+    /**
+     * Import stations from CSV content
+     */
+    private fun importFromCsv(content: String, errors: MutableList<String>): ImportResult {
+        val stations = mutableListOf<RadioStation>()
+        val lines = content.lines().filter { it.isNotBlank() }
+
+        if (lines.isEmpty()) {
+            return ImportResult(emptyList(), listOf("Empty CSV file"), FileFormat.CSV)
+        }
+
+        // Parse header to get column indices
+        val header = parseCsvLine(lines[0])
+        val nameIdx = header.indexOfFirst { it.lowercase() in listOf("name", "title", "station") }
+        val urlIdx = header.indexOfFirst { it.lowercase() in listOf("url", "streamurl", "stream_url", "stream") }
+        val proxyTypeIdx = header.indexOfFirst { it.lowercase() in listOf("proxytype", "proxy_type", "proxy") }
+        val proxyHostIdx = header.indexOfFirst { it.lowercase() in listOf("proxyhost", "proxy_host") }
+        val proxyPortIdx = header.indexOfFirst { it.lowercase() in listOf("proxyport", "proxy_port") }
+        val genreIdx = header.indexOfFirst { it.lowercase() in listOf("genre", "category") }
+        val coverArtIdx = header.indexOfFirst { it.lowercase() in listOf("coverarturi", "cover_art", "coverart", "image") }
+        val likedIdx = header.indexOfFirst { it.lowercase() in listOf("isliked", "liked", "favorite") }
+
+        if (nameIdx == -1 || urlIdx == -1) {
+            errors.add("CSV must have 'name' and 'url' columns")
+            return ImportResult(emptyList(), errors, FileFormat.CSV)
+        }
+
+        // Parse data rows
+        for (i in 1 until lines.size) {
+            try {
+                val fields = parseCsvLine(lines[i])
+                if (fields.size <= maxOf(nameIdx, urlIdx)) {
+                    errors.add("Row $i: Not enough columns")
+                    continue
+                }
+
+                val name = fields.getOrNull(nameIdx)?.trim() ?: ""
+                val url = fields.getOrNull(urlIdx)?.trim() ?: ""
+
+                if (name.isEmpty() || url.isEmpty()) {
+                    errors.add("Row $i: Name or URL is empty")
+                    continue
+                }
+
+                val proxyTypeStr = fields.getOrNull(proxyTypeIdx)?.trim()?.uppercase() ?: "NONE"
+                val proxyType = ProxyType.fromString(proxyTypeStr)
+                val useProxy = proxyType != ProxyType.NONE
+
+                val station = RadioStation(
+                    name = name,
+                    streamUrl = url,
+                    proxyType = proxyType.name,
+                    proxyHost = fields.getOrNull(proxyHostIdx)?.trim() ?: proxyType.getDefaultHost(),
+                    proxyPort = fields.getOrNull(proxyPortIdx)?.toIntOrNull() ?: proxyType.getDefaultPort(),
+                    useProxy = useProxy,
+                    genre = fields.getOrNull(genreIdx)?.trim() ?: "Other",
+                    coverArtUri = fields.getOrNull(coverArtIdx)?.trim()?.takeIf { it.isNotEmpty() },
+                    isLiked = fields.getOrNull(likedIdx)?.trim()?.lowercase() in listOf("true", "1", "yes")
+                )
+
+                stations.add(station)
+            } catch (e: Exception) {
+                errors.add("Row $i: ${e.message}")
+            }
+        }
+
+        return ImportResult(stations, errors, FileFormat.CSV)
+    }
+
+    /**
+     * Import stations from JSON content
+     */
+    private fun importFromJson(content: String, errors: MutableList<String>): ImportResult {
+        val stations = mutableListOf<RadioStation>()
+
+        try {
+            val json = if (content.trim().startsWith("[")) {
+                JSONArray(content)
+            } else {
+                val rootObj = JSONObject(content)
+                rootObj.optJSONArray("stations") ?: JSONArray()
+            }
+
+            for (i in 0 until json.length()) {
+                try {
+                    val obj = json.getJSONObject(i)
+                    val name = obj.optString("name", "").takeIf { it.isNotEmpty() }
+                        ?: obj.optString("title", "")
+                    val url = obj.optString("streamUrl", "").takeIf { it.isNotEmpty() }
+                        ?: obj.optString("url", "").takeIf { it.isNotEmpty() }
+                        ?: obj.optString("stream", "")
+
+                    if (name.isEmpty() || url.isEmpty()) {
+                        errors.add("Entry $i: Missing name or URL")
+                        continue
+                    }
+
+                    val proxyTypeStr = obj.optString("proxyType", "NONE").uppercase()
+                    val proxyType = ProxyType.fromString(proxyTypeStr)
+                    val useProxy = proxyType != ProxyType.NONE
+
+                    val station = RadioStation(
+                        name = name,
+                        streamUrl = url,
+                        proxyType = proxyType.name,
+                        proxyHost = obj.optString("proxyHost", proxyType.getDefaultHost()),
+                        proxyPort = obj.optInt("proxyPort", proxyType.getDefaultPort()),
+                        useProxy = useProxy,
+                        genre = obj.optString("genre", "Other"),
+                        coverArtUri = obj.optString("coverArtUri", null)?.takeIf { it.isNotEmpty() && it != "null" },
+                        isLiked = obj.optBoolean("isLiked", false)
+                    )
+
+                    stations.add(station)
+                } catch (e: Exception) {
+                    errors.add("Entry $i: ${e.message}")
+                }
+            }
+        } catch (e: Exception) {
+            errors.add("Invalid JSON format: ${e.message}")
+        }
+
+        return ImportResult(stations, errors, FileFormat.JSON)
+    }
+
+    /**
+     * Import stations from M3U content
+     */
+    private fun importFromM3u(content: String, errors: MutableList<String>): ImportResult {
+        val stations = mutableListOf<RadioStation>()
+        val lines = content.lines()
+
+        var currentName: String? = null
+        var currentGenre = "Other"
+        var currentProxyType = ProxyType.NONE
+        var currentProxyHost = ""
+        var currentProxyPort = 0
+        var currentCoverArt: String? = null
+        var currentLiked = false
+
+        for (line in lines) {
+            val trimmed = line.trim()
+
+            when {
+                trimmed.startsWith("#EXTINF:") -> {
+                    // Parse: #EXTINF:duration,title [info]
+                    val info = trimmed.substringAfter(",").trim()
+                    // Remove proxy indicators from name
+                    currentName = info.replace(Regex("\\s*\\[(I2P|Tor)\\]\\s*$"), "").trim()
+
+                    // Detect proxy type from indicator
+                    when {
+                        info.contains("[I2P]") -> {
+                            currentProxyType = ProxyType.I2P
+                            currentProxyHost = ProxyType.I2P.getDefaultHost()
+                            currentProxyPort = ProxyType.I2P.getDefaultPort()
+                        }
+                        info.contains("[Tor]") -> {
+                            currentProxyType = ProxyType.TOR
+                            currentProxyHost = ProxyType.TOR.getDefaultHost()
+                            currentProxyPort = ProxyType.TOR.getDefaultPort()
+                        }
+                    }
+                }
+                trimmed.startsWith("#I2PRADIO:") -> {
+                    // Parse custom I2P Radio attributes
+                    val attr = trimmed.substringAfter("#I2PRADIO:")
+                    val (key, value) = attr.split("=", limit = 2).let {
+                        it.getOrElse(0) { "" } to it.getOrElse(1) { "" }
+                    }
+                    when (key.lowercase()) {
+                        "genre" -> currentGenre = value
+                        "proxytype" -> {
+                            currentProxyType = ProxyType.fromString(value)
+                            if (currentProxyHost.isEmpty()) {
+                                currentProxyHost = currentProxyType.getDefaultHost()
+                                currentProxyPort = currentProxyType.getDefaultPort()
+                            }
+                        }
+                        "proxyhost" -> currentProxyHost = value
+                        "proxyport" -> currentProxyPort = value.toIntOrNull() ?: currentProxyPort
+                        "coverart" -> currentCoverArt = value.takeIf { it.isNotEmpty() }
+                        "liked" -> currentLiked = value.lowercase() in listOf("true", "1", "yes")
+                    }
+                }
+                trimmed.isNotEmpty() && !trimmed.startsWith("#") -> {
+                    // This is a URL line
+                    val url = trimmed
+                    val name = currentName ?: url.substringAfterLast("/").substringBefore(".")
+
+                    if (url.startsWith("http://") || url.startsWith("https://")) {
+                        val useProxy = currentProxyType != ProxyType.NONE
+                        val station = RadioStation(
+                            name = name,
+                            streamUrl = url,
+                            proxyType = currentProxyType.name,
+                            proxyHost = if (useProxy) currentProxyHost else "",
+                            proxyPort = if (useProxy) currentProxyPort else 0,
+                            useProxy = useProxy,
+                            genre = currentGenre,
+                            coverArtUri = currentCoverArt,
+                            isLiked = currentLiked
+                        )
+                        stations.add(station)
+                    }
+
+                    // Reset for next entry
+                    currentName = null
+                    currentGenre = "Other"
+                    currentProxyType = ProxyType.NONE
+                    currentProxyHost = ""
+                    currentProxyPort = 0
+                    currentCoverArt = null
+                    currentLiked = false
+                }
+            }
+        }
+
+        return ImportResult(stations, errors, FileFormat.M3U)
+    }
+
+    /**
+     * Import stations from PLS content
+     */
+    private fun importFromPls(content: String, errors: MutableList<String>): ImportResult {
+        val stations = mutableListOf<RadioStation>()
+        val lines = content.lines()
+
+        // Parse PLS entries - collect File, Title, and attributes
+        val files = mutableMapOf<Int, String>()
+        val titles = mutableMapOf<Int, String>()
+        val genres = mutableMapOf<Int, String>()
+        val proxyTypes = mutableMapOf<Int, ProxyType>()
+        val proxyHosts = mutableMapOf<Int, String>()
+        val proxyPorts = mutableMapOf<Int, Int>()
+        val coverArts = mutableMapOf<Int, String>()
+        val liked = mutableMapOf<Int, Boolean>()
+
+        var currentEntryNum = 0
+
+        for (line in lines) {
+            val trimmed = line.trim()
+
+            when {
+                trimmed.startsWith("File", ignoreCase = true) -> {
+                    val match = Regex("File(\\d+)=(.+)", RegexOption.IGNORE_CASE).find(trimmed)
+                    if (match != null) {
+                        val num = match.groupValues[1].toIntOrNull() ?: continue
+                        files[num] = match.groupValues[2]
+                        currentEntryNum = num
+                    }
+                }
+                trimmed.startsWith("Title", ignoreCase = true) -> {
+                    val match = Regex("Title(\\d+)=(.+)", RegexOption.IGNORE_CASE).find(trimmed)
+                    if (match != null) {
+                        val num = match.groupValues[1].toIntOrNull() ?: continue
+                        var title = match.groupValues[2]
+
+                        // Detect and remove proxy indicators
+                        when {
+                            title.contains("[I2P]") -> {
+                                proxyTypes[num] = ProxyType.I2P
+                                title = title.replace(Regex("\\s*\\[I2P\\]\\s*"), "")
+                            }
+                            title.contains("[Tor]") -> {
+                                proxyTypes[num] = ProxyType.TOR
+                                title = title.replace(Regex("\\s*\\[Tor\\]\\s*"), "")
+                            }
+                        }
+                        titles[num] = title.trim()
+                    }
+                }
+                trimmed.startsWith("; I2PRADIO:") -> {
+                    val attr = trimmed.substringAfter("; I2PRADIO:")
+                    val (key, value) = attr.split("=", limit = 2).let {
+                        it.getOrElse(0) { "" } to it.getOrElse(1) { "" }
+                    }
+                    when (key.lowercase()) {
+                        "genre" -> genres[currentEntryNum] = value
+                        "proxytype" -> proxyTypes[currentEntryNum] = ProxyType.fromString(value)
+                        "proxyhost" -> proxyHosts[currentEntryNum] = value
+                        "proxyport" -> proxyPorts[currentEntryNum] = value.toIntOrNull() ?: 0
+                        "coverart" -> coverArts[currentEntryNum] = value
+                        "liked" -> liked[currentEntryNum] = value.lowercase() in listOf("true", "1", "yes")
+                    }
+                }
+            }
+        }
+
+        // Build stations from parsed data
+        for ((num, url) in files) {
+            if (!url.startsWith("http://") && !url.startsWith("https://")) continue
+
+            val title = titles[num] ?: url.substringAfterLast("/").substringBefore(".")
+            val proxyType = proxyTypes[num] ?: ProxyType.NONE
+            val useProxy = proxyType != ProxyType.NONE
+
+            val station = RadioStation(
+                name = title,
+                streamUrl = url,
+                proxyType = proxyType.name,
+                proxyHost = proxyHosts[num] ?: proxyType.getDefaultHost(),
+                proxyPort = proxyPorts[num] ?: proxyType.getDefaultPort(),
+                useProxy = useProxy,
+                genre = genres[num] ?: "Other",
+                coverArtUri = coverArts[num]?.takeIf { it.isNotEmpty() },
+                isLiked = liked[num] ?: false
+            )
+            stations.add(station)
+        }
+
+        return ImportResult(stations, errors, FileFormat.PLS)
+    }
+
+    // ==================== HELPER FUNCTIONS ====================
+
+    /**
+     * Escape a field for CSV output
+     */
+    private fun escapeCsvField(field: String): String {
+        return if (field.contains(",") || field.contains("\"") || field.contains("\n")) {
+            "\"${field.replace("\"", "\"\"")}\""
+        } else {
+            field
+        }
+    }
+
+    /**
+     * Parse a CSV line, handling quoted fields
+     */
+    private fun parseCsvLine(line: String): List<String> {
+        val fields = mutableListOf<String>()
+        val current = StringBuilder()
+        var inQuotes = false
+        var i = 0
+
+        while (i < line.length) {
+            val c = line[i]
+            when {
+                c == '"' -> {
+                    if (inQuotes && i + 1 < line.length && line[i + 1] == '"') {
+                        // Escaped quote
+                        current.append('"')
+                        i++
+                    } else {
+                        inQuotes = !inQuotes
+                    }
+                }
+                c == ',' && !inQuotes -> {
+                    fields.add(current.toString())
+                    current.clear()
+                }
+                else -> current.append(c)
+            }
+            i++
+        }
+        fields.add(current.toString())
+
+        return fields
+    }
+}

--- a/app/src/main/res/drawable/ic_share.xml
+++ b/app/src/main/res/drawable/ic_share.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M18,16.08c-0.76,0 -1.44,0.3 -1.96,0.77L8.91,12.7c0.05,-0.23 0.09,-0.46 0.09,-0.7s-0.04,-0.47 -0.09,-0.7l7.05,-4.11c0.54,0.5 1.25,0.81 2.04,0.81 1.66,0 3,-1.34 3,-3s-1.34,-3 -3,-3 -3,1.34 -3,3c0,0.24 0.04,0.47 0.09,0.7L8.04,9.81C7.5,9.31 6.79,9 6,9c-1.66,0 -3,1.34 -3,3s1.34,3 3,3c0.79,0 1.5,-0.31 2.04,-0.81l7.12,4.16c-0.05,0.21 -0.08,0.43 -0.08,0.65 0,1.61 1.31,2.92 2.92,2.92s2.92,-1.31 2.92,-2.92 -1.31,-2.92 -2.92,-2.92z"/>
+</vector>

--- a/app/src/main/res/layout/fragment_settings.xml
+++ b/app/src/main/res/layout/fragment_settings.xml
@@ -516,6 +516,120 @@
 
         </com.google.android.material.card.MaterialCardView>
 
+        <!-- Import/Export Section -->
+        <com.google.android.material.card.MaterialCardView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            app:cardCornerRadius="16dp"
+            app:cardElevation="0dp"
+            app:strokeWidth="0dp"
+            app:cardBackgroundColor="?attr/colorSurfaceContainer">
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                android:padding="16dp">
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="Stations"
+                    android:textSize="14sp"
+                    android:textStyle="bold"
+                    android:textColor="?attr/colorPrimary"
+                    android:layout_marginBottom="16dp" />
+
+                <!-- Import Stations -->
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="horizontal"
+                    android:gravity="center_vertical"
+                    android:paddingVertical="8dp">
+
+                    <LinearLayout
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:orientation="vertical">
+
+                        <TextView
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="Import Stations"
+                            android:textSize="16sp"
+                            android:textColor="?attr/colorOnSurface" />
+
+                        <TextView
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="Import from CSV, JSON, M3U, or PLS"
+                            android:textSize="12sp"
+                            android:textColor="?attr/colorOnSurfaceVariant" />
+
+                    </LinearLayout>
+
+                    <com.google.android.material.button.MaterialButton
+                        android:id="@+id/importStationsButton"
+                        style="@style/Widget.Material3.Button.TonalButton"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="Import"
+                        android:textSize="12sp"
+                        app:icon="@drawable/ic_folder"
+                        app:iconSize="18dp" />
+
+                </LinearLayout>
+
+                <!-- Export Stations -->
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="horizontal"
+                    android:gravity="center_vertical"
+                    android:paddingVertical="8dp"
+                    android:layout_marginTop="8dp">
+
+                    <LinearLayout
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:orientation="vertical">
+
+                        <TextView
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="Export Stations"
+                            android:textSize="16sp"
+                            android:textColor="?attr/colorOnSurface" />
+
+                        <TextView
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="Export your stations to a file"
+                            android:textSize="12sp"
+                            android:textColor="?attr/colorOnSurfaceVariant" />
+
+                    </LinearLayout>
+
+                    <com.google.android.material.button.MaterialButton
+                        android:id="@+id/exportStationsButton"
+                        style="@style/Widget.Material3.Button.TonalButton"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="Export"
+                        android:textSize="12sp"
+                        app:icon="@drawable/ic_share"
+                        app:iconSize="18dp" />
+
+                </LinearLayout>
+
+            </LinearLayout>
+
+        </com.google.android.material.card.MaterialCardView>
+
         <!-- About Section -->
         <com.google.android.material.card.MaterialCardView
             android:layout_width="match_parent"


### PR DESCRIPTION
Tor Privacy Fix:
- Created SecureImageLoader utility that routes HTTP/HTTPS image requests through Tor SOCKS proxy when Force Tor settings are enabled
- Local content URIs (file://, content://) bypass proxy automatically
- Updated all image loading locations (RadioService, NowPlayingFragment, RadiosFragment, MiniPlayerView, AddEditRadioDialog) to use loadSecure()
- Added Tor state listener to invalidate image loader cache when Tor connection changes

Station Import/Export Feature:
- Added StationImportExport utility supporting CSV, JSON, M3U, and PLS formats
- Export preserves all station metadata including proxy settings, genre, cover art, and liked status
- Import auto-detects format and shows preview before importing
- Custom I2PRADIO attributes in M3U/PLS preserve full station data
- Added import/export buttons in Settings under new "Stations" section