### PR TITLE
Add missing SwipeRefreshLayout dependency

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -67,6 +67,9 @@ dependencies {
     // ViewPager2 for tabs
     implementation("androidx.viewpager2:viewpager2:1.0.0")
 
+    // SwipeRefreshLayout for pull-to-refresh
+    implementation("androidx.swiperefreshlayout:swiperefreshlayout:1.1.0")
+
     // Lifecycle
     implementation("androidx.lifecycle:lifecycle-viewmodel-ktx:2.7.0")
     implementation("androidx.lifecycle:lifecycle-livedata-ktx:2.7.0")


### PR DESCRIPTION
BrowseStationsFragment uses SwipeRefreshLayout for pull-to-refresh functionality but the dependency was not declared in build.gradle.kts.