### PR TITLE
Fix memory leaks and Material You toggle issues

### DIFF
--- a/app/src/main/java/com/opensource/i2pradio/ui/MiniPlayerView.kt
+++ b/app/src/main/java/com/opensource/i2pradio/ui/MiniPlayerView.kt
@@ -123,8 +123,13 @@ class MiniPlayerView @JvmOverloads constructor(
                 error(R.drawable.ic_radio)
             }
         } else {
+            // Force reload to get fresh drawable with current theme colors (Material You)
+            coverImage.setImageDrawable(null)
             coverImage.load(R.drawable.ic_radio) {
                 crossfade(true)
+                // Disable all caching to force fresh drawable with current theme
+                memoryCachePolicy(CachePolicy.DISABLED)
+                diskCachePolicy(CachePolicy.DISABLED)
             }
         }
         // Update the current station's cover art reference
@@ -186,13 +191,18 @@ class MiniPlayerView @JvmOverloads constructor(
             }
         } else {
             // Explicitly clear any cached/loading state and set default drawable
+            // Force reload to get fresh drawable with current theme colors (Material You)
+            coverImage.setImageDrawable(null)
             coverImage.load(R.drawable.ic_radio) {
                 crossfade(true)
+                // Disable all caching to force fresh drawable with current theme
+                memoryCachePolicy(CachePolicy.DISABLED)
+                diskCachePolicy(CachePolicy.DISABLED)
             }
         }
 
-        // Show loading indicator when a new station is set (buffering will start)
-        progressIndicator.visibility = VISIBLE
+        // Don't change progress indicator visibility here - let setBufferingState() handle it
+        // The RadioService will broadcast buffering state which will properly show/hide the indicator
     }
 
     fun setPlayingState(playing: Boolean) {


### PR DESCRIPTION
Memory Leak Fixes:
- Add OkHttpClient resource cleanup in RadioService
- Store OkHttpClient instance and properly shutdown dispatcher
- Evict all connections and close cache on stopStream()
- Prevents "resource failed to call release" warnings

Miniplayer Loading Animation:
- Remove unconditional progress indicator visibility in setStation()
- Let setBufferingState() control visibility via service broadcasts
- Fixes missing loading animation for Tor radios

Material You Toggle Fixes:
1. Buffer bar disappearing:
   - Sync UI state with service in NowPlayingFragment.onServiceConnected()
   - Query service state after activity recreation
   - Update buffer bar visibility based on playing state

2. Cover art sizing:
   - Set scaleType early to CENTER_CROP for actual images
   - Prevents small square centered image after theme change

3. Default icon color:
   - Force reload ic_radio drawable with cache disabled
   - Clear ImageView before loading to get fresh theme colors
   - Applied to both NowPlayingFragment and MiniPlayerView
   - Ensures Material You colors update immediately