### PR TITLE
Update monochrome app icon for Material You support

### DIFF
--- a/app/src/main/res/drawable/ic_launcher_monochrome.xml
+++ b/app/src/main/res/drawable/ic_launcher_monochrome.xml
@@ -1,44 +1,31 @@
 <?xml version="1.0" encoding="utf-8"?>
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="108dp"
-    android:height="108dp"
-    android:viewportWidth="108"
-    android:viewportHeight="108">
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
 
-    <!--
-    Monochrome version for Material You themed icons (Android 13+)
-    Matches the foreground design with single-color rendering
-    -->
-
-    <!-- The Antenna (Stick) -->
+    <!-- Antenna Stick -->
     <path
-        android:fillColor="#00000000"
         android:strokeColor="#000000"
-        android:strokeWidth="4.125"
+        android:strokeWidth="1.5"
         android:strokeLineCap="round"
-        android:pathData="M56.75,45.75 L73.25,34.2"/>
+        android:pathData="M13,9 L19,4.8"/>
 
-    <!-- The Antenna (Ball Tip) -->
+    <!-- Antenna Ball -->
     <path
         android:fillColor="#000000"
-        android:pathData="M76,32.275 m-3.575,0 a3.575,3.575 0 1,1 7.15,0 a3.575,3.575 0 1,1 -7.15,0"/>
+        android:pathData="M20,4.1 m-1.3,0 a1.3,1.3 0 1,1 2.6,0 a1.3,1.3 0 1,1 -2.6,0"/>
 
-    <!-- The Main Radio Body -->
+    <!-- Radio Body with Speaker Hole + Grill Line Cutouts -->
     <path
         android:fillColor="#000000"
-        android:pathData="M40.25,45.75 h27.5 c4.565,0 8.25,3.685 8.25,8.25 v13.75 c0,4.565 -3.685,8.25 -8.25,8.25 h-27.5 c-4.565,0 -8.25,-3.685 -8.25,-8.25 v-13.75 c0,-4.565 3.685,-8.25 8.25,-8.25 z"/>
-
-    <!-- The Speaker (Circle Cutout) -->
-    <path
-        android:fillColor="#00000000"
-        android:pathData="M62.25,60.875 m-7.7,0 a7.7,7.7 0 1,1 15.4,0 a7.7,7.7 0 1,1 -15.4,0"/>
-
-    <!-- The Speaker Grill (Lines) -->
-    <path
-        android:fillColor="#00000000"
-        android:strokeColor="#00000000"
-        android:strokeWidth="3.85"
-        android:strokeLineCap="round"
-        android:pathData="M38.875,55.375 h9.625 M38.875,60.875 h9.625 M38.875,66.375 h9.625"/>
+        android:fillType="evenOdd"
+        android:pathData="
+            M7,9h10c1.66,0 3,1.34 3,3v5c0,1.66 -1.34,3 -3,3h-10c-1.66,0 -3,-1.34 -3,-3v-5c0,-1.66 1.34,-3 3,-3z
+            M15,11.7a2.8,2.8 0 1,0 0,5.6a2.8,2.8 0 1,0 0,-5.6z
+            M6.5,11.8 h3.5 a0.7,0.7,0,0,1,0,1.4 h-3.5 a0.7,0.7,0,0,1,0,-1.4z
+            M6.5,13.8 h3.5 a0.7,0.7,0,0,1,0,1.4 h-3.5 a0.7,0.7,0,0,1,0,-1.4z
+            M6.5,15.8 h3.5 a0.7,0.7,0,0,1,0,1.4 h-3.5 a0.7,0.7,0,0,1,0,-1.4z"/>
 
 </vector>


### PR DESCRIPTION
Polish the monochrome icon with improved design using evenOdd fill type for proper cutouts of the speaker hole and grill lines. This ensures the icon renders correctly with Material You theming on Android 13+.