### PR TITLE
Fix multiple bugs: N+1 query, unscoped coroutines, and edge cases

### DIFF
--- a/app/src/main/java/com/opensource/i2pradio/data/RadioDao.kt
+++ b/app/src/main/java/com/opensource/i2pradio/data/RadioDao.kt
@@ -109,4 +109,8 @@ interface RadioDao {
     // Update cached station's verification timestamp
     @Query("UPDATE radio_stations SET lastVerified = :timestamp WHERE id = :id")
     suspend fun updateLastVerified(id: Long, timestamp: Long)
+
+    // Get multiple stations by RadioBrowser UUIDs (batch query to avoid N+1 problem)
+    @Query("SELECT * FROM radio_stations WHERE radioBrowserUuid IN (:uuids)")
+    suspend fun getStationsByRadioBrowserUuids(uuids: List<String>): List<RadioStation>
 }

--- a/app/src/main/java/com/opensource/i2pradio/data/radiobrowser/RadioBrowserRepository.kt
+++ b/app/src/main/java/com/opensource/i2pradio/data/radiobrowser/RadioBrowserRepository.kt
@@ -138,6 +138,22 @@ class RadioBrowserRepository(context: Context) {
     }
 
     /**
+     * Get station info for multiple RadioBrowser UUIDs at once (batch query)
+     * Returns a map of UUID -> RadioStation for efficient lookup
+     */
+    suspend fun getStationInfoByUuids(radioBrowserUuids: List<String>): Map<String, RadioStation> {
+        return withContext(Dispatchers.IO) {
+            if (radioBrowserUuids.isEmpty()) {
+                return@withContext emptyMap()
+            }
+            val stations = radioDao.getStationsByRadioBrowserUuids(radioBrowserUuids)
+            // Filter out stations with null or empty UUIDs to avoid key collisions
+            stations.filter { !it.radioBrowserUuid.isNullOrEmpty() }
+                .associateBy { it.radioBrowserUuid!! }
+        }
+    }
+
+    /**
      * Toggle like status for a station by its RadioBrowser UUID
      */
     suspend fun toggleLikeByUuid(radioBrowserUuid: String) {


### PR DESCRIPTION
Bug #13: Fix N+1 query problem in BrowseViewModel
- Add batch query method in RadioDao to fetch multiple stations by UUID at once
- Implement getStationInfoByUuids() in RadioBrowserRepository
- Replace loop with single batch query in checkSavedStatus()
- Reduces database queries from N+1 to 1 for station status checks

Bug #14: Fix unscoped coroutines in SettingsFragment
- Replace CoroutineScope(Dispatchers.IO) with lifecycleScope
- Ensures coroutines are cancelled when Fragment is destroyed
- Fixes potential memory leaks in import/export operations

Bug #15: Fix race condition in BrowseViewModel.likeStation()
- Remove misleading Long? return type that always returned null
- Function now properly fire-and-forget with no return value
- Simplifies API and eliminates race condition

Bugs #16-17: Fix unsafe context usage in async operations
- Capture context early before async operations in SettingsFragment
- Add isAdded checks before using requireContext() after async work
- Prevents crashes when Fragment is destroyed during import/export

Bug #18: Fix null UUID handling in batch query
- Filter out null/empty UUIDs in getStationInfoByUuids()
- Prevents key collisions in associateBy map creation
- Ensures robust handling of edge cases