### PR TITLE
Fix Material You theming for app icon hole and grates

### DIFF
--- a/app/src/main/res/drawable/ic_launcher_monochrome.xml
+++ b/app/src/main/res/drawable/ic_launcher_monochrome.xml
@@ -30,13 +30,13 @@
 
     <!-- The Speaker (Circle Cutout) -->
     <path
-        android:fillColor="#FFFFFF"
+        android:fillColor="#00000000"
         android:pathData="M62.25,60.875 m-7.7,0 a7.7,7.7 0 1,1 15.4,0 a7.7,7.7 0 1,1 -15.4,0"/>
 
     <!-- The Speaker Grill (Lines) -->
     <path
         android:fillColor="#00000000"
-        android:strokeColor="#FFFFFF"
+        android:strokeColor="#00000000"
         android:strokeWidth="3.85"
         android:strokeLineCap="round"
         android:pathData="M38.875,55.375 h9.625 M38.875,60.875 h9.625 M38.875,66.375 h9.625"/>


### PR DESCRIPTION
Changed speaker hole and grill lines from white to transparent in monochrome drawable so they appear as cutouts with different colors when Material You theme is applied.