### PR TITLE
Fix browser UI sizing: reduce + button size for better visual balance

### DIFF
--- a/app/src/main/res/layout/item_browse_station.xml
+++ b/app/src/main/res/layout/item_browse_station.xml
@@ -111,8 +111,8 @@
         <com.google.android.material.button.MaterialButton
             android:id="@+id/actionButton"
             style="@style/Widget.Material3.Button.IconButton.Filled.Tonal"
-            android:layout_width="40dp"
-            android:layout_height="40dp"
+            android:layout_width="36dp"
+            android:layout_height="36dp"
             android:contentDescription="Add to library"
             android:insetTop="0dp"
             android:insetBottom="0dp"


### PR DESCRIPTION
Reduced the action button (+ button) size from 40dp to 36dp to create better visual balance with the heart icon. The filled tonal style background made the larger button appear too visually dominant compared to the borderless heart button.