### PR TITLE
Fix heart button toast notifications across all views

### DIFF
--- a/app/src/main/java/com/opensource/i2pradio/MainActivity.kt
+++ b/app/src/main/java/com/opensource/i2pradio/MainActivity.kt
@@ -311,11 +311,17 @@ class MainActivity : AppCompatActivity() {
                         updatedStation?.let {
                             miniPlayerView.updateLikeState(it.isLiked)
                             viewModel.updateCurrentStationLikeState(it.isLiked)
-                            // Show toast message when station is liked
+                            // Show toast message for both like and unlike
                             if (it.isLiked) {
                                 Toast.makeText(
                                     this@MainActivity,
                                     getString(R.string.station_saved, station.name),
+                                    Toast.LENGTH_SHORT
+                                ).show()
+                            } else {
+                                Toast.makeText(
+                                    this@MainActivity,
+                                    getString(R.string.station_removed, station.name),
                                     Toast.LENGTH_SHORT
                                 ).show()
                             }
@@ -329,11 +335,17 @@ class MainActivity : AppCompatActivity() {
                         updatedStation?.let {
                             miniPlayerView.updateLikeState(it.isLiked)
                             viewModel.updateCurrentStationLikeState(it.isLiked)
-                            // Show toast message when station is liked
+                            // Show toast message for both like and unlike
                             if (it.isLiked) {
                                 Toast.makeText(
                                     this@MainActivity,
                                     getString(R.string.station_saved, station.name),
+                                    Toast.LENGTH_SHORT
+                                ).show()
+                            } else {
+                                Toast.makeText(
+                                    this@MainActivity,
+                                    getString(R.string.station_removed, station.name),
                                     Toast.LENGTH_SHORT
                                 ).show()
                             }

--- a/app/src/main/java/com/opensource/i2pradio/ui/LibraryFragment.kt
+++ b/app/src/main/java/com/opensource/i2pradio/ui/LibraryFragment.kt
@@ -419,11 +419,17 @@ class LibraryFragment : Fragment() {
                     if (viewModel.getCurrentStation()?.id == it.id) {
                         viewModel.updateCurrentStationLikeState(it.isLiked)
                     }
-                    // Show toast message when station is liked
+                    // Show toast message for both like and unlike
                     if (it.isLiked) {
                         Toast.makeText(
                             requireContext(),
                             getString(R.string.station_saved, station.name),
+                            Toast.LENGTH_SHORT
+                        ).show()
+                    } else {
+                        Toast.makeText(
+                            requireContext(),
+                            getString(R.string.station_removed, station.name),
                             Toast.LENGTH_SHORT
                         ).show()
                     }

--- a/app/src/main/java/com/opensource/i2pradio/ui/NowPlayingFragment.kt
+++ b/app/src/main/java/com/opensource/i2pradio/ui/NowPlayingFragment.kt
@@ -334,6 +334,20 @@ class NowPlayingFragment : Fragment() {
                             updatedStation?.let {
                                 viewModel.updateCurrentStationLikeState(it.isLiked)
                                 updateLikeButton(it.isLiked)
+                                // Show toast message
+                                if (it.isLiked) {
+                                    Toast.makeText(
+                                        requireContext(),
+                                        getString(R.string.station_saved, station.name),
+                                        Toast.LENGTH_SHORT
+                                    ).show()
+                                } else {
+                                    Toast.makeText(
+                                        requireContext(),
+                                        getString(R.string.station_removed, station.name),
+                                        Toast.LENGTH_SHORT
+                                    ).show()
+                                }
                             }
                         }
                     } else {
@@ -344,6 +358,20 @@ class NowPlayingFragment : Fragment() {
                             updatedStation?.let {
                                 viewModel.updateCurrentStationLikeState(it.isLiked)
                                 updateLikeButton(it.isLiked)
+                                // Show toast message
+                                if (it.isLiked) {
+                                    Toast.makeText(
+                                        requireContext(),
+                                        getString(R.string.station_saved, station.name),
+                                        Toast.LENGTH_SHORT
+                                    ).show()
+                                } else {
+                                    Toast.makeText(
+                                        requireContext(),
+                                        getString(R.string.station_removed, station.name),
+                                        Toast.LENGTH_SHORT
+                                    ).show()
+                                }
                             }
                         }
                     }

--- a/app/src/main/java/com/opensource/i2pradio/ui/browse/BrowseStationsFragment.kt
+++ b/app/src/main/java/com/opensource/i2pradio/ui/browse/BrowseStationsFragment.kt
@@ -320,11 +320,17 @@ class BrowseStationsFragment : Fragment() {
         lifecycleScope.launch {
             val updatedStation = repository.getStationInfoByUuid(station.stationuuid)
             updatedStation?.let {
-                // Show toast message when station is liked
+                // Show toast message for both like and unlike
                 if (it.isLiked) {
                     Toast.makeText(
                         requireContext(),
                         getString(R.string.station_saved, station.name),
+                        Toast.LENGTH_SHORT
+                    ).show()
+                } else {
+                    Toast.makeText(
+                        requireContext(),
+                        getString(R.string.station_removed, station.name),
                         Toast.LENGTH_SHORT
                     ).show()
                 }


### PR DESCRIPTION
Fixes missing and incorrect toast messages for the heart (like/unlike) button:
- Now Playing view: Added toasts for both like and unlike actions
- Browse section: Added toast for unlike action (was only showing for like)
- Mini Player: Added toast for unlike action (was only showing for like)
- Library: Added toast for unlike action (was only showing for like)

All heart buttons now consistently show "added to library" when hearted and "removed from library" when unhearted, matching the behavior of the "+" button.