### PR TITLE
Add station removal feature and fix Material You toggle issues

### DIFF
--- a/app/src/main/java/com/opensource/i2pradio/MainActivity.kt
+++ b/app/src/main/java/com/opensource/i2pradio/MainActivity.kt
@@ -87,6 +87,13 @@ class MainActivity : AppCompatActivity() {
             val binder = service as RadioService.RadioBinder
             radioService = binder.getService()
             isServiceBound = true
+
+            // After reconnecting, update ViewModel with current playback state
+            // This ensures UI is synchronized after activity recreation (e.g., Material You toggle)
+            radioService?.let { service ->
+                viewModel.setPlaying(service.isPlaying())
+                viewModel.setBuffering(service.isBuffering())
+            }
         }
 
         override fun onServiceDisconnected(name: ComponentName?) {

--- a/app/src/main/java/com/opensource/i2pradio/RadioService.kt
+++ b/app/src/main/java/com/opensource/i2pradio/RadioService.kt
@@ -1818,6 +1818,16 @@ class RadioService : Service() {
     fun getPlayerVolume(): Float = player?.volume ?: 1f
 
     /**
+     * Check if the player is currently playing
+     */
+    fun isPlaying(): Boolean = player?.isPlaying == true
+
+    /**
+     * Check if the player is currently buffering
+     */
+    fun isBuffering(): Boolean = player?.playbackState == Player.STATE_BUFFERING
+
+    /**
      * Broadcast audio session open to allow equalizer apps to attach.
      * This follows the standard Android audio effect protocol.
      */

--- a/app/src/main/java/com/opensource/i2pradio/data/radiobrowser/RadioBrowserRepository.kt
+++ b/app/src/main/java/com/opensource/i2pradio/data/radiobrowser/RadioBrowserRepository.kt
@@ -276,4 +276,22 @@ class RadioBrowserRepository(context: Context) {
             radioDao.updateLastVerified(stationId, System.currentTimeMillis())
         }
     }
+
+    /**
+     * Delete a station by its RadioBrowser UUID
+     * @return true if station was found and deleted, false otherwise
+     */
+    suspend fun deleteStationByUuid(radioBrowserUuid: String): Boolean {
+        return withContext(Dispatchers.IO) {
+            val station = radioDao.getStationByRadioBrowserUuid(radioBrowserUuid)
+            if (station != null) {
+                radioDao.deleteStation(station)
+                Log.d(TAG, "Deleted station: ${station.name}")
+                true
+            } else {
+                Log.d(TAG, "Station not found for deletion: $radioBrowserUuid")
+                false
+            }
+        }
+    }
 }

--- a/app/src/main/java/com/opensource/i2pradio/ui/browse/BrowseStationsAdapter.kt
+++ b/app/src/main/java/com/opensource/i2pradio/ui/browse/BrowseStationsAdapter.kt
@@ -20,6 +20,7 @@ import com.opensource.i2pradio.util.loadSecure
 class BrowseStationsAdapter(
     private val onStationClick: (RadioBrowserStation) -> Unit,
     private val onAddClick: (RadioBrowserStation) -> Unit,
+    private val onRemoveClick: (RadioBrowserStation) -> Unit,
     private val onLikeClick: (RadioBrowserStation) -> Unit
 ) : RecyclerView.Adapter<BrowseStationsAdapter.ViewHolder>() {
 
@@ -183,22 +184,18 @@ class BrowseStationsAdapter(
             }
 
             actionButton.setOnClickListener {
-                if (!savedUuids.contains(station.stationuuid)) {
+                if (savedUuids.contains(station.stationuuid)) {
+                    onRemoveClick(station)
+                } else {
                     onAddClick(station)
                 }
             }
         }
 
         fun updateSavedStatus(isSaved: Boolean) {
-            if (isSaved) {
-                actionButton.setIconResource(R.drawable.ic_check)
-                actionButton.isEnabled = false
-                actionButton.alpha = 0.6f
-            } else {
-                actionButton.setIconResource(R.drawable.ic_add)
-                actionButton.isEnabled = true
-                actionButton.alpha = 1f
-            }
+            actionButton.setIconResource(if (isSaved) R.drawable.ic_check else R.drawable.ic_add)
+            actionButton.isEnabled = true
+            actionButton.alpha = 1f
         }
 
         fun updateLikedStatus(isLiked: Boolean) {

--- a/app/src/main/java/com/opensource/i2pradio/ui/browse/BrowseStationsFragment.kt
+++ b/app/src/main/java/com/opensource/i2pradio/ui/browse/BrowseStationsFragment.kt
@@ -93,6 +93,7 @@ class BrowseStationsFragment : Fragment() {
         adapter = BrowseStationsAdapter(
             onStationClick = { station -> playStation(station) },
             onAddClick = { station -> saveStation(station) },
+            onRemoveClick = { station -> removeStation(station) },
             onLikeClick = { station -> likeStation(station) }
         )
         recyclerView.adapter = adapter
@@ -300,6 +301,15 @@ class BrowseStationsFragment : Fragment() {
         Toast.makeText(
             requireContext(),
             getString(R.string.station_saved, station.name),
+            Toast.LENGTH_SHORT
+        ).show()
+    }
+
+    private fun removeStation(station: RadioBrowserStation) {
+        viewModel.removeStation(station)
+        Toast.makeText(
+            requireContext(),
+            getString(R.string.station_removed, station.name),
             Toast.LENGTH_SHORT
         ).show()
     }

--- a/app/src/main/java/com/opensource/i2pradio/ui/browse/BrowseViewModel.kt
+++ b/app/src/main/java/com/opensource/i2pradio/ui/browse/BrowseViewModel.kt
@@ -266,6 +266,25 @@ class BrowseViewModel(application: Application) : AndroidViewModel(application) 
     }
 
     /**
+     * Remove a station from user's library
+     */
+    fun removeStation(station: RadioBrowserStation) {
+        viewModelScope.launch {
+            val deleted = repository.deleteStationByUuid(station.stationuuid)
+            if (deleted) {
+                // Update saved and liked UUIDs sets
+                val savedCurrent = _savedStationUuids.value.orEmpty().toMutableSet()
+                savedCurrent.remove(station.stationuuid)
+                _savedStationUuids.value = savedCurrent
+
+                val likedCurrent = _likedStationUuids.value.orEmpty().toMutableSet()
+                likedCurrent.remove(station.stationuuid)
+                _likedStationUuids.value = likedCurrent
+            }
+        }
+    }
+
+    /**
      * Load countries list
      */
     private fun loadCountries() {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -46,5 +46,6 @@
     <string name="loading_countries">Loading countries…</string>
     <string name="loading_genres">Loading genres…</string>
     <string name="station_saved">%s added to library</string>
+    <string name="station_removed">%s removed from library</string>
     <string name="tor_required_warning">Force Tor is enabled but Tor is not connected. Connect to Tor to browse stations.</string>
 </resources>


### PR DESCRIPTION
Features:
- Add ability to remove stations from library by clicking checkmark in browse tab
- Checkmark now toggles between add (+) and remove (✓) states
- Toast notification shows when station is removed from library

Bug Fixes:
- Fix Material You toggle causing playback buffer display to disappear
- RadioService now exposes isPlaying() and isBuffering() methods
- MainActivity syncs playback state when service reconnects after activity recreation

Code Quality:
- Simplify updateSavedStatus() in BrowseStationsAdapter (remove redundant code)
- Add deleteStationByUuid() method to RadioBrowserRepository
- Add removeStation() method to BrowseViewModel
