### PR TITLE
Add hamburger menu icons for genre and default sort options

### DIFF
--- a/app/src/main/java/com/opensource/i2pradio/ui/LibraryFragment.kt
+++ b/app/src/main/java/com/opensource/i2pradio/ui/LibraryFragment.kt
@@ -60,7 +60,7 @@ class LibraryFragment : Fragment() {
 
     // Predefined genres list (sorted alphabetically)
     private val allGenres = listOf(
-        "All Genres", "Alternative", "Ambient", "Blues", "Christian", "Classical",
+        "≡ All Genres", "Alternative", "Ambient", "Blues", "Christian", "Classical",
         "Comedy", "Country", "Dance", "EDM", "Electronic", "Folk",
         "Funk", "Gospel", "Hip Hop", "Indie", "Jazz", "K-Pop",
         "Latin", "Lo-Fi", "Metal", "News", "Oldies", "Pop", "Punk",
@@ -222,9 +222,9 @@ class LibraryFragment : Fragment() {
             val combinedGenres = (allGenres + dbGenres)
                 .distinct()
                 .sortedWith(compareBy {
-                    // "All Genres" first, "Other" last, rest alphabetically
+                    // "≡ All Genres" first, "Other" last, rest alphabetically
                     when (it) {
-                        "All Genres" -> "0$it"
+                        "≡ All Genres" -> "0$it"
                         "Other" -> "ZZZ$it"
                         else -> "A$it"
                     }
@@ -291,7 +291,7 @@ class LibraryFragment : Fragment() {
 
         var filteredGenres = genres.toList()
         val adapter = GenreAdapter(filteredGenres, selectedIndex) { selectedGenre ->
-            currentGenreFilter = if (selectedGenre == "All Genres") null else selectedGenre
+            currentGenreFilter = if (selectedGenre == "≡ All Genres") null else selectedGenre
             PreferencesHelper.setGenreFilter(requireContext(), currentGenreFilter)
             updateGenreFilterButtonText()
             // Clear search when changing genre filter

--- a/app/src/main/res/drawable/ic_menu.xml
+++ b/app/src/main/res/drawable/ic_menu.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M3,18h18v-2H3v2zM3,13h18v-2H3v2zM3,6v2h18V6H3z"/>
+</vector>

--- a/app/src/main/res/layout/fragment_browse_stations.xml
+++ b/app/src/main/res/layout/fragment_browse_stations.xml
@@ -126,7 +126,7 @@
                 android:layout_height="wrap_content"
                 android:text="@string/filter_genre"
                 android:textSize="12sp"
-                app:icon="@drawable/ic_filter"
+                app:icon="@drawable/ic_menu"
                 app:iconSize="18dp" />
 
         </LinearLayout>

--- a/app/src/main/res/layout/fragment_library.xml
+++ b/app/src/main/res/layout/fragment_library.xml
@@ -70,7 +70,7 @@
                 android:layout_height="wrap_content"
                 android:text="@string/genre_all"
                 android:textSize="12sp"
-                app:icon="@drawable/ic_filter"
+                app:icon="@drawable/ic_menu"
                 app:iconSize="18dp" />
 
             <!-- Sort Button -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -16,17 +16,17 @@
     <string name="equalizer_surround_sound">Surround Sound</string>
 
     <!-- Sort options -->
-    <string name="sort_default">Default</string>
+    <string name="sort_default">≡ Default</string>
     <string name="sort_name">Name</string>
     <string name="sort_recent">Recent</string>
     <string name="sort_liked">Liked</string>
-    <string name="sort_genre">Genre</string>
+    <string name="sort_genre">≡ Genre</string>
 
     <!-- Search -->
     <string name="search_stations">Search library</string>
 
     <!-- Genre filter -->
-    <string name="genre_all">All Genres</string>
+    <string name="genre_all">≡ All Genres</string>
     <string name="filter_by_genre">Filter by Genre</string>
 
     <!-- Browse/Discover Stations -->
@@ -38,9 +38,9 @@
     <string name="browse_no_results">No Stations Found</string>
     <string name="browse_no_results_hint">Try a different search or filter</string>
     <string name="filter_country">Country</string>
-    <string name="filter_genre">Genre</string>
+    <string name="filter_genre">≡ Genre</string>
     <string name="filter_all_countries">All Countries</string>
-    <string name="filter_all_genres">All Genres</string>
+    <string name="filter_all_genres">≡ All Genres</string>
     <string name="select_country">Select Country</string>
     <string name="select_genre">Select Genre</string>
     <string name="loading_countries">Loading countries…</string>


### PR DESCRIPTION
- Created new ic_menu.xml hamburger icon drawable (three horizontal lines)
- Updated sort_default and sort_genre strings to display "≡ Default" and "≡ Genre"
- Updated genre_all and filter_all_genres strings to display "≡ All Genres"
- Changed genre filter buttons in both Browse and Library fragments to use hamburger icon
- Updated LibraryFragment genre list to use "≡ All Genres" instead of plain "All Genres"

This provides a consistent visual indicator for default/all options using the recognizable hamburger menu icon pattern.