### PR TITLE
Fix browse screen like/unlike to properly remove stations from library

### DIFF
--- a/app/src/main/java/com/opensource/i2pradio/ui/browse/BrowseViewModel.kt
+++ b/app/src/main/java/com/opensource/i2pradio/ui/browse/BrowseViewModel.kt
@@ -232,11 +232,18 @@ class BrowseViewModel(application: Application) : AndroidViewModel(application) 
 
         viewModelScope.launch {
             if (isCurrentlyLiked) {
-                // Unlike: toggle the like status in the database
-                repository.toggleLikeByUuid(uuid)
-                val likedCurrent = _likedStationUuids.value.orEmpty().toMutableSet()
-                likedCurrent.remove(uuid)
-                _likedStationUuids.value = likedCurrent
+                // Unlike: remove the station from library entirely
+                val deleted = repository.deleteStationByUuid(uuid)
+                if (deleted) {
+                    // Update both saved and liked UUIDs sets
+                    val savedCurrent = _savedStationUuids.value.orEmpty().toMutableSet()
+                    savedCurrent.remove(uuid)
+                    _savedStationUuids.value = savedCurrent
+
+                    val likedCurrent = _likedStationUuids.value.orEmpty().toMutableSet()
+                    likedCurrent.remove(uuid)
+                    _likedStationUuids.value = likedCurrent
+                }
             } else {
                 // Like: save and mark as liked
                 val id = repository.saveStationAsLiked(station)


### PR DESCRIPTION
When users unliked a station (clicked heart again), the station was only being marked as unliked but remained in the library. This caused:
- Misleading "removed from library" toast (station was still there)
- The "+" button still showing a checkmark (indicating station was saved)

Changed toggleLike() to delete the station entirely when unliking, matching the toast message and user expectations.