### PR TITLE
Fix stale metadata and Tor UI flickering during Material You toggle

### DIFF
--- a/app/src/main/java/com/opensource/i2pradio/RadioService.kt
+++ b/app/src/main/java/com/opensource/i2pradio/RadioService.kt
@@ -1600,6 +1600,13 @@ class RadioService : Service() {
         reconnectRunnable?.let { handler.removeCallbacks(it) }
         reconnectRunnable = null
 
+        // Clear metadata, bitrate, and codec when stopping stream
+        // This prevents stale metadata from appearing when switching stations
+        // or when the UI is recreated (e.g., Material You toggle)
+        currentMetadata = null
+        currentBitrate = 0
+        currentCodec = null
+
         // Broadcast audio session close before releasing player
         player?.audioSessionId?.let { sessionId ->
             if (sessionId != 0) {

--- a/app/src/main/java/com/opensource/i2pradio/ui/NowPlayingFragment.kt
+++ b/app/src/main/java/com/opensource/i2pradio/ui/NowPlayingFragment.kt
@@ -109,18 +109,22 @@ class NowPlayingFragment : Fragment() {
                 // Update buffer bar visibility based on playing state
                 updateBufferBarVisibility(isPlaying)
 
-                // Restore metadata if available
-                val metadata = svc.getCurrentMetadata()
-                if (!metadata.isNullOrBlank()) {
-                    metadataText.text = metadata
-                    metadataText.visibility = View.VISIBLE
-                }
+                // Only restore metadata if we're currently playing
+                // This prevents stale metadata from previous stations appearing
+                // when the activity is recreated (e.g., Material You toggle)
+                if (isPlaying) {
+                    val metadata = svc.getCurrentMetadata()
+                    if (!metadata.isNullOrBlank()) {
+                        metadataText.text = metadata
+                        metadataText.visibility = View.VISIBLE
+                    }
 
-                // Restore stream info if available
-                val bitrate = svc.getCurrentBitrate()
-                val codec = svc.getCurrentCodec()
-                if (bitrate > 0 || (!codec.isNullOrBlank() && codec != "Unknown")) {
-                    updateStreamInfo(bitrate, codec ?: "Unknown")
+                    // Restore stream info if available
+                    val bitrate = svc.getCurrentBitrate()
+                    val codec = svc.getCurrentCodec()
+                    if (bitrate > 0 || (!codec.isNullOrBlank() && codec != "Unknown")) {
+                        updateStreamInfo(bitrate, codec ?: "Unknown")
+                    }
                 }
 
                 // Sync ViewModel state if needed

--- a/app/src/main/java/com/opensource/i2pradio/ui/SettingsFragment.kt
+++ b/app/src/main/java/com/opensource/i2pradio/ui/SettingsFragment.kt
@@ -415,8 +415,11 @@ class SettingsFragment : Fragment() {
             }
         }
 
-        // Update initial Tor status
-        updateTorStatusUI(TorManager.state)
+        // Update initial Tor status using the debounced path to prevent flickering
+        // during rapid state transitions (e.g., Material You toggle activity recreation)
+        // This ensures the UI only updates once instead of twice (here + listener firing)
+        pendingTorState = TorManager.state
+        torUiUpdateHandler.postDelayed(torUiUpdateRunnable, 200)
 
         // Handle switch toggle
         embeddedTorSwitch?.setOnCheckedChangeListener { switch, isChecked ->


### PR DESCRIPTION
Fixes two bugs that occur when toggling Material You in settings:

1. **Stale metadata bug**: Song metadata from previous station displays incorrectly when switching to a station without metadata
   - Clear metadata/bitrate/codec in stopStream() to prevent stale data
   - Only restore metadata in NowPlayingFragment if currently playing
   - Prevents wrong song titles showing after Material You toggle

2. **Tor UI flicker bug**: Tor status button and SOCKS port text flicker briefly during Material You toggle (activity recreation)
   - Use debounced update path for initial Tor status in setupTorControls
   - Prevents double UI update (direct + listener firing)
   - Ensures smooth UI during theme changes

Both fixes ensure consistent, flicker-free UI behavior during settings changes and activity recreation.