### PR TITLE
Add RadioBrowser integration with hybrid data architecture

### DIFF
--- a/app/src/main/assets/bundled_stations.json
+++ b/app/src/main/assets/bundled_stations.json
@@ -1,0 +1,186 @@
+{
+  "version": 1,
+  "description": "Bundled starter stations for I2P Radio",
+  "stations": [
+    {
+      "name": "BBC World Service",
+      "streamUrl": "http://stream.live.vc.bbcmedia.co.uk/bbc_world_service",
+      "genre": "News",
+      "country": "United Kingdom",
+      "countryCode": "GB",
+      "bitrate": 96,
+      "codec": "MP3"
+    },
+    {
+      "name": "NPR News",
+      "streamUrl": "https://npr-ice.streamguys1.com/live.mp3",
+      "genre": "News",
+      "country": "United States",
+      "countryCode": "US",
+      "bitrate": 128,
+      "codec": "MP3"
+    },
+    {
+      "name": "Classical KING FM",
+      "streamUrl": "https://classicalking.streamguys1.com/king-aac-64k",
+      "genre": "Classical",
+      "country": "United States",
+      "countryCode": "US",
+      "bitrate": 64,
+      "codec": "AAC"
+    },
+    {
+      "name": "KEXP 90.3 FM",
+      "streamUrl": "https://kexp-mp3-128.streamguys1.com/kexp128.mp3",
+      "genre": "Alternative",
+      "country": "United States",
+      "countryCode": "US",
+      "bitrate": 128,
+      "codec": "MP3"
+    },
+    {
+      "name": "Jazz24",
+      "streamUrl": "https://live.amperwave.net/direct/ppm-jazz24mp3-ibc1",
+      "genre": "Jazz",
+      "country": "United States",
+      "countryCode": "US",
+      "bitrate": 128,
+      "codec": "MP3"
+    },
+    {
+      "name": "SomaFM Groove Salad",
+      "streamUrl": "https://ice4.somafm.com/groovesalad-128-mp3",
+      "genre": "Ambient",
+      "country": "United States",
+      "countryCode": "US",
+      "bitrate": 128,
+      "codec": "MP3"
+    },
+    {
+      "name": "SomaFM Drone Zone",
+      "streamUrl": "https://ice4.somafm.com/dronezone-128-mp3",
+      "genre": "Ambient",
+      "country": "United States",
+      "countryCode": "US",
+      "bitrate": 128,
+      "codec": "MP3"
+    },
+    {
+      "name": "SomaFM DEF CON Radio",
+      "streamUrl": "https://ice4.somafm.com/defcon-128-mp3",
+      "genre": "Electronic",
+      "country": "United States",
+      "countryCode": "US",
+      "bitrate": 128,
+      "codec": "MP3"
+    },
+    {
+      "name": "Radio Paradise Main Mix",
+      "streamUrl": "https://stream.radioparadise.com/aac-320",
+      "genre": "Rock",
+      "country": "United States",
+      "countryCode": "US",
+      "bitrate": 320,
+      "codec": "AAC"
+    },
+    {
+      "name": "FIP Radio",
+      "streamUrl": "https://icecast.radiofrance.fr/fip-midfi.mp3",
+      "genre": "World",
+      "country": "France",
+      "countryCode": "FR",
+      "bitrate": 128,
+      "codec": "MP3"
+    },
+    {
+      "name": "NTS Radio 1",
+      "streamUrl": "https://stream-relay-geo.ntslive.net/stream",
+      "genre": "Electronic",
+      "country": "United Kingdom",
+      "countryCode": "GB",
+      "bitrate": 128,
+      "codec": "MP3"
+    },
+    {
+      "name": "BBC Radio 6 Music",
+      "streamUrl": "http://stream.live.vc.bbcmedia.co.uk/bbc_6music",
+      "genre": "Alternative",
+      "country": "United Kingdom",
+      "countryCode": "GB",
+      "bitrate": 128,
+      "codec": "MP3"
+    },
+    {
+      "name": "FluxFM Berlin",
+      "streamUrl": "https://streams.fluxfm.de/live/mp3-320/audio/",
+      "genre": "Alternative",
+      "country": "Germany",
+      "countryCode": "DE",
+      "bitrate": 320,
+      "codec": "MP3"
+    },
+    {
+      "name": "WFMU Freeform Radio",
+      "streamUrl": "https://stream0.wfmu.org/freeform-128k",
+      "genre": "Alternative",
+      "country": "United States",
+      "countryCode": "US",
+      "bitrate": 128,
+      "codec": "MP3"
+    },
+    {
+      "name": "Dublab",
+      "streamUrl": "https://dublab.out.airtime.pro/dublab_a",
+      "genre": "Electronic",
+      "country": "United States",
+      "countryCode": "US",
+      "bitrate": 128,
+      "codec": "MP3"
+    },
+    {
+      "name": "Triple J",
+      "streamUrl": "https://live-radio01.mediahubaustralia.com/2TJW/mp3/",
+      "genre": "Alternative",
+      "country": "Australia",
+      "countryCode": "AU",
+      "bitrate": 96,
+      "codec": "MP3"
+    },
+    {
+      "name": "RAI Radio 3",
+      "streamUrl": "https://icestreaming.rai.it/3.mp3",
+      "genre": "Classical",
+      "country": "Italy",
+      "countryCode": "IT",
+      "bitrate": 128,
+      "codec": "MP3"
+    },
+    {
+      "name": "RNE Radio Clásica",
+      "streamUrl": "https://rtvelivestreamv3.akamaized.net/rtvesec/rne/rne_r2_main.mp3",
+      "genre": "Classical",
+      "country": "Spain",
+      "countryCode": "ES",
+      "bitrate": 128,
+      "codec": "MP3"
+    },
+    {
+      "name": "Bluegrass Country",
+      "streamUrl": "https://ice24.securenetsystems.net/WAMU",
+      "genre": "Country",
+      "country": "United States",
+      "countryCode": "US",
+      "bitrate": 128,
+      "codec": "MP3"
+    },
+    {
+      "name": "KCRW Eclectic24",
+      "streamUrl": "https://kcrw.streamguys1.com/kcrw_192k_mp3_e24",
+      "genre": "Alternative",
+      "country": "United States",
+      "countryCode": "US",
+      "bitrate": 192,
+      "codec": "MP3"
+    }
+  ]
+}

--- a/app/src/main/java/com/opensource/i2pradio/MainActivity.kt
+++ b/app/src/main/java/com/opensource/i2pradio/MainActivity.kt
@@ -32,6 +32,7 @@ import com.opensource.i2pradio.ui.RadioViewModel
 import com.opensource.i2pradio.ui.RadiosFragment
 import com.opensource.i2pradio.ui.TorQuickControlBottomSheet
 import com.opensource.i2pradio.ui.TorStatusView
+import com.opensource.i2pradio.ui.browse.BrowseStationsFragment
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -218,7 +219,7 @@ class MainActivity : AppCompatActivity() {
 
         // Click mini-player to go to Now Playing tab
         miniPlayerView.setOnMiniPlayerClickListener {
-            viewPager.currentItem = 1  // Switch to Now Playing tab
+            viewPager.currentItem = 2  // Switch to Now Playing tab (index 2 now)
         }
 
         // Play/pause toggle - update ViewModel to sync state and trigger animation
@@ -276,9 +277,10 @@ class MainActivity : AppCompatActivity() {
 
         TabLayoutMediator(tabLayout, viewPager) { tab, position ->
             tab.text = when (position) {
-                0 -> "Radio Stations"
-                1 -> "Now Playing"
-                2 -> "Settings"
+                0 -> getString(R.string.tab_radios)
+                1 -> getString(R.string.tab_browse)
+                2 -> getString(R.string.tab_now_playing)
+                3 -> getString(R.string.tab_settings)
                 else -> ""
             }
         }.attach()
@@ -287,7 +289,7 @@ class MainActivity : AppCompatActivity() {
         viewPager.registerOnPageChangeCallback(object : ViewPager2.OnPageChangeCallback() {
             override fun onPageSelected(position: Int) {
                 super.onPageSelected(position)
-                if (position == 1) {
+                if (position == 2) {
                     // On Now Playing tab - keep mini player hidden
                     miniPlayerView.hideForNowPlaying()
                     miniPlayerContainer.visibility = View.INVISIBLE
@@ -327,13 +329,14 @@ class MainActivity : AppCompatActivity() {
     private inner class ViewPagerAdapter(activity: AppCompatActivity) :
         FragmentStateAdapter(activity) {
 
-        override fun getItemCount(): Int = 3
+        override fun getItemCount(): Int = 4
 
         override fun createFragment(position: Int): Fragment {
             return when (position) {
                 0 -> RadiosFragment()
-                1 -> NowPlayingFragment()
-                2 -> SettingsFragment()  // We'll create this next!
+                1 -> BrowseStationsFragment()
+                2 -> NowPlayingFragment()
+                3 -> SettingsFragment()
                 else -> RadiosFragment()  // Fallback
             }
         }

--- a/app/src/main/java/com/opensource/i2pradio/data/DefaultStations.kt
+++ b/app/src/main/java/com/opensource/i2pradio/data/DefaultStations.kt
@@ -1,29 +1,100 @@
 package com.opensource.i2pradio.data
 
+import android.content.Context
+import android.util.Log
+import org.json.JSONObject
+
+/**
+ * Provides default/bundled radio stations.
+ *
+ * Loads stations from bundled_stations.json asset file for a rich first-launch experience.
+ * Falls back to hardcoded stations if asset loading fails.
+ */
 object DefaultStations {
-    fun getPresetStations(): List<RadioStation> {
+    private const val TAG = "DefaultStations"
+    private const val BUNDLED_STATIONS_FILE = "bundled_stations.json"
+
+    /**
+     * Get preset stations from bundled JSON asset.
+     * Falls back to hardcoded stations if loading fails.
+     */
+    fun getPresetStations(context: Context): List<RadioStation> {
+        return try {
+            loadBundledStations(context)
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to load bundled stations, using fallback", e)
+            getFallbackStations()
+        }
+    }
+
+    /**
+     * Load stations from the bundled JSON asset file.
+     */
+    private fun loadBundledStations(context: Context): List<RadioStation> {
+        val stations = mutableListOf<RadioStation>()
+        val jsonString = context.assets.open(BUNDLED_STATIONS_FILE).bufferedReader().use { it.readText() }
+        val json = JSONObject(jsonString)
+        val stationsArray = json.getJSONArray("stations")
+
+        for (i in 0 until stationsArray.length()) {
+            val stationJson = stationsArray.getJSONObject(i)
+            val station = RadioStation(
+                name = stationJson.getString("name"),
+                streamUrl = stationJson.getString("streamUrl"),
+                genre = stationJson.optString("genre", "Other"),
+                country = stationJson.optString("country", ""),
+                countryCode = stationJson.optString("countryCode", ""),
+                bitrate = stationJson.optInt("bitrate", 0),
+                codec = stationJson.optString("codec", ""),
+                source = StationSource.BUNDLED.name,
+                isPreset = false,
+                useProxy = false
+            )
+            stations.add(station)
+        }
+
+        Log.d(TAG, "Loaded ${stations.size} bundled stations")
+        return stations
+    }
+
+    /**
+     * Fallback hardcoded stations in case asset loading fails.
+     */
+    private fun getFallbackStations(): List<RadioStation> {
         return listOf(
             RadioStation(
                 name = "BBC World Service",
                 streamUrl = "http://stream.live.vc.bbcmedia.co.uk/bbc_world_service",
                 genre = "News",
-                isPreset = false,  // Changed to false
+                source = StationSource.BUNDLED.name,
+                isPreset = false,
                 useProxy = false
             ),
             RadioStation(
                 name = "NPR News",
                 streamUrl = "https://npr-ice.streamguys1.com/live.mp3",
                 genre = "News",
-                isPreset = false,  // Changed to false
+                source = StationSource.BUNDLED.name,
+                isPreset = false,
                 useProxy = false
             ),
             RadioStation(
                 name = "Classical KING FM",
                 streamUrl = "https://classicalking.streamguys1.com/king-aac-64k",
                 genre = "Classical",
-                isPreset = false,  // Changed to false
+                source = StationSource.BUNDLED.name,
+                isPreset = false,
                 useProxy = false
             )
         )
+    }
+
+    /**
+     * Legacy method for backward compatibility.
+     * @deprecated Use getPresetStations(context) instead
+     */
+    @Deprecated("Use getPresetStations(context) instead", ReplaceWith("getPresetStations(context)"))
+    fun getPresetStations(): List<RadioStation> {
+        return getFallbackStations()
     }
 }

--- a/app/src/main/java/com/opensource/i2pradio/data/RadioDatabase.kt
+++ b/app/src/main/java/com/opensource/i2pradio/data/RadioDatabase.kt
@@ -7,7 +7,7 @@ import androidx.room.RoomDatabase
 import androidx.room.migration.Migration
 import androidx.sqlite.db.SupportSQLiteDatabase
 
-@Database(entities = [RadioStation::class], version = 3, exportSchema = false)
+@Database(entities = [RadioStation::class], version = 4, exportSchema = false)
 abstract class RadioDatabase : RoomDatabase() {
     abstract fun radioDao(): RadioDao
 
@@ -42,6 +42,48 @@ abstract class RadioDatabase : RoomDatabase() {
             }
         }
 
+        // Migration from version 3 to 4: Add RadioBrowser integration fields
+        private val MIGRATION_3_4 = object : Migration(3, 4) {
+            override fun migrate(database: SupportSQLiteDatabase) {
+                // Add source column - default to USER for existing stations
+                database.execSQL(
+                    "ALTER TABLE radio_stations ADD COLUMN source TEXT NOT NULL DEFAULT 'USER'"
+                )
+                // Add RadioBrowser UUID for deduplication
+                database.execSQL(
+                    "ALTER TABLE radio_stations ADD COLUMN radioBrowserUuid TEXT DEFAULT NULL"
+                )
+                // Add lastVerified timestamp
+                database.execSQL(
+                    "ALTER TABLE radio_stations ADD COLUMN lastVerified INTEGER NOT NULL DEFAULT 0"
+                )
+                // Add cachedAt timestamp
+                database.execSQL(
+                    "ALTER TABLE radio_stations ADD COLUMN cachedAt INTEGER NOT NULL DEFAULT 0"
+                )
+                // Add bitrate
+                database.execSQL(
+                    "ALTER TABLE radio_stations ADD COLUMN bitrate INTEGER NOT NULL DEFAULT 0"
+                )
+                // Add codec
+                database.execSQL(
+                    "ALTER TABLE radio_stations ADD COLUMN codec TEXT NOT NULL DEFAULT ''"
+                )
+                // Add country
+                database.execSQL(
+                    "ALTER TABLE radio_stations ADD COLUMN country TEXT NOT NULL DEFAULT ''"
+                )
+                // Add countryCode
+                database.execSQL(
+                    "ALTER TABLE radio_stations ADD COLUMN countryCode TEXT NOT NULL DEFAULT ''"
+                )
+                // Add homepage
+                database.execSQL(
+                    "ALTER TABLE radio_stations ADD COLUMN homepage TEXT NOT NULL DEFAULT ''"
+                )
+            }
+        }
+
         fun getDatabase(context: Context): RadioDatabase {
             return INSTANCE ?: synchronized(this) {
                 val instance = Room.databaseBuilder(
@@ -49,7 +91,7 @@ abstract class RadioDatabase : RoomDatabase() {
                     RadioDatabase::class.java,
                     "radio_database"
                 )
-                    .addMigrations(MIGRATION_1_2, MIGRATION_2_3)
+                    .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4)
                     .fallbackToDestructiveMigration()  // Handles both upgrades and downgrades if migration not found
                     .build()
                 INSTANCE = instance

--- a/app/src/main/java/com/opensource/i2pradio/data/RadioRepository.kt
+++ b/app/src/main/java/com/opensource/i2pradio/data/RadioRepository.kt
@@ -98,8 +98,8 @@ class RadioRepository(context: Context) {
                 return@withContext
             }
 
-            // Add preset stations
-            DefaultStations.getPresetStations().forEach { station ->
+            // Add preset stations from bundled JSON
+            DefaultStations.getPresetStations(context).forEach { station ->
                 radioDao.insertStation(station)
             }
 

--- a/app/src/main/java/com/opensource/i2pradio/data/radiobrowser/RadioBrowserClient.kt
+++ b/app/src/main/java/com/opensource/i2pradio/data/radiobrowser/RadioBrowserClient.kt
@@ -1,0 +1,460 @@
+package com.opensource.i2pradio.data.radiobrowser
+
+import android.content.Context
+import android.util.Log
+import com.opensource.i2pradio.tor.TorManager
+import com.opensource.i2pradio.ui.PreferencesHelper
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import org.json.JSONArray
+import java.net.InetSocketAddress
+import java.net.Proxy
+import java.util.concurrent.TimeUnit
+
+/**
+ * Client for the RadioBrowser API (radio-browser.info)
+ *
+ * Supports proxy routing through Tor when Force Tor settings are enabled,
+ * ensuring metadata fetches don't leak user's real IP.
+ */
+class RadioBrowserClient(private val context: Context) {
+
+    companion object {
+        private const val TAG = "RadioBrowserClient"
+
+        // RadioBrowser API servers (use multiple for redundancy)
+        private val API_SERVERS = listOf(
+            "de1.api.radio-browser.info",
+            "nl1.api.radio-browser.info",
+            "at1.api.radio-browser.info"
+        )
+
+        private const val DEFAULT_LIMIT = 50
+        private const val MAX_LIMIT = 100
+        private const val CONNECT_TIMEOUT_SECONDS = 30L
+        private const val READ_TIMEOUT_SECONDS = 30L
+        private const val CONNECT_TIMEOUT_PROXY_SECONDS = 60L
+        private const val READ_TIMEOUT_PROXY_SECONDS = 60L
+
+        // User agent to identify our app to RadioBrowser
+        private const val USER_AGENT = "I2PRadio/1.0 (Android; +https://github.com/example/i2pradio)"
+    }
+
+    private var currentServerIndex = 0
+
+    /**
+     * Build an OkHttpClient respecting Force Tor settings
+     */
+    private fun buildHttpClient(): OkHttpClient {
+        val builder = OkHttpClient.Builder()
+
+        val forceTorAll = PreferencesHelper.isForceTorAll(context)
+        val forceTorExceptI2P = PreferencesHelper.isForceTorExceptI2P(context)
+        val torEnabled = PreferencesHelper.isEmbeddedTorEnabled(context)
+        val torConnected = TorManager.isConnected()
+
+        Log.d(TAG, "Building HTTP client - ForceTorAll: $forceTorAll, ForceTorExceptI2P: $forceTorExceptI2P, TorEnabled: $torEnabled, TorConnected: $torConnected")
+
+        // Route through Tor if Force Tor is enabled and Tor is connected
+        if ((forceTorAll || forceTorExceptI2P) && torConnected) {
+            val socksHost = TorManager.getProxyHost()
+            val socksPort = TorManager.getProxyPort()
+
+            if (socksPort > 0) {
+                Log.d(TAG, "Routing RadioBrowser API through Tor SOCKS5 proxy at $socksHost:$socksPort")
+                builder.proxy(Proxy(Proxy.Type.SOCKS, InetSocketAddress(socksHost, socksPort)))
+                builder.connectTimeout(CONNECT_TIMEOUT_PROXY_SECONDS, TimeUnit.SECONDS)
+                builder.readTimeout(READ_TIMEOUT_PROXY_SECONDS, TimeUnit.SECONDS)
+            } else {
+                Log.w(TAG, "Force Tor enabled but Tor proxy port invalid, using direct connection")
+                builder.connectTimeout(CONNECT_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+                builder.readTimeout(READ_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+            }
+        } else {
+            builder.connectTimeout(CONNECT_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+            builder.readTimeout(READ_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+        }
+
+        return builder.build()
+    }
+
+    /**
+     * Get the current API base URL, cycling through servers on failure
+     */
+    private fun getApiBaseUrl(): String {
+        return "https://${API_SERVERS[currentServerIndex]}/json"
+    }
+
+    /**
+     * Cycle to the next API server
+     */
+    private fun cycleServer() {
+        currentServerIndex = (currentServerIndex + 1) % API_SERVERS.size
+        Log.d(TAG, "Cycled to API server: ${API_SERVERS[currentServerIndex]}")
+    }
+
+    /**
+     * Execute an API request with retry logic
+     */
+    private suspend fun executeRequest(endpoint: String, retries: Int = 2): RadioBrowserResult<List<RadioBrowserStation>> {
+        return withContext(Dispatchers.IO) {
+            var lastException: Exception? = null
+
+            repeat(retries + 1) { attempt ->
+                try {
+                    val client = buildHttpClient()
+                    val url = "${getApiBaseUrl()}$endpoint"
+
+                    Log.d(TAG, "API Request (attempt ${attempt + 1}): $url")
+
+                    val request = Request.Builder()
+                        .url(url)
+                        .header("User-Agent", USER_AGENT)
+                        .header("Accept", "application/json")
+                        .get()
+                        .build()
+
+                    val response = client.newCall(request).execute()
+
+                    if (!response.isSuccessful) {
+                        Log.w(TAG, "API request failed with code: ${response.code}")
+                        response.close()
+                        if (attempt < retries) {
+                            cycleServer()
+                        }
+                        lastException = Exception("HTTP ${response.code}")
+                        return@repeat
+                    }
+
+                    val body = response.body?.string()
+                    response.close()
+
+                    if (body.isNullOrEmpty()) {
+                        Log.w(TAG, "Empty response body")
+                        lastException = Exception("Empty response")
+                        if (attempt < retries) {
+                            cycleServer()
+                        }
+                        return@repeat
+                    }
+
+                    val stations = parseStationsJson(body)
+                    Log.d(TAG, "Successfully parsed ${stations.size} stations")
+                    return@withContext RadioBrowserResult.Success(stations)
+
+                } catch (e: Exception) {
+                    Log.e(TAG, "API request failed (attempt ${attempt + 1}): ${e.message}")
+                    lastException = e
+                    if (attempt < retries) {
+                        cycleServer()
+                    }
+                }
+            }
+
+            RadioBrowserResult.Error(
+                lastException?.message ?: "Unknown error",
+                lastException
+            )
+        }
+    }
+
+    /**
+     * Parse JSON array of stations
+     */
+    private fun parseStationsJson(json: String): List<RadioBrowserStation> {
+        val stations = mutableListOf<RadioBrowserStation>()
+        try {
+            val jsonArray = JSONArray(json)
+            for (i in 0 until jsonArray.length()) {
+                try {
+                    val station = RadioBrowserStation.fromJson(jsonArray.getJSONObject(i))
+                    // Filter out stations with empty names or URLs
+                    if (station.name.isNotEmpty() && station.getStreamUrl().isNotEmpty()) {
+                        stations.add(station)
+                    }
+                } catch (e: Exception) {
+                    Log.w(TAG, "Failed to parse station at index $i: ${e.message}")
+                }
+            }
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to parse stations JSON: ${e.message}")
+        }
+        return stations
+    }
+
+    /**
+     * Search for stations by name
+     */
+    suspend fun searchByName(
+        query: String,
+        limit: Int = DEFAULT_LIMIT,
+        offset: Int = 0,
+        order: String = "votes",
+        reverse: Boolean = true,
+        hidebroken: Boolean = true
+    ): RadioBrowserResult<List<RadioBrowserStation>> {
+        val params = buildString {
+            append("/stations/byname/${java.net.URLEncoder.encode(query, "UTF-8")}")
+            append("?limit=$limit")
+            append("&offset=$offset")
+            append("&order=$order")
+            append("&reverse=$reverse")
+            append("&hidebroken=$hidebroken")
+        }
+        return executeRequest(params)
+    }
+
+    /**
+     * Search stations with advanced filters
+     */
+    suspend fun searchStations(
+        name: String? = null,
+        tag: String? = null,
+        country: String? = null,
+        countrycode: String? = null,
+        language: String? = null,
+        limit: Int = DEFAULT_LIMIT,
+        offset: Int = 0,
+        order: String = "votes",
+        reverse: Boolean = true,
+        hidebroken: Boolean = true
+    ): RadioBrowserResult<List<RadioBrowserStation>> {
+        val params = buildString {
+            append("/stations/search")
+            append("?limit=$limit")
+            append("&offset=$offset")
+            append("&order=$order")
+            append("&reverse=$reverse")
+            append("&hidebroken=$hidebroken")
+            name?.let { append("&name=${java.net.URLEncoder.encode(it, "UTF-8")}") }
+            tag?.let { append("&tag=${java.net.URLEncoder.encode(it, "UTF-8")}") }
+            country?.let { append("&country=${java.net.URLEncoder.encode(it, "UTF-8")}") }
+            countrycode?.let { append("&countrycode=${java.net.URLEncoder.encode(it, "UTF-8")}") }
+            language?.let { append("&language=${java.net.URLEncoder.encode(it, "UTF-8")}") }
+        }
+        return executeRequest(params)
+    }
+
+    /**
+     * Get top voted stations
+     */
+    suspend fun getTopVoted(
+        limit: Int = DEFAULT_LIMIT,
+        offset: Int = 0,
+        hidebroken: Boolean = true
+    ): RadioBrowserResult<List<RadioBrowserStation>> {
+        val params = "/stations/topvote/$limit?offset=$offset&hidebroken=$hidebroken"
+        return executeRequest(params)
+    }
+
+    /**
+     * Get top clicked stations (popular)
+     */
+    suspend fun getTopClicked(
+        limit: Int = DEFAULT_LIMIT,
+        offset: Int = 0,
+        hidebroken: Boolean = true
+    ): RadioBrowserResult<List<RadioBrowserStation>> {
+        val params = "/stations/topclick/$limit?offset=$offset&hidebroken=$hidebroken"
+        return executeRequest(params)
+    }
+
+    /**
+     * Get recently changed/updated stations
+     */
+    suspend fun getRecentlyChanged(
+        limit: Int = DEFAULT_LIMIT,
+        offset: Int = 0,
+        hidebroken: Boolean = true
+    ): RadioBrowserResult<List<RadioBrowserStation>> {
+        val params = "/stations/lastchange/$limit?offset=$offset&hidebroken=$hidebroken"
+        return executeRequest(params)
+    }
+
+    /**
+     * Get stations by country code (ISO 3166-1 alpha-2)
+     */
+    suspend fun getByCountryCode(
+        countryCode: String,
+        limit: Int = DEFAULT_LIMIT,
+        offset: Int = 0,
+        order: String = "votes",
+        reverse: Boolean = true,
+        hidebroken: Boolean = true
+    ): RadioBrowserResult<List<RadioBrowserStation>> {
+        val params = buildString {
+            append("/stations/bycountrycodeexact/${countryCode.uppercase()}")
+            append("?limit=$limit")
+            append("&offset=$offset")
+            append("&order=$order")
+            append("&reverse=$reverse")
+            append("&hidebroken=$hidebroken")
+        }
+        return executeRequest(params)
+    }
+
+    /**
+     * Get stations by tag/genre
+     */
+    suspend fun getByTag(
+        tag: String,
+        limit: Int = DEFAULT_LIMIT,
+        offset: Int = 0,
+        order: String = "votes",
+        reverse: Boolean = true,
+        hidebroken: Boolean = true
+    ): RadioBrowserResult<List<RadioBrowserStation>> {
+        val params = buildString {
+            append("/stations/bytag/${java.net.URLEncoder.encode(tag, "UTF-8")}")
+            append("?limit=$limit")
+            append("&offset=$offset")
+            append("&order=$order")
+            append("&reverse=$reverse")
+            append("&hidebroken=$hidebroken")
+        }
+        return executeRequest(params)
+    }
+
+    /**
+     * Get a station by its UUID
+     */
+    suspend fun getByUuid(uuid: String): RadioBrowserResult<List<RadioBrowserStation>> {
+        val params = "/stations/byuuid/$uuid"
+        return executeRequest(params)
+    }
+
+    /**
+     * Get list of available countries with station counts
+     */
+    suspend fun getCountries(): RadioBrowserResult<List<CountryInfo>> {
+        return withContext(Dispatchers.IO) {
+            try {
+                val client = buildHttpClient()
+                val url = "${getApiBaseUrl()}/countries?order=stationcount&reverse=true"
+
+                val request = Request.Builder()
+                    .url(url)
+                    .header("User-Agent", USER_AGENT)
+                    .header("Accept", "application/json")
+                    .get()
+                    .build()
+
+                val response = client.newCall(request).execute()
+
+                if (!response.isSuccessful) {
+                    response.close()
+                    return@withContext RadioBrowserResult.Error("HTTP ${response.code}")
+                }
+
+                val body = response.body?.string()
+                response.close()
+
+                if (body.isNullOrEmpty()) {
+                    return@withContext RadioBrowserResult.Error("Empty response")
+                }
+
+                val countries = mutableListOf<CountryInfo>()
+                val jsonArray = JSONArray(body)
+                for (i in 0 until jsonArray.length()) {
+                    val obj = jsonArray.getJSONObject(i)
+                    countries.add(
+                        CountryInfo(
+                            name = obj.optString("name", ""),
+                            iso3166_1 = obj.optString("iso_3166_1", ""),
+                            stationCount = obj.optInt("stationcount", 0)
+                        )
+                    )
+                }
+
+                RadioBrowserResult.Success(countries)
+            } catch (e: Exception) {
+                Log.e(TAG, "Failed to fetch countries: ${e.message}")
+                RadioBrowserResult.Error(e.message ?: "Unknown error", e)
+            }
+        }
+    }
+
+    /**
+     * Get list of available tags with station counts
+     */
+    suspend fun getTags(limit: Int = 100): RadioBrowserResult<List<TagInfo>> {
+        return withContext(Dispatchers.IO) {
+            try {
+                val client = buildHttpClient()
+                val url = "${getApiBaseUrl()}/tags?order=stationcount&reverse=true&limit=$limit"
+
+                val request = Request.Builder()
+                    .url(url)
+                    .header("User-Agent", USER_AGENT)
+                    .header("Accept", "application/json")
+                    .get()
+                    .build()
+
+                val response = client.newCall(request).execute()
+
+                if (!response.isSuccessful) {
+                    response.close()
+                    return@withContext RadioBrowserResult.Error("HTTP ${response.code}")
+                }
+
+                val body = response.body?.string()
+                response.close()
+
+                if (body.isNullOrEmpty()) {
+                    return@withContext RadioBrowserResult.Error("Empty response")
+                }
+
+                val tags = mutableListOf<TagInfo>()
+                val jsonArray = JSONArray(body)
+                for (i in 0 until jsonArray.length()) {
+                    val obj = jsonArray.getJSONObject(i)
+                    val name = obj.optString("name", "")
+                    if (name.isNotEmpty()) {
+                        tags.add(
+                            TagInfo(
+                                name = name,
+                                stationCount = obj.optInt("stationcount", 0)
+                            )
+                        )
+                    }
+                }
+
+                RadioBrowserResult.Success(tags)
+            } catch (e: Exception) {
+                Log.e(TAG, "Failed to fetch tags: ${e.message}")
+                RadioBrowserResult.Error(e.message ?: "Unknown error", e)
+            }
+        }
+    }
+
+    /**
+     * Check if Force Tor is enabled but Tor is not connected
+     * (used to warn users before making API calls)
+     */
+    fun isTorRequiredButNotConnected(): Boolean {
+        val forceTorAll = PreferencesHelper.isForceTorAll(context)
+        val forceTorExceptI2P = PreferencesHelper.isForceTorExceptI2P(context)
+        val torConnected = TorManager.isConnected()
+
+        return (forceTorAll || forceTorExceptI2P) && !torConnected
+    }
+}
+
+/**
+ * Country information from RadioBrowser
+ */
+data class CountryInfo(
+    val name: String,
+    val iso3166_1: String,
+    val stationCount: Int
+)
+
+/**
+ * Tag/genre information from RadioBrowser
+ */
+data class TagInfo(
+    val name: String,
+    val stationCount: Int
+)

--- a/app/src/main/java/com/opensource/i2pradio/data/radiobrowser/RadioBrowserStation.kt
+++ b/app/src/main/java/com/opensource/i2pradio/data/radiobrowser/RadioBrowserStation.kt
@@ -1,0 +1,164 @@
+package com.opensource.i2pradio.data.radiobrowser
+
+import org.json.JSONObject
+
+/**
+ * Data class representing a radio station from the RadioBrowser API.
+ * Maps to the JSON response structure from radio-browser.info
+ */
+data class RadioBrowserStation(
+    val stationuuid: String,
+    val name: String,
+    val url: String,
+    val urlResolved: String,
+    val homepage: String,
+    val favicon: String,
+    val tags: String,
+    val country: String,
+    val countrycode: String,
+    val state: String,
+    val language: String,
+    val languagecodes: String,
+    val votes: Int,
+    val lastchangetime: String,
+    val codec: String,
+    val bitrate: Int,
+    val hls: Boolean,
+    val lastcheckok: Boolean,
+    val clickcount: Int,
+    val clicktrend: Int,
+    val sslError: Boolean,
+    val geoLat: Double?,
+    val geoLong: Double?
+) {
+    companion object {
+        /**
+         * Parse a RadioBrowserStation from a JSONObject
+         */
+        fun fromJson(json: JSONObject): RadioBrowserStation {
+            return RadioBrowserStation(
+                stationuuid = json.optString("stationuuid", ""),
+                name = json.optString("name", "").trim(),
+                url = json.optString("url", ""),
+                urlResolved = json.optString("url_resolved", ""),
+                homepage = json.optString("homepage", ""),
+                favicon = json.optString("favicon", ""),
+                tags = json.optString("tags", ""),
+                country = json.optString("country", ""),
+                countrycode = json.optString("countrycode", ""),
+                state = json.optString("state", ""),
+                language = json.optString("language", ""),
+                languagecodes = json.optString("languagecodes", ""),
+                votes = json.optInt("votes", 0),
+                lastchangetime = json.optString("lastchangetime", ""),
+                codec = json.optString("codec", ""),
+                bitrate = json.optInt("bitrate", 0),
+                hls = json.optInt("hls", 0) == 1,
+                lastcheckok = json.optInt("lastcheckok", 0) == 1,
+                clickcount = json.optInt("clickcount", 0),
+                clicktrend = json.optInt("clicktrend", 0),
+                sslError = json.optInt("ssl_error", 0) == 1,
+                geoLat = json.optDouble("geo_lat").takeIf { !it.isNaN() },
+                geoLong = json.optDouble("geo_long").takeIf { !it.isNaN() }
+            )
+        }
+    }
+
+    /**
+     * Get the best available stream URL (resolved URL preferred)
+     */
+    fun getStreamUrl(): String {
+        return urlResolved.takeIf { it.isNotEmpty() } ?: url
+    }
+
+    /**
+     * Get the primary genre/tag from the tags list
+     */
+    fun getPrimaryGenre(): String {
+        val tagList = tags.split(",").map { it.trim() }.filter { it.isNotEmpty() }
+        return mapToAppGenre(tagList.firstOrNull() ?: "Other")
+    }
+
+    /**
+     * Map RadioBrowser tags to app's genre categories
+     */
+    private fun mapToAppGenre(tag: String): String {
+        val lowerTag = tag.lowercase()
+        return when {
+            lowerTag.contains("news") -> "News"
+            lowerTag.contains("talk") -> "Talk"
+            lowerTag.contains("sport") -> "Sports"
+            lowerTag.contains("classical") -> "Classical"
+            lowerTag.contains("jazz") -> "Jazz"
+            lowerTag.contains("rock") -> "Rock"
+            lowerTag.contains("pop") -> "Pop"
+            lowerTag.contains("electronic") || lowerTag.contains("techno") ||
+                lowerTag.contains("house") || lowerTag.contains("trance") -> "Electronic"
+            lowerTag.contains("dance") || lowerTag.contains("edm") -> "Dance"
+            lowerTag.contains("hip hop") || lowerTag.contains("hip-hop") ||
+                lowerTag.contains("hiphop") || lowerTag.contains("rap") -> "Hip Hop"
+            lowerTag.contains("country") -> "Country"
+            lowerTag.contains("blues") -> "Blues"
+            lowerTag.contains("metal") -> "Metal"
+            lowerTag.contains("punk") -> "Punk"
+            lowerTag.contains("indie") -> "Indie"
+            lowerTag.contains("alternative") -> "Alternative"
+            lowerTag.contains("folk") -> "Folk"
+            lowerTag.contains("reggae") -> "Reggae"
+            lowerTag.contains("latin") || lowerTag.contains("salsa") ||
+                lowerTag.contains("merengue") -> "Latin"
+            lowerTag.contains("r&b") || lowerTag.contains("rnb") ||
+                lowerTag.contains("soul") -> "R&B"
+            lowerTag.contains("gospel") || lowerTag.contains("christian") ||
+                lowerTag.contains("religious") -> "Christian"
+            lowerTag.contains("ambient") || lowerTag.contains("chillout") ||
+                lowerTag.contains("lounge") -> "Ambient"
+            lowerTag.contains("world") -> "World"
+            lowerTag.contains("oldies") || lowerTag.contains("80s") ||
+                lowerTag.contains("70s") || lowerTag.contains("60s") -> "Oldies"
+            lowerTag.contains("kpop") || lowerTag.contains("k-pop") -> "K-Pop"
+            lowerTag.contains("lofi") || lowerTag.contains("lo-fi") -> "Lo-Fi"
+            lowerTag.contains("funk") -> "Funk"
+            lowerTag.contains("comedy") -> "Comedy"
+            else -> tag.replaceFirstChar { it.uppercase() }.take(20)
+        }
+    }
+
+    /**
+     * Check if this station appears to be working
+     */
+    fun isLikelyWorking(): Boolean {
+        return lastcheckok && !sslError && getStreamUrl().isNotEmpty()
+    }
+
+    /**
+     * Get a display string for bitrate/codec info
+     */
+    fun getQualityInfo(): String {
+        val parts = mutableListOf<String>()
+        if (bitrate > 0) parts.add("${bitrate}kbps")
+        if (codec.isNotEmpty()) parts.add(codec.uppercase())
+        return parts.joinToString(" • ")
+    }
+}
+
+/**
+ * Enum for different search/browse categories
+ */
+enum class BrowseCategory {
+    TOP_VOTED,
+    TOP_CLICKED,
+    RECENTLY_CHANGED,
+    BY_COUNTRY,
+    BY_TAG,
+    SEARCH
+}
+
+/**
+ * Result wrapper for RadioBrowser API calls
+ */
+sealed class RadioBrowserResult<out T> {
+    data class Success<T>(val data: T) : RadioBrowserResult<T>()
+    data class Error(val message: String, val exception: Exception? = null) : RadioBrowserResult<Nothing>()
+    data object Loading : RadioBrowserResult<Nothing>()
+}

--- a/app/src/main/java/com/opensource/i2pradio/ui/browse/BrowseStationsFragment.kt
+++ b/app/src/main/java/com/opensource/i2pradio/ui/browse/BrowseStationsFragment.kt
@@ -1,0 +1,329 @@
+package com.opensource.i2pradio.ui.browse
+
+import android.app.AlertDialog
+import android.content.Intent
+import android.os.Bundle
+import android.text.Editable
+import android.text.TextWatcher
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.view.inputmethod.EditorInfo
+import android.widget.FrameLayout
+import android.widget.LinearLayout
+import android.widget.Toast
+import androidx.core.content.ContextCompat
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.activityViewModels
+import androidx.fragment.app.viewModels
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
+import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+import com.google.android.material.button.MaterialButton
+import com.google.android.material.card.MaterialCardView
+import com.google.android.material.chip.Chip
+import com.google.android.material.textfield.TextInputEditText
+import com.opensource.i2pradio.R
+import com.opensource.i2pradio.RadioService
+import com.opensource.i2pradio.data.radiobrowser.RadioBrowserRepository
+import com.opensource.i2pradio.data.radiobrowser.RadioBrowserStation
+import com.opensource.i2pradio.ui.RadioViewModel
+
+/**
+ * Fragment for browsing and searching RadioBrowser stations.
+ */
+class BrowseStationsFragment : Fragment() {
+
+    private lateinit var recyclerView: RecyclerView
+    private lateinit var swipeRefresh: SwipeRefreshLayout
+    private lateinit var loadingContainer: FrameLayout
+    private lateinit var emptyStateContainer: LinearLayout
+    private lateinit var torWarningBanner: MaterialCardView
+    private lateinit var searchInput: TextInputEditText
+    private lateinit var chipTopVoted: Chip
+    private lateinit var chipPopular: Chip
+    private lateinit var chipRecent: Chip
+    private lateinit var countryFilterButton: MaterialButton
+    private lateinit var genreFilterButton: MaterialButton
+    private lateinit var adapter: BrowseStationsAdapter
+
+    private val viewModel: BrowseViewModel by viewModels()
+    private val radioViewModel: RadioViewModel by activityViewModels()
+    private lateinit var repository: RadioBrowserRepository
+
+    private var searchDebounceRunnable: Runnable? = null
+    private val searchDebounceDelay = 500L
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        val view = inflater.inflate(R.layout.fragment_browse_stations, container, false)
+
+        repository = RadioBrowserRepository(requireContext())
+
+        // Find views
+        recyclerView = view.findViewById(R.id.stationsRecyclerView)
+        swipeRefresh = view.findViewById(R.id.swipeRefresh)
+        loadingContainer = view.findViewById(R.id.loadingContainer)
+        emptyStateContainer = view.findViewById(R.id.emptyStateContainer)
+        torWarningBanner = view.findViewById(R.id.torWarningBanner)
+        searchInput = view.findViewById(R.id.searchInput)
+        chipTopVoted = view.findViewById(R.id.chipTopVoted)
+        chipPopular = view.findViewById(R.id.chipPopular)
+        chipRecent = view.findViewById(R.id.chipRecent)
+        countryFilterButton = view.findViewById(R.id.countryFilterButton)
+        genreFilterButton = view.findViewById(R.id.genreFilterButton)
+
+        setupRecyclerView()
+        setupSearch()
+        setupChips()
+        setupFilters()
+        setupSwipeRefresh()
+        observeViewModel()
+
+        return view
+    }
+
+    private fun setupRecyclerView() {
+        adapter = BrowseStationsAdapter(
+            onStationClick = { station -> playStation(station) },
+            onAddClick = { station -> saveStation(station) }
+        )
+        recyclerView.adapter = adapter
+        recyclerView.layoutManager = LinearLayoutManager(requireContext())
+
+        // Pagination - load more when scrolling near bottom
+        recyclerView.addOnScrollListener(object : RecyclerView.OnScrollListener() {
+            override fun onScrolled(recyclerView: RecyclerView, dx: Int, dy: Int) {
+                super.onScrolled(recyclerView, dx, dy)
+                val layoutManager = recyclerView.layoutManager as LinearLayoutManager
+                val totalItemCount = layoutManager.itemCount
+                val lastVisibleItem = layoutManager.findLastVisibleItemPosition()
+
+                if (totalItemCount > 0 && lastVisibleItem >= totalItemCount - 5) {
+                    viewModel.loadMore()
+                }
+            }
+        })
+    }
+
+    private fun setupSearch() {
+        searchInput.addTextChangedListener(object : TextWatcher {
+            override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {}
+            override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {}
+            override fun afterTextChanged(s: Editable?) {
+                // Debounce search
+                searchDebounceRunnable?.let { searchInput.removeCallbacks(it) }
+                searchDebounceRunnable = Runnable {
+                    val query = s?.toString()?.trim() ?: ""
+                    if (query.length >= 2) {
+                        viewModel.search(query)
+                        clearChipSelection()
+                    } else if (query.isEmpty()) {
+                        // Reset to top voted when search is cleared
+                        chipTopVoted.isChecked = true
+                        viewModel.loadTopVoted()
+                    }
+                }
+                searchInput.postDelayed(searchDebounceRunnable!!, searchDebounceDelay)
+            }
+        })
+
+        searchInput.setOnEditorActionListener { _, actionId, _ ->
+            if (actionId == EditorInfo.IME_ACTION_SEARCH) {
+                val query = searchInput.text?.toString()?.trim() ?: ""
+                if (query.isNotEmpty()) {
+                    viewModel.search(query)
+                    clearChipSelection()
+                }
+                searchInput.clearFocus()
+                true
+            } else {
+                false
+            }
+        }
+    }
+
+    private fun setupChips() {
+        chipTopVoted.setOnCheckedChangeListener { _, isChecked ->
+            if (isChecked) {
+                clearSearch()
+                viewModel.loadTopVoted()
+            }
+        }
+
+        chipPopular.setOnCheckedChangeListener { _, isChecked ->
+            if (isChecked) {
+                clearSearch()
+                viewModel.loadTopClicked()
+            }
+        }
+
+        chipRecent.setOnCheckedChangeListener { _, isChecked ->
+            if (isChecked) {
+                clearSearch()
+                viewModel.loadRecentlyChanged()
+            }
+        }
+    }
+
+    private fun setupFilters() {
+        countryFilterButton.setOnClickListener {
+            showCountryFilterDialog()
+        }
+
+        genreFilterButton.setOnClickListener {
+            showGenreFilterDialog()
+        }
+    }
+
+    private fun setupSwipeRefresh() {
+        swipeRefresh.setOnRefreshListener {
+            viewModel.refresh()
+        }
+    }
+
+    private fun observeViewModel() {
+        viewModel.stations.observe(viewLifecycleOwner) { stations ->
+            adapter.submitList(stations)
+            updateEmptyState(stations.isEmpty())
+        }
+
+        viewModel.isLoading.observe(viewLifecycleOwner) { isLoading ->
+            if (isLoading && adapter.itemCount == 0) {
+                loadingContainer.visibility = View.VISIBLE
+            } else {
+                loadingContainer.visibility = View.GONE
+            }
+            swipeRefresh.isRefreshing = isLoading && adapter.itemCount > 0
+        }
+
+        viewModel.errorMessage.observe(viewLifecycleOwner) { error ->
+            error?.let {
+                Toast.makeText(requireContext(), it, Toast.LENGTH_SHORT).show()
+                viewModel.clearError()
+            }
+        }
+
+        viewModel.showTorWarning.observe(viewLifecycleOwner) { showWarning ->
+            torWarningBanner.visibility = if (showWarning) View.VISIBLE else View.GONE
+        }
+
+        viewModel.savedStationUuids.observe(viewLifecycleOwner) { uuids ->
+            adapter.updateSavedUuids(uuids)
+        }
+
+        viewModel.selectedCountry.observe(viewLifecycleOwner) { country ->
+            countryFilterButton.text = country?.name ?: getString(R.string.filter_country)
+        }
+
+        viewModel.selectedTag.observe(viewLifecycleOwner) { tag ->
+            genreFilterButton.text = tag?.name ?: getString(R.string.filter_genre)
+        }
+    }
+
+    private fun updateEmptyState(isEmpty: Boolean) {
+        if (isEmpty && viewModel.isLoading.value != true) {
+            emptyStateContainer.visibility = View.VISIBLE
+            recyclerView.visibility = View.GONE
+        } else {
+            emptyStateContainer.visibility = View.GONE
+            recyclerView.visibility = View.VISIBLE
+        }
+    }
+
+    private fun clearChipSelection() {
+        chipTopVoted.isChecked = false
+        chipPopular.isChecked = false
+        chipRecent.isChecked = false
+    }
+
+    private fun clearSearch() {
+        searchDebounceRunnable?.let { searchInput.removeCallbacks(it) }
+        searchInput.setText("")
+    }
+
+    private fun playStation(station: RadioBrowserStation) {
+        // Convert to RadioStation and play
+        val radioStation = repository.convertToRadioStation(station)
+        radioViewModel.setCurrentStation(radioStation)
+        radioViewModel.setBuffering(true)
+
+        val intent = Intent(requireContext(), RadioService::class.java).apply {
+            action = RadioService.ACTION_PLAY
+            putExtra("stream_url", radioStation.streamUrl)
+            putExtra("station_name", radioStation.name)
+            putExtra("proxy_host", "")
+            putExtra("proxy_port", 0)
+            putExtra("proxy_type", "NONE")
+            putExtra("cover_art_uri", radioStation.coverArtUri)
+        }
+        ContextCompat.startForegroundService(requireContext(), intent)
+    }
+
+    private fun saveStation(station: RadioBrowserStation) {
+        viewModel.saveStation(station)
+        Toast.makeText(
+            requireContext(),
+            getString(R.string.station_saved, station.name),
+            Toast.LENGTH_SHORT
+        ).show()
+    }
+
+    private fun showCountryFilterDialog() {
+        val countries = viewModel.countries.value ?: return
+        if (countries.isEmpty()) {
+            Toast.makeText(requireContext(), R.string.loading_countries, Toast.LENGTH_SHORT).show()
+            return
+        }
+
+        val countryNames = listOf(getString(R.string.filter_all_countries)) +
+                countries.map { "${it.name} (${it.stationCount})" }
+
+        AlertDialog.Builder(requireContext())
+            .setTitle(R.string.select_country)
+            .setItems(countryNames.toTypedArray()) { _, which ->
+                if (which == 0) {
+                    viewModel.filterByCountry(null)
+                    chipTopVoted.isChecked = true
+                } else {
+                    viewModel.filterByCountry(countries[which - 1])
+                    clearChipSelection()
+                    clearSearch()
+                }
+            }
+            .show()
+    }
+
+    private fun showGenreFilterDialog() {
+        val tags = viewModel.tags.value ?: return
+        if (tags.isEmpty()) {
+            Toast.makeText(requireContext(), R.string.loading_genres, Toast.LENGTH_SHORT).show()
+            return
+        }
+
+        val tagNames = listOf(getString(R.string.filter_all_genres)) +
+                tags.map { "${it.name} (${it.stationCount})" }
+
+        AlertDialog.Builder(requireContext())
+            .setTitle(R.string.select_genre)
+            .setItems(tagNames.toTypedArray()) { _, which ->
+                if (which == 0) {
+                    viewModel.filterByTag(null)
+                    chipTopVoted.isChecked = true
+                } else {
+                    viewModel.filterByTag(tags[which - 1])
+                    clearChipSelection()
+                    clearSearch()
+                }
+            }
+            .show()
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        searchDebounceRunnable?.let { searchInput.removeCallbacks(it) }
+    }
+}

--- a/app/src/main/java/com/opensource/i2pradio/ui/browse/BrowseViewModel.kt
+++ b/app/src/main/java/com/opensource/i2pradio/ui/browse/BrowseViewModel.kt
@@ -1,0 +1,349 @@
+package com.opensource.i2pradio.ui.browse
+
+import android.app.Application
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.viewModelScope
+import com.opensource.i2pradio.data.radiobrowser.BrowseCategory
+import com.opensource.i2pradio.data.radiobrowser.CountryInfo
+import com.opensource.i2pradio.data.radiobrowser.RadioBrowserRepository
+import com.opensource.i2pradio.data.radiobrowser.RadioBrowserResult
+import com.opensource.i2pradio.data.radiobrowser.RadioBrowserStation
+import com.opensource.i2pradio.data.radiobrowser.TagInfo
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
+
+/**
+ * ViewModel for the Browse Stations feature.
+ * Manages UI state for searching and browsing RadioBrowser stations.
+ */
+class BrowseViewModel(application: Application) : AndroidViewModel(application) {
+
+    private val repository = RadioBrowserRepository(application)
+
+    // Current browse category
+    private val _currentCategory = MutableLiveData(BrowseCategory.TOP_VOTED)
+    val currentCategory: LiveData<BrowseCategory> = _currentCategory
+
+    // Station list
+    private val _stations = MutableLiveData<List<RadioBrowserStation>>(emptyList())
+    val stations: LiveData<List<RadioBrowserStation>> = _stations
+
+    // Loading state
+    private val _isLoading = MutableLiveData(false)
+    val isLoading: LiveData<Boolean> = _isLoading
+
+    // Error message
+    private val _errorMessage = MutableLiveData<String?>(null)
+    val errorMessage: LiveData<String?> = _errorMessage
+
+    // Tor warning (when Force Tor enabled but not connected)
+    private val _showTorWarning = MutableLiveData(false)
+    val showTorWarning: LiveData<Boolean> = _showTorWarning
+
+    // Search query
+    private val _searchQuery = MutableLiveData("")
+    val searchQuery: LiveData<String> = _searchQuery
+
+    // Selected country for filtering
+    private val _selectedCountry = MutableLiveData<CountryInfo?>(null)
+    val selectedCountry: LiveData<CountryInfo?> = _selectedCountry
+
+    // Selected tag for filtering
+    private val _selectedTag = MutableLiveData<TagInfo?>(null)
+    val selectedTag: LiveData<TagInfo?> = _selectedTag
+
+    // Countries list (for filter dropdown)
+    private val _countries = MutableLiveData<List<CountryInfo>>(emptyList())
+    val countries: LiveData<List<CountryInfo>> = _countries
+
+    // Tags list (for filter dropdown)
+    private val _tags = MutableLiveData<List<TagInfo>>(emptyList())
+    val tags: LiveData<List<TagInfo>> = _tags
+
+    // Pagination
+    private var currentOffset = 0
+    private val pageSize = 50
+    private val _hasMoreResults = MutableLiveData(true)
+    val hasMoreResults: LiveData<Boolean> = _hasMoreResults
+
+    // Track saved station UUIDs for UI state
+    private val _savedStationUuids = MutableLiveData<Set<String>>(emptySet())
+    val savedStationUuids: LiveData<Set<String>> = _savedStationUuids
+
+    // Current search/fetch job for cancellation
+    private var currentJob: Job? = null
+
+    init {
+        // Load initial data
+        loadTopVoted()
+        loadCountries()
+        loadTags()
+    }
+
+    /**
+     * Load top voted stations
+     */
+    fun loadTopVoted() {
+        _currentCategory.value = BrowseCategory.TOP_VOTED
+        currentOffset = 0
+        _stations.value = emptyList()
+        fetchStations()
+    }
+
+    /**
+     * Load top clicked (popular) stations
+     */
+    fun loadTopClicked() {
+        _currentCategory.value = BrowseCategory.TOP_CLICKED
+        currentOffset = 0
+        _stations.value = emptyList()
+        fetchStations()
+    }
+
+    /**
+     * Load recently changed stations
+     */
+    fun loadRecentlyChanged() {
+        _currentCategory.value = BrowseCategory.RECENTLY_CHANGED
+        currentOffset = 0
+        _stations.value = emptyList()
+        fetchStations()
+    }
+
+    /**
+     * Search stations by name
+     */
+    fun search(query: String) {
+        _searchQuery.value = query
+        _currentCategory.value = BrowseCategory.SEARCH
+        currentOffset = 0
+        _stations.value = emptyList()
+        if (query.isNotBlank()) {
+            fetchStations()
+        }
+    }
+
+    /**
+     * Filter by country
+     */
+    fun filterByCountry(country: CountryInfo?) {
+        _selectedCountry.value = country
+        _currentCategory.value = BrowseCategory.BY_COUNTRY
+        currentOffset = 0
+        _stations.value = emptyList()
+        if (country != null) {
+            fetchStations()
+        }
+    }
+
+    /**
+     * Filter by tag/genre
+     */
+    fun filterByTag(tag: TagInfo?) {
+        _selectedTag.value = tag
+        _currentCategory.value = BrowseCategory.BY_TAG
+        currentOffset = 0
+        _stations.value = emptyList()
+        if (tag != null) {
+            fetchStations()
+        }
+    }
+
+    /**
+     * Load more results (pagination)
+     */
+    fun loadMore() {
+        if (_isLoading.value == true || _hasMoreResults.value == false) return
+        currentOffset += pageSize
+        fetchStations(append = true)
+    }
+
+    /**
+     * Refresh current view
+     */
+    fun refresh() {
+        currentOffset = 0
+        _stations.value = emptyList()
+        _errorMessage.value = null
+        fetchStations()
+    }
+
+    /**
+     * Clear error message
+     */
+    fun clearError() {
+        _errorMessage.value = null
+    }
+
+    /**
+     * Check if a station is already saved
+     */
+    suspend fun isStationSaved(uuid: String): Boolean {
+        return repository.isStationSaved(uuid)
+    }
+
+    /**
+     * Save a station to user's library
+     */
+    fun saveStation(station: RadioBrowserStation) {
+        viewModelScope.launch {
+            val id = repository.saveStation(station, asUserStation = true)
+            if (id != null) {
+                // Update saved UUIDs set
+                val current = _savedStationUuids.value.orEmpty().toMutableSet()
+                current.add(station.stationuuid)
+                _savedStationUuids.value = current
+            }
+        }
+    }
+
+    /**
+     * Mark a station as saved (for UI state)
+     */
+    fun markAsSaved(uuid: String) {
+        val current = _savedStationUuids.value.orEmpty().toMutableSet()
+        current.add(uuid)
+        _savedStationUuids.value = current
+    }
+
+    /**
+     * Load countries list
+     */
+    private fun loadCountries() {
+        viewModelScope.launch {
+            when (val result = repository.getCountries()) {
+                is RadioBrowserResult.Success -> {
+                    // Filter to countries with at least 10 stations
+                    _countries.value = result.data.filter { it.stationCount >= 10 }
+                }
+                is RadioBrowserResult.Error -> {
+                    // Silently fail - countries are optional
+                }
+                is RadioBrowserResult.Loading -> {}
+            }
+        }
+    }
+
+    /**
+     * Load tags list
+     */
+    private fun loadTags() {
+        viewModelScope.launch {
+            when (val result = repository.getTags(100)) {
+                is RadioBrowserResult.Success -> {
+                    // Filter to tags with at least 50 stations
+                    _tags.value = result.data.filter { it.stationCount >= 50 }
+                }
+                is RadioBrowserResult.Error -> {
+                    // Silently fail - tags are optional
+                }
+                is RadioBrowserResult.Loading -> {}
+            }
+        }
+    }
+
+    /**
+     * Fetch stations based on current category and filters
+     */
+    private fun fetchStations(append: Boolean = false) {
+        // Check Tor status
+        if (repository.isTorRequiredButNotConnected()) {
+            _showTorWarning.value = true
+            return
+        }
+        _showTorWarning.value = false
+
+        // Cancel previous job
+        currentJob?.cancel()
+
+        currentJob = viewModelScope.launch {
+            _isLoading.value = true
+            _errorMessage.value = null
+
+            val result: RadioBrowserResult<List<RadioBrowserStation>> = when (_currentCategory.value) {
+                BrowseCategory.TOP_VOTED -> {
+                    repository.getTopVoted(pageSize, currentOffset)
+                }
+                BrowseCategory.TOP_CLICKED -> {
+                    repository.getTopClicked(pageSize, currentOffset)
+                }
+                BrowseCategory.RECENTLY_CHANGED -> {
+                    repository.getRecentlyChanged(pageSize, currentOffset)
+                }
+                BrowseCategory.BY_COUNTRY -> {
+                    val country = _selectedCountry.value
+                    if (country != null) {
+                        repository.getByCountryCode(country.iso3166_1, pageSize, currentOffset)
+                    } else {
+                        RadioBrowserResult.Error("No country selected")
+                    }
+                }
+                BrowseCategory.BY_TAG -> {
+                    val tag = _selectedTag.value
+                    if (tag != null) {
+                        repository.getByTag(tag.name, pageSize, currentOffset)
+                    } else {
+                        RadioBrowserResult.Error("No tag selected")
+                    }
+                }
+                BrowseCategory.SEARCH -> {
+                    val query = _searchQuery.value
+                    if (!query.isNullOrBlank()) {
+                        repository.searchByName(query, pageSize, currentOffset)
+                    } else {
+                        RadioBrowserResult.Error("Empty search query")
+                    }
+                }
+                null -> RadioBrowserResult.Error("No category selected")
+            }
+
+            when (result) {
+                is RadioBrowserResult.Success -> {
+                    val newStations = result.data
+                    if (append) {
+                        val current = _stations.value.orEmpty()
+                        _stations.value = current + newStations
+                    } else {
+                        _stations.value = newStations
+                    }
+                    _hasMoreResults.value = newStations.size >= pageSize
+
+                    // Check which stations are already saved
+                    checkSavedStatus(newStations)
+                }
+                is RadioBrowserResult.Error -> {
+                    _errorMessage.value = result.message
+                    _hasMoreResults.value = false
+                }
+                is RadioBrowserResult.Loading -> {
+                    // Already handled by _isLoading
+                }
+            }
+
+            _isLoading.value = false
+        }
+    }
+
+    /**
+     * Check saved status for a list of stations
+     */
+    private suspend fun checkSavedStatus(stations: List<RadioBrowserStation>) {
+        val savedUuids = mutableSetOf<String>()
+        savedUuids.addAll(_savedStationUuids.value.orEmpty())
+
+        for (station in stations) {
+            if (repository.isStationSaved(station.stationuuid)) {
+                savedUuids.add(station.stationuuid)
+            }
+        }
+
+        _savedStationUuids.value = savedUuids
+    }
+
+    override fun onCleared() {
+        super.onCleared()
+        currentJob?.cancel()
+    }
+}

--- a/app/src/main/res/drawable/ic_check.xml
+++ b/app/src/main/res/drawable/ic_check.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorOnSurface">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M9,16.17L4.83,12l-1.42,1.41L9,19 21,7l-1.41,-1.41z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_location.xml
+++ b/app/src/main/res/drawable/ic_location.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorOnSurface">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M12,2C8.13,2 5,5.13 5,9c0,5.25 7,13 7,13s7,-7.75 7,-13c0,-3.87 -3.13,-7 -7,-7zM12,11.5c-1.38,0 -2.5,-1.12 -2.5,-2.5s1.12,-2.5 2.5,-2.5 2.5,1.12 2.5,2.5 -1.12,2.5 -2.5,2.5z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_warning.xml
+++ b/app/src/main/res/drawable/ic_warning.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorOnSurface">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M1,21h22L12,2 1,21zM13,18h-2v-2h2v2zM13,14h-2v-4h2v4z"/>
+</vector>

--- a/app/src/main/res/layout/fragment_browse_stations.xml
+++ b/app/src/main/res/layout/fragment_browse_stations.xml
@@ -1,0 +1,231 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="?attr/colorSurface">
+
+    <!-- Main content area -->
+    <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+        android:id="@+id/swipeRefresh"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_marginTop="168dp">
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/stationsRecyclerView"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:clipToPadding="false"
+            android:paddingBottom="100dp"
+            android:scrollbars="vertical"
+            app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager" />
+
+    </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
+
+    <!-- Header with Search and Filters -->
+    <LinearLayout
+        android:id="@+id/headerContainer"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:background="?attr/colorSurface"
+        android:elevation="2dp">
+
+        <!-- Search Bar -->
+        <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/searchInputLayout"
+            style="@style/Widget.Material3.TextInputLayout.OutlinedBox.Dense"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="12dp"
+            android:layout_marginTop="8dp"
+            app:startIconDrawable="@drawable/ic_search"
+            app:endIconMode="clear_text"
+            app:boxCornerRadiusTopStart="24dp"
+            app:boxCornerRadiusTopEnd="24dp"
+            app:boxCornerRadiusBottomStart="24dp"
+            app:boxCornerRadiusBottomEnd="24dp"
+            android:hint="@string/search_radio_browser">
+
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/searchInput"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:inputType="text"
+                android:imeOptions="actionSearch"
+                android:maxLines="1" />
+
+        </com.google.android.material.textfield.TextInputLayout>
+
+        <!-- Category Chips -->
+        <HorizontalScrollView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:scrollbars="none"
+            android:paddingHorizontal="8dp"
+            android:paddingVertical="8dp">
+
+            <com.google.android.material.chip.ChipGroup
+                android:id="@+id/categoryChips"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                app:singleSelection="true"
+                app:selectionRequired="true">
+
+                <com.google.android.material.chip.Chip
+                    android:id="@+id/chipTopVoted"
+                    style="@style/Widget.Material3.Chip.Filter"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/browse_top_voted"
+                    android:checked="true" />
+
+                <com.google.android.material.chip.Chip
+                    android:id="@+id/chipPopular"
+                    style="@style/Widget.Material3.Chip.Filter"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/browse_popular" />
+
+                <com.google.android.material.chip.Chip
+                    android:id="@+id/chipRecent"
+                    style="@style/Widget.Material3.Chip.Filter"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/browse_recent" />
+
+            </com.google.android.material.chip.ChipGroup>
+
+        </HorizontalScrollView>
+
+        <!-- Filter Row -->
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:paddingHorizontal="8dp"
+            android:paddingBottom="4dp">
+
+            <!-- Country Filter -->
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/countryFilterButton"
+                style="@style/Widget.Material3.Button.TextButton.Icon"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/filter_country"
+                android:textSize="12sp"
+                app:icon="@drawable/ic_location"
+                app:iconSize="18dp" />
+
+            <!-- Genre/Tag Filter -->
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/genreFilterButton"
+                style="@style/Widget.Material3.Button.TextButton.Icon"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/filter_genre"
+                android:textSize="12sp"
+                app:icon="@drawable/ic_filter"
+                app:iconSize="18dp" />
+
+        </LinearLayout>
+
+    </LinearLayout>
+
+    <!-- Loading Indicator -->
+    <FrameLayout
+        android:id="@+id/loadingContainer"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:visibility="gone"
+        android:background="?attr/colorSurface">
+
+        <com.google.android.material.progressindicator.CircularProgressIndicator
+            android:id="@+id/loadingIndicator"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:indeterminate="true" />
+
+    </FrameLayout>
+
+    <!-- Empty State -->
+    <LinearLayout
+        android:id="@+id/emptyStateContainer"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:gravity="center"
+        android:orientation="vertical"
+        android:padding="32dp"
+        android:visibility="gone">
+
+        <ImageView
+            android:id="@+id/emptyStateIcon"
+            android:layout_width="96dp"
+            android:layout_height="96dp"
+            android:alpha="0.3"
+            android:src="@drawable/ic_radio"
+            app:tint="?attr/colorOnSurface" />
+
+        <TextView
+            android:id="@+id/emptyStateTitle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:text="@string/browse_no_results"
+            android:textColor="?attr/colorOnSurface"
+            android:textSize="18sp"
+            android:textStyle="bold" />
+
+        <TextView
+            android:id="@+id/emptyStateMessage"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:gravity="center"
+            android:text="@string/browse_no_results_hint"
+            android:textColor="?attr/colorOnSurfaceVariant"
+            android:textSize="14sp" />
+
+    </LinearLayout>
+
+    <!-- Tor Warning Banner -->
+    <com.google.android.material.card.MaterialCardView
+        android:id="@+id/torWarningBanner"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_gravity="bottom"
+        android:layout_margin="16dp"
+        android:visibility="gone"
+        app:cardBackgroundColor="?attr/colorErrorContainer"
+        app:cardCornerRadius="12dp">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:gravity="center_vertical"
+            android:padding="12dp">
+
+            <ImageView
+                android:layout_width="24dp"
+                android:layout_height="24dp"
+                android:src="@drawable/ic_warning"
+                app:tint="?attr/colorOnErrorContainer" />
+
+            <TextView
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:layout_marginStart="12dp"
+                android:text="@string/tor_required_warning"
+                android:textColor="?attr/colorOnErrorContainer"
+                android:textSize="14sp" />
+
+        </LinearLayout>
+
+    </com.google.android.material.card.MaterialCardView>
+
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/item_browse_station.xml
+++ b/app/src/main/res/layout/item_browse_station.xml
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.google.android.material.card.MaterialCardView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginHorizontal="16dp"
+    android:layout_marginVertical="6dp"
+    android:clickable="true"
+    android:focusable="true"
+    android:foreground="?attr/selectableItemBackground"
+    app:cardBackgroundColor="?attr/colorSurfaceContainerLow"
+    app:cardCornerRadius="24dp"
+    app:cardElevation="2dp"
+    app:strokeWidth="0dp">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:padding="12dp">
+
+        <!-- Station Icon/Favicon -->
+        <com.google.android.material.imageview.ShapeableImageView
+            android:id="@+id/stationIcon"
+            android:layout_width="56dp"
+            android:layout_height="56dp"
+            android:scaleType="centerCrop"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:shapeAppearanceOverlay="@style/ShapeAppearance.Material3.Corner.Medium"
+            tools:src="@drawable/ic_radio" />
+
+        <!-- Station Name -->
+        <TextView
+            android:id="@+id/stationName"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="12dp"
+            android:layout_marginEnd="8dp"
+            android:ellipsize="end"
+            android:maxLines="1"
+            android:textColor="?attr/colorOnSurface"
+            android:textSize="16sp"
+            android:textStyle="bold"
+            app:layout_constraintBottom_toTopOf="@id/stationInfo"
+            app:layout_constraintEnd_toStartOf="@id/actionButton"
+            app:layout_constraintStart_toEndOf="@id/stationIcon"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintVertical_chainStyle="packed"
+            tools:text="BBC World Service" />
+
+        <!-- Station Info (genre, country, quality) -->
+        <TextView
+            android:id="@+id/stationInfo"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="12dp"
+            android:layout_marginTop="2dp"
+            android:layout_marginEnd="8dp"
+            android:ellipsize="end"
+            android:maxLines="1"
+            android:textColor="?attr/colorOnSurfaceVariant"
+            android:textSize="13sp"
+            app:layout_constraintBottom_toTopOf="@id/qualityInfo"
+            app:layout_constraintEnd_toStartOf="@id/actionButton"
+            app:layout_constraintStart_toEndOf="@id/stationIcon"
+            app:layout_constraintTop_toBottomOf="@id/stationName"
+            tools:text="News • United States" />
+
+        <!-- Quality Info (bitrate, codec) -->
+        <TextView
+            android:id="@+id/qualityInfo"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="12dp"
+            android:layout_marginTop="2dp"
+            android:layout_marginEnd="8dp"
+            android:ellipsize="end"
+            android:maxLines="1"
+            android:textColor="?attr/colorOutline"
+            android:textSize="11sp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toStartOf="@id/actionButton"
+            app:layout_constraintStart_toEndOf="@id/stationIcon"
+            app:layout_constraintTop_toBottomOf="@id/stationInfo"
+            tools:text="128kbps MP3" />
+
+        <!-- Action Button (Add/Saved indicator) -->
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/actionButton"
+            style="@style/Widget.Material3.Button.IconButton.Filled.Tonal"
+            android:layout_width="44dp"
+            android:layout_height="44dp"
+            android:contentDescription="Add to library"
+            app:icon="@drawable/ic_add"
+            app:iconSize="24dp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+</com.google.android.material.card.MaterialCardView>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -28,4 +28,23 @@
     <!-- Genre filter -->
     <string name="genre_all">All Genres</string>
     <string name="filter_by_genre">Filter by Genre</string>
+
+    <!-- Browse/Discover Stations -->
+    <string name="tab_browse">Browse</string>
+    <string name="search_radio_browser">Search thousands of stations…</string>
+    <string name="browse_top_voted">Top Voted</string>
+    <string name="browse_popular">Popular</string>
+    <string name="browse_recent">Recent</string>
+    <string name="browse_no_results">No Stations Found</string>
+    <string name="browse_no_results_hint">Try a different search or filter</string>
+    <string name="filter_country">Country</string>
+    <string name="filter_genre">Genre</string>
+    <string name="filter_all_countries">All Countries</string>
+    <string name="filter_all_genres">All Genres</string>
+    <string name="select_country">Select Country</string>
+    <string name="select_genre">Select Genre</string>
+    <string name="loading_countries">Loading countries…</string>
+    <string name="loading_genres">Loading genres…</string>
+    <string name="station_saved">%s added to library</string>
+    <string name="tor_required_warning">Force Tor is enabled but Tor is not connected. Connect to Tor to browse stations.</string>
 </resources>


### PR DESCRIPTION
Integrates RadioBrowser API (radio-browser.info) for discovering radio stations. Implements a hybrid approach with bundled starter stations, on-demand API fetching, and local caching.

Features:
- RadioBrowserClient with Tor proxy support for privacy
- Browse tab with search, country, and genre filters
- Top Voted, Popular, and Recent categories
- Save discovered stations to user's library
- 20 bundled starter stations from various genres
- Database migration v3->v4 with new tracking fields

Technical changes:
- Add RadioBrowserStation model with genre mapping
- Add RadioBrowserRepository with caching logic
- Add BrowseViewModel, Fragment, and Adapter
- Extend RadioStation entity with source tracking fields
- Update DefaultStations to load from bundled JSON asset
- Update MainActivity to include 4-tab navigation

Privacy considerations:
- API requests respect Force Tor settings
- Image loading uses SecureImageLoader for Tor routing
- Stations are clearnet by default (user can add Tor/I2P manually)