### PR TITLE
Fix Tor button consistency and universal like/unlike synchronization

### DIFF
--- a/app/src/main/java/com/opensource/i2pradio/ui/NowPlayingFragment.kt
+++ b/app/src/main/java/com/opensource/i2pradio/ui/NowPlayingFragment.kt
@@ -334,6 +334,15 @@ class NowPlayingFragment : Fragment() {
                             updatedStation?.let {
                                 viewModel.updateCurrentStationLikeState(it.isLiked)
                                 updateLikeButton(it.isLiked)
+
+                                // Broadcast like state change to all views
+                                val broadcastIntent = Intent(com.opensource.i2pradio.MainActivity.BROADCAST_LIKE_STATE_CHANGED).apply {
+                                    putExtra(com.opensource.i2pradio.MainActivity.EXTRA_IS_LIKED, it.isLiked)
+                                    putExtra(com.opensource.i2pradio.MainActivity.EXTRA_STATION_ID, it.id)
+                                    putExtra(com.opensource.i2pradio.MainActivity.EXTRA_RADIO_BROWSER_UUID, station.radioBrowserUuid)
+                                }
+                                LocalBroadcastManager.getInstance(requireContext()).sendBroadcast(broadcastIntent)
+
                                 // Show toast message
                                 if (it.isLiked) {
                                     Toast.makeText(
@@ -358,6 +367,15 @@ class NowPlayingFragment : Fragment() {
                             updatedStation?.let {
                                 viewModel.updateCurrentStationLikeState(it.isLiked)
                                 updateLikeButton(it.isLiked)
+
+                                // Broadcast like state change to all views
+                                val broadcastIntent = Intent(com.opensource.i2pradio.MainActivity.BROADCAST_LIKE_STATE_CHANGED).apply {
+                                    putExtra(com.opensource.i2pradio.MainActivity.EXTRA_IS_LIKED, it.isLiked)
+                                    putExtra(com.opensource.i2pradio.MainActivity.EXTRA_STATION_ID, it.id)
+                                    putExtra(com.opensource.i2pradio.MainActivity.EXTRA_RADIO_BROWSER_UUID, station.radioBrowserUuid)
+                                }
+                                LocalBroadcastManager.getInstance(requireContext()).sendBroadcast(broadcastIntent)
+
                                 // Show toast message
                                 if (it.isLiked) {
                                     Toast.makeText(

--- a/app/src/main/java/com/opensource/i2pradio/ui/TorQuickControlBottomSheet.kt
+++ b/app/src/main/java/com/opensource/i2pradio/ui/TorQuickControlBottomSheet.kt
@@ -271,6 +271,8 @@ class TorQuickControlBottomSheet : BottomSheetDialogFragment() {
                 TorService.start(requireContext())
             }
             TorManager.TorState.CONNECTED -> {
+                // Disable Tor in preferences and stop
+                PreferencesHelper.setEmbeddedTorEnabled(requireContext(), false)
                 TorService.stop(requireContext())
             }
             TorManager.TorState.STARTING -> {
@@ -285,7 +287,8 @@ class TorQuickControlBottomSheet : BottomSheetDialogFragment() {
     private fun handleSecondaryAction() {
         when (TorManager.state) {
             TorManager.TorState.STARTING -> {
-                // Cancel connecting
+                // Cancel connecting - also disable preference
+                PreferencesHelper.setEmbeddedTorEnabled(requireContext(), false)
                 TorService.stop(requireContext())
             }
             else -> {

--- a/app/src/main/java/com/opensource/i2pradio/ui/browse/BrowseViewModel.kt
+++ b/app/src/main/java/com/opensource/i2pradio/ui/browse/BrowseViewModel.kt
@@ -454,6 +454,19 @@ class BrowseViewModel(application: Application) : AndroidViewModel(application) 
         _likedStationUuids.value = likedUuids
     }
 
+    /**
+     * Refresh liked and saved station UUIDs from the database.
+     * Called when like state changes from other views to keep UI in sync.
+     */
+    fun refreshLikedAndSavedUuids() {
+        viewModelScope.launch(Dispatchers.IO) {
+            val currentStations = _stations.value ?: emptyList()
+            if (currentStations.isNotEmpty()) {
+                checkSavedStatus(currentStations)
+            }
+        }
+    }
+
     override fun onCleared() {
         super.onCleared()
         currentJob?.cancel()


### PR DESCRIPTION
This commit addresses two critical bugs:

## 1. Tor Button Consistency Fix
- **Problem**: The top-right Tor button and Settings "Enable Tor" switch were not in sync
- **Root Cause**: TorQuickControlBottomSheet updated preference when connecting but not when disconnecting
- **Solution**:
  - Updated TorQuickControlBottomSheet to set preference to false when disconnecting/canceling
  - Added SharedPreferences listener to SettingsFragment to automatically update switch when preference changes from other sources
  - Extracted switch listener setup into reusable method for preference change handler

**Files Modified**:
- TorQuickControlBottomSheet.kt: Added preference updates for disconnect/cancel actions
- SettingsFragment.kt: Added preference change listener, extracted setupTorSwitchListener() method

## 2. Universal Like/Unlike Synchronization
- **Problem**: Like/unlike actions didn't update consistently across all screens (now playing, miniplayer, browse, library)
- **Root Cause**: Each view had independent state management with no cross-view communication
- **Solution**:
  - Implemented broadcast system (BROADCAST_LIKE_STATE_CHANGED) similar to playback state changes
  - All views send broadcast when like state changes
  - All views listen for broadcast and update their UI accordingly
  - BrowseViewModel refreshes liked UUIDs from database when broadcast received
  - Library adapter refreshes to update heart icons

**Files Modified**:
- MainActivity.kt: Added broadcast constant, updated receiver to handle like changes, sends broadcast from miniplayer
- NowPlayingFragment.kt: Sends broadcast when like state changes
- BrowseStationsFragment.kt: Sends and listens for broadcast, triggers ViewModel refresh
- BrowseViewModel.kt: Added refreshLikedAndSavedUuids() method to sync state from database
- LibraryFragment.kt: Sends and listens for broadcast, refreshes adapter

**Technical Implementation**:
- Uses LocalBroadcastManager for efficient in-app communication
- Broadcasts include station ID and RadioBrowser UUID for proper identification
- All fragments register/unregister receivers in onResume/onPause lifecycle methods
- Changes are Gödelian-rigorous: every like/unlike action updates all possible views simultaneously

**Testing Notes**:
- Tor button and setting switch now stay in sync regardless of which is toggled
- Like/unlike in any view (now playing, miniplayer, browse, library) instantly updates all other views
- Works for both RadioBrowser stations (UUID-based) and local stations (ID-based)