### PR TITLE
Fix crash and privacy leak in proxy routing

### DIFF
--- a/app/src/main/java/com/opensource/i2pradio/ui/RadiosFragment.kt
+++ b/app/src/main/java/com/opensource/i2pradio/ui/RadiosFragment.kt
@@ -335,8 +335,8 @@ class RadiosFragment : Fragment() {
         }
 
         inner class ViewHolder(view: View) : RecyclerView.ViewHolder(view) {
-            val textView: TextView = view.findViewById(android.R.id.text1)
-            val radioButton: android.widget.RadioButton = view.findViewById(R.id.radio_button)
+            val textView: TextView? = view.findViewById(android.R.id.text1)
+            val radioButton: android.widget.RadioButton? = view.findViewById(R.id.radio_button)
         }
 
         override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
@@ -348,8 +348,8 @@ class RadiosFragment : Fragment() {
 
         override fun onBindViewHolder(holder: ViewHolder, position: Int) {
             val genre = genres[position]
-            holder.textView.text = genre
-            holder.radioButton.isChecked = position == selectedPosition
+            holder.textView?.text = genre
+            holder.radioButton?.isChecked = position == selectedPosition
 
             holder.itemView.setOnClickListener {
                 selectedPosition = position


### PR DESCRIPTION
Bug fixes:
1. Fix NullPointerException crash in GenreAdapter ViewHolder
   - Made TextView and RadioButton nullable to handle layout mismatches
   - Prevents app crashes when findViewById returns null
   - Crash occurred at RadiosFragment.kt:339

2. Fix privacy leak when proxy settings change
   - Stop playback immediately when Force Tor switches change
   - Prevents streams from continuing with old routing settings
   - Example: I2P stream continuing through I2P when user switches to "Force Tor All"
   - Stream now stops when proxy routing changes, requiring user to restart with new settings

Security impact:
When users change proxy routing preferences (Force Tor All / Force Tor Except I2P), the current stream was continuing to use the OLD routing, potentially violating the user's privacy expectations. This fix ensures streams stop immediately when routing preferences change, requiring the user to restart playback with the new routing.