### PR TITLE
Fix hamburger icon implementation in Library and Browse screens

### DIFF
--- a/app/src/main/java/com/opensource/i2pradio/ui/LibraryFragment.kt
+++ b/app/src/main/java/com/opensource/i2pradio/ui/LibraryFragment.kt
@@ -60,7 +60,7 @@ class LibraryFragment : Fragment() {
 
     // Predefined genres list (sorted alphabetically)
     private val allGenres = listOf(
-        "≡ All Genres", "Alternative", "Ambient", "Blues", "Christian", "Classical",
+        "All Genres", "Alternative", "Ambient", "Blues", "Christian", "Classical",
         "Comedy", "Country", "Dance", "EDM", "Electronic", "Folk",
         "Funk", "Gospel", "Hip Hop", "Indie", "Jazz", "K-Pop",
         "Latin", "Lo-Fi", "Metal", "News", "Oldies", "Pop", "Punk",
@@ -222,9 +222,9 @@ class LibraryFragment : Fragment() {
             val combinedGenres = (allGenres + dbGenres)
                 .distinct()
                 .sortedWith(compareBy {
-                    // "≡ All Genres" first, "Other" last, rest alphabetically
+                    // "All Genres" first, "Other" last, rest alphabetically
                     when (it) {
-                        "≡ All Genres" -> "0$it"
+                        "All Genres" -> "0$it"
                         "Other" -> "ZZZ$it"
                         else -> "A$it"
                     }
@@ -291,7 +291,7 @@ class LibraryFragment : Fragment() {
 
         var filteredGenres = genres.toList()
         val adapter = GenreAdapter(filteredGenres, selectedIndex) { selectedGenre ->
-            currentGenreFilter = if (selectedGenre == "≡ All Genres") null else selectedGenre
+            currentGenreFilter = if (selectedGenre == "All Genres") null else selectedGenre
             PreferencesHelper.setGenreFilter(requireContext(), currentGenreFilter)
             updateGenreFilterButtonText()
             // Clear search when changing genre filter
@@ -374,6 +374,12 @@ class LibraryFragment : Fragment() {
             SortOrder.LIKED -> getString(R.string.sort_liked)
             SortOrder.GENRE -> getString(R.string.sort_genre)
         }
+
+        // Use hamburger icon for Default and Genre, sort icon for others
+        sortButton.setIconResource(when (currentSortOrder) {
+            SortOrder.DEFAULT, SortOrder.GENRE -> R.drawable.ic_menu
+            else -> R.drawable.ic_sort
+        })
     }
 
     private fun updateGenreFilterButtonText() {

--- a/app/src/main/res/layout/fragment_browse_stations.xml
+++ b/app/src/main/res/layout/fragment_browse_stations.xml
@@ -116,7 +116,7 @@
                 android:text="@string/filter_country"
                 android:textSize="12sp"
                 app:icon="@drawable/ic_location"
-                app:iconSize="18dp" />
+                app:iconSize="24dp" />
 
             <!-- Genre/Tag Filter -->
             <com.google.android.material.button.MaterialButton
@@ -127,7 +127,7 @@
                 android:text="@string/filter_genre"
                 android:textSize="12sp"
                 app:icon="@drawable/ic_menu"
-                app:iconSize="18dp" />
+                app:iconSize="24dp" />
 
         </LinearLayout>
 

--- a/app/src/main/res/layout/fragment_library.xml
+++ b/app/src/main/res/layout/fragment_library.xml
@@ -71,7 +71,7 @@
                 android:text="@string/genre_all"
                 android:textSize="12sp"
                 app:icon="@drawable/ic_menu"
-                app:iconSize="18dp" />
+                app:iconSize="24dp" />
 
             <!-- Sort Button -->
             <com.google.android.material.button.MaterialButton
@@ -82,7 +82,7 @@
                 android:text="Default"
                 android:textSize="12sp"
                 app:icon="@drawable/ic_sort"
-                app:iconSize="18dp" />
+                app:iconSize="24dp" />
 
         </LinearLayout>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -16,17 +16,17 @@
     <string name="equalizer_surround_sound">Surround Sound</string>
 
     <!-- Sort options -->
-    <string name="sort_default">≡ Default</string>
+    <string name="sort_default">Default</string>
     <string name="sort_name">Name</string>
     <string name="sort_recent">Recent</string>
     <string name="sort_liked">Liked</string>
-    <string name="sort_genre">≡ Genre</string>
+    <string name="sort_genre">Genre</string>
 
     <!-- Search -->
     <string name="search_stations">Search library</string>
 
     <!-- Genre filter -->
-    <string name="genre_all">≡ All Genres</string>
+    <string name="genre_all">All Genres</string>
     <string name="filter_by_genre">Filter by Genre</string>
 
     <!-- Browse/Discover Stations -->
@@ -38,9 +38,9 @@
     <string name="browse_no_results">No Stations Found</string>
     <string name="browse_no_results_hint">Try a different search or filter</string>
     <string name="filter_country">Country</string>
-    <string name="filter_genre">≡ Genre</string>
+    <string name="filter_genre">Genre</string>
     <string name="filter_all_countries">All Countries</string>
-    <string name="filter_all_genres">≡ All Genres</string>
+    <string name="filter_all_genres">All Genres</string>
     <string name="select_country">Select Country</string>
     <string name="select_genre">Select Genre</string>
     <string name="loading_countries">Loading countries…</string>


### PR DESCRIPTION
Remove small hamburger icons (≡) hardcoded in text strings and replace with proper large icons on buttons:
- Remove ≡ from sort_default, sort_genre, genre_all, filter_genre, and filter_all_genres strings
- Update LibraryFragment to dynamically set hamburger icon for Default and Genre sort options
- Increase icon size from 18dp to 24dp for better visibility
- Update "All Genres" references in LibraryFragment allGenres list and sorting logic