### PR TITLE
Fix miniplayer blocking "Add Radio" FAB button in Library tab

### DIFF
--- a/app/src/main/java/com/opensource/i2pradio/MainActivity.kt
+++ b/app/src/main/java/com/opensource/i2pradio/MainActivity.kt
@@ -191,6 +191,7 @@ class MainActivity : AppCompatActivity() {
                 // Station cleared - hide mini player
                 miniPlayerView.setStation(null)
                 miniPlayerContainer.visibility = View.GONE
+                viewModel.setMiniPlayerVisible(false)
                 miniPlayerManuallyClosed = false
                 lastStationId = null
                 lastStationUrl = null
@@ -215,6 +216,7 @@ class MainActivity : AppCompatActivity() {
                     if (!miniPlayerManuallyClosed) {
                         miniPlayerView.setStation(station)
                         miniPlayerContainer.visibility = View.VISIBLE
+                        viewModel.setMiniPlayerVisible(true)
                     }
                 } else {
                     // Same station, just update like state without animations
@@ -263,6 +265,7 @@ class MainActivity : AppCompatActivity() {
             viewModel.setPlaying(false)
             miniPlayerView.setStation(null)
             miniPlayerContainer.visibility = View.GONE
+            viewModel.setMiniPlayerVisible(false)
         }
 
         // Like button toggles liked state in database
@@ -389,11 +392,15 @@ class MainActivity : AppCompatActivity() {
                     // On Now Playing tab - keep mini player hidden
                     miniPlayerView.hideForNowPlaying()
                     miniPlayerContainer.visibility = View.INVISIBLE
+                    viewModel.setMiniPlayerVisible(false)
                 } else {
                     // On other tabs - show mini player if station is playing
                     if (viewModel.currentStation.value != null && !miniPlayerManuallyClosed) {
                         miniPlayerContainer.visibility = View.VISIBLE
                         miniPlayerView.showWithAnimation()
+                        viewModel.setMiniPlayerVisible(true)
+                    } else {
+                        viewModel.setMiniPlayerVisible(false)
                     }
                 }
             }

--- a/app/src/main/java/com/opensource/i2pradio/ui/LibraryFragment.kt
+++ b/app/src/main/java/com/opensource/i2pradio/ui/LibraryFragment.kt
@@ -125,6 +125,11 @@ class LibraryFragment : Fragment() {
             showAddRadioDialog()
         }
 
+        // Observe miniplayer visibility to adjust FAB margin dynamically
+        viewModel.isMiniPlayerVisible.observe(viewLifecycleOwner) { isVisible ->
+            adjustFabMarginForMiniPlayer(isVisible)
+        }
+
         return view
     }
 
@@ -465,6 +470,28 @@ class LibraryFragment : Fragment() {
             }
         }
         popup.show()
+    }
+
+    /**
+     * Adjusts the FAB bottom margin based on miniplayer visibility.
+     * When miniplayer is visible, adds extra margin to prevent overlap.
+     */
+    private fun adjustFabMarginForMiniPlayer(isMiniPlayerVisible: Boolean) {
+        val layoutParams = fabAddRadio.layoutParams as ViewGroup.MarginLayoutParams
+        val density = resources.displayMetrics.density
+
+        // Base margin: 24dp
+        // Miniplayer height with margins: ~100dp
+        val baseMargin = (24 * density).toInt()
+        val miniPlayerHeight = (100 * density).toInt()
+
+        layoutParams.bottomMargin = if (isMiniPlayerVisible) {
+            baseMargin + miniPlayerHeight  // 124dp total when miniplayer is visible
+        } else {
+            baseMargin  // 24dp when miniplayer is hidden
+        }
+
+        fabAddRadio.layoutParams = layoutParams
     }
 }
 

--- a/app/src/main/java/com/opensource/i2pradio/ui/RadioViewModel.kt
+++ b/app/src/main/java/com/opensource/i2pradio/ui/RadioViewModel.kt
@@ -44,6 +44,10 @@ class RadioViewModel(application: Application) : AndroidViewModel(application) {
     private val _coverArtUpdate = MutableLiveData<CoverArtUpdate?>()
     val coverArtUpdate: LiveData<CoverArtUpdate?> = _coverArtUpdate
 
+    // Miniplayer visibility state for UI components that need to adjust when miniplayer shows/hides
+    private val _isMiniPlayerVisible = MutableLiveData<Boolean>(false)
+    val isMiniPlayerVisible: LiveData<Boolean> = _isMiniPlayerVisible
+
     fun setCurrentStation(station: RadioStation?) {
         val previousStation = _currentStation.value
         _currentStation.value = station
@@ -103,6 +107,10 @@ class RadioViewModel(application: Application) : AndroidViewModel(application) {
 
     fun setBuffering(buffering: Boolean) {
         _isBuffering.value = buffering
+    }
+
+    fun setMiniPlayerVisible(visible: Boolean) {
+        _isMiniPlayerVisible.value = visible
     }
 
     fun getCurrentStation(): RadioStation? = _currentStation.value


### PR DESCRIPTION
The floating action button (FAB) for adding a new radio station was being obscured by the miniplayer when playing audio in the Library tab.

Solution:
- Added isMiniPlayerVisible LiveData to RadioViewModel to track miniplayer state
- Updated MainActivity to set visibility state when showing/hiding miniplayer
- Modified LibraryFragment to observe miniplayer visibility and dynamically adjust FAB bottom margin (124dp when visible, 24dp when hidden)

This ensures the FAB is always accessible without wasting screen space when the miniplayer is not showing.