### PR TITLE
Implement user browse history tracking

### DIFF
--- a/app/src/main/java/com/opensource/i2pradio/data/BrowseHistory.kt
+++ b/app/src/main/java/com/opensource/i2pradio/data/BrowseHistory.kt
@@ -1,0 +1,49 @@
+package com.opensource.i2pradio.data
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+/**
+ * Entity to track stations visited/played from the Browse section.
+ * Keeps a history of the last 75 stations the user interacted with in browse.
+ */
+@Entity(tableName = "browse_history")
+data class BrowseHistory(
+    @PrimaryKey(autoGenerate = true)
+    val id: Long = 0,
+
+    /**
+     * RadioBrowser UUID of the station
+     */
+    val radioBrowserUuid: String,
+
+    /**
+     * Timestamp when the station was visited/played from browse
+     */
+    val visitedAt: Long = System.currentTimeMillis(),
+
+    /**
+     * Station name (cached for display without needing to join with radio_stations table)
+     */
+    val stationName: String,
+
+    /**
+     * Station stream URL (cached)
+     */
+    val streamUrl: String,
+
+    /**
+     * Station cover art URI (cached)
+     */
+    val coverArtUri: String? = null,
+
+    /**
+     * Station country (cached)
+     */
+    val country: String = "",
+
+    /**
+     * Station genre/tags (cached)
+     */
+    val genre: String = ""
+)

--- a/app/src/main/java/com/opensource/i2pradio/ui/browse/BrowseStationsFragment.kt
+++ b/app/src/main/java/com/opensource/i2pradio/ui/browse/BrowseStationsFragment.kt
@@ -279,6 +279,11 @@ class BrowseStationsFragment : Fragment() {
     }
 
     private fun playStation(station: RadioBrowserStation) {
+        // Add to browse history
+        lifecycleScope.launch {
+            repository.addToBrowseHistory(station)
+        }
+
         // Convert to RadioStation and play
         val radioStation = repository.convertToRadioStation(station)
         radioViewModel.setCurrentStation(radioStation)

--- a/app/src/main/java/com/opensource/i2pradio/ui/browse/BrowseViewModel.kt
+++ b/app/src/main/java/com/opensource/i2pradio/ui/browse/BrowseViewModel.kt
@@ -107,8 +107,7 @@ class BrowseViewModel(application: Application) : AndroidViewModel(application) 
     }
 
     /**
-     * Load history (recently changed stations)
-     * TODO: Implement true user browse history tracking (last ~75 stations played from browse)
+     * Load history (last 75 stations played from browse)
      */
     fun loadHistory() {
         _currentCategory.value = BrowseCategory.HISTORY
@@ -346,9 +345,8 @@ class BrowseViewModel(application: Application) : AndroidViewModel(application) 
                     repository.getTopClicked(pageSize, currentOffset)
                 }
                 BrowseCategory.HISTORY -> {
-                    // Currently shows recently changed stations
-                    // TODO: Replace with user's browse history (last ~75 played from browse)
-                    repository.getRecentlyChanged(pageSize, currentOffset)
+                    // Show user's browse history (last 75 played from browse)
+                    repository.getBrowseHistory()
                 }
                 BrowseCategory.BY_COUNTRY -> {
                     val country = _selectedCountry.value


### PR DESCRIPTION
This change implements proper browse history tracking for the Browse section. Previously, the "History" option showed recently changed stations from the RadioBrowser API. Now it tracks the user's actual browsing history - the last 75 stations they played from the Browse section only.

Changes:
- Created BrowseHistory entity to store visited stations
- Added database migration (v4 to v5) for browse_history table
- Updated RadioDao with browse history queries (get, insert, update, delete)
- Enhanced RadioBrowserRepository with browse history management
- Modified BrowseStationsFragment to track station plays
- Updated BrowseViewModel to use browse history instead of recently changed

The implementation:
- Tracks up to 75 most recent stations played from browse
- Updates timestamp if station is played again (moves to top)
- Automatically cleans up old entries to maintain 75-item limit
- Stores cached station data for offline display

Resolves TODO in BrowseViewModel.kt:111 and BrowseViewModel.kt:350