### PR TITLE
Fix RadioBrowserStation constructor calls in MainActivity and NowPlay…

### DIFF
--- a/app/src/main/java/com/opensource/i2pradio/MainActivity.kt
+++ b/app/src/main/java/com/opensource/i2pradio/MainActivity.kt
@@ -272,15 +272,27 @@ class MainActivity : AppCompatActivity() {
                         val radioBrowserStation = com.opensource.i2pradio.data.radiobrowser.RadioBrowserStation(
                             stationuuid = station.radioBrowserUuid,
                             name = station.name,
-                            url_resolved = station.streamUrl,
+                            url = station.streamUrl,
+                            urlResolved = station.streamUrl,
+                            homepage = station.homepage ?: "",
                             favicon = station.coverArtUri ?: "",
                             tags = station.genre,
                             country = station.country ?: "",
                             countrycode = station.countryCode ?: "",
+                            state = "",
+                            language = "",
+                            languagecodes = "",
+                            votes = 0,
+                            lastchangetime = "",
                             codec = station.codec ?: "",
                             bitrate = station.bitrate,
-                            homepage = station.homepage ?: "",
-                            lastcheckok = 1
+                            hls = false,
+                            lastcheckok = true,
+                            clickcount = 0,
+                            clicktrend = 0,
+                            sslError = false,
+                            geoLat = null,
+                            geoLong = null
                         )
                         radioBrowserRepository.saveStationAsLiked(radioBrowserStation)
                     }

--- a/app/src/main/java/com/opensource/i2pradio/ui/NowPlayingFragment.kt
+++ b/app/src/main/java/com/opensource/i2pradio/ui/NowPlayingFragment.kt
@@ -263,15 +263,27 @@ class NowPlayingFragment : Fragment() {
                             val radioBrowserStation = com.opensource.i2pradio.data.radiobrowser.RadioBrowserStation(
                                 stationuuid = station.radioBrowserUuid,
                                 name = station.name,
-                                url_resolved = station.streamUrl,
+                                url = station.streamUrl,
+                                urlResolved = station.streamUrl,
+                                homepage = station.homepage ?: "",
                                 favicon = station.coverArtUri ?: "",
                                 tags = station.genre,
                                 country = station.country ?: "",
                                 countrycode = station.countryCode ?: "",
+                                state = "",
+                                language = "",
+                                languagecodes = "",
+                                votes = 0,
+                                lastchangetime = "",
                                 codec = station.codec ?: "",
                                 bitrate = station.bitrate,
-                                homepage = station.homepage ?: "",
-                                lastcheckok = 1
+                                hls = false,
+                                lastcheckok = true,
+                                clickcount = 0,
+                                clicktrend = 0,
+                                sslError = false,
+                                geoLat = null,
+                                geoLong = null
                             )
                             radioBrowserRepository.saveStationAsLiked(radioBrowserStation)
                         }


### PR DESCRIPTION
…ingFragment

Fixed compilation errors caused by incorrect RadioBrowserStation constructor calls:
- Changed url_resolved to urlResolved (proper camelCase parameter name)
- Added missing required parameters: url, state, language, languagecodes, votes, lastchangetime, hls, clickcount, clicktrend, sslError, geoLat, geoLong
- Changed lastcheckok from Int (1) to Boolean (true)
- Provided sensible defaults for missing required fields