### PR TITLE
Fix build errors in RadiosFragment and BrowseStationsFragment

### DIFF
--- a/app/src/main/java/com/opensource/i2pradio/ui/RadiosFragment.kt
+++ b/app/src/main/java/com/opensource/i2pradio/ui/RadiosFragment.kt
@@ -13,12 +13,14 @@ import android.view.ViewGroup
 import android.view.animation.DecelerateInterpolator
 import android.view.inputmethod.EditorInfo
 import android.widget.ImageView
+import android.widget.LinearLayout
 import android.widget.PopupMenu
 import android.widget.TextView
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.LiveData
 import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import coil.request.Disposable
 import com.opensource.i2pradio.util.loadSecure

--- a/app/src/main/java/com/opensource/i2pradio/ui/browse/BrowseStationsFragment.kt
+++ b/app/src/main/java/com/opensource/i2pradio/ui/browse/BrowseStationsFragment.kt
@@ -269,7 +269,7 @@ class BrowseStationsFragment : Fragment() {
     private fun clearChipSelection() {
         chipTopVoted.isChecked = false
         chipPopular.isChecked = false
-        chipRecent.isChecked = false
+        chipHistory.isChecked = false
     }
 
     private fun clearSearch() {


### PR DESCRIPTION
- Add missing import for android.widget.LinearLayout in RadiosFragment.kt
- Add missing import for androidx.recyclerview.widget.LinearLayoutManager in RadiosFragment.kt
- Fix chipRecent reference to chipHistory in BrowseStationsFragment.kt

Resolves all 21 compilation errors related to unresolved references and type inference issues.