### PR TITLE
Fix crash when liking stations in browse tab

### DIFF
--- a/app/src/main/java/com/opensource/i2pradio/ui/browse/BrowseViewModel.kt
+++ b/app/src/main/java/com/opensource/i2pradio/ui/browse/BrowseViewModel.kt
@@ -451,8 +451,8 @@ class BrowseViewModel(application: Application) : AndroidViewModel(application) 
             }
         }
 
-        _savedStationUuids.value = savedUuids
-        _likedStationUuids.value = likedUuids
+        _savedStationUuids.postValue(savedUuids)
+        _likedStationUuids.postValue(likedUuids)
     }
 
     /**


### PR DESCRIPTION
The app was crashing with "Cannot invoke setValue on a background thread" when users clicked the "like station" button in the browse tab's radio list.

Root cause: The checkSavedStatus() function in BrowseViewModel was calling setValue() on LiveData from a background thread (Dispatchers.IO). This happened because refreshLikedAndSavedUuids() explicitly launches its coroutine with Dispatchers.IO.

Fix: Changed setValue() to postValue() for _savedStationUuids and _likedStationUuids in checkSavedStatus() (lines 454-455). postValue() is thread-safe and can be called from any thread, making it the correct choice for updating LiveData from background coroutines.

This ensures the like button works correctly without crashing the app.