### PR TITLE
Change recording directory and fix Tor settings UI clipping

### DIFF
--- a/app/src/main/java/com/opensource/i2pradio/RadioService.kt
+++ b/app/src/main/java/com/opensource/i2pradio/RadioService.kt
@@ -710,7 +710,7 @@ class RadioService : Service() {
                     }
 
                     recordingMediaStoreUri = mediaStoreUri
-                    filePath = "Music/i2pradio/$finalFileName"
+                    filePath = "Music/deutsia_radio/$finalFileName"
                     android.util.Log.d("RadioService", "Recording stream connected, writing to MediaStore: $filePath (URI: $mediaStoreUri)")
 
                     val rawOutputStream = resolver.openOutputStream(mediaStoreUri)

--- a/app/src/main/java/com/opensource/i2pradio/ui/SettingsFragment.kt
+++ b/app/src/main/java/com/opensource/i2pradio/ui/SettingsFragment.kt
@@ -766,17 +766,17 @@ class SettingsFragment : Fragment() {
                 recordingDirectoryPath?.text = displayName
                 recordingDirectoryButton?.text = "Change"
             } catch (e: Exception) {
-                recordingDirectoryPath?.text = "Default (Music/i2pradio)"
+                recordingDirectoryPath?.text = "Default (Music/deutsia_radio)"
                 recordingDirectoryButton?.text = "Change"
             }
         } else {
-            recordingDirectoryPath?.text = "Default (Music/i2pradio)"
+            recordingDirectoryPath?.text = "Default (Music/deutsia_radio)"
             recordingDirectoryButton?.text = "Change"
         }
     }
 
     private fun showRecordingDirectoryDialog() {
-        val options = mutableListOf("Default (Music/i2pradio)", "Choose custom folder...")
+        val options = mutableListOf("Default (Music/deutsia_radio)", "Choose custom folder...")
         val savedUri = PreferencesHelper.getRecordingDirectoryUri(requireContext())
         if (savedUri != null) {
             options.add(1, "Clear custom folder")

--- a/app/src/main/res/layout/fragment_settings.xml
+++ b/app/src/main/res/layout/fragment_settings.xml
@@ -200,7 +200,9 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:orientation="vertical"
-                android:padding="16dp">
+                android:padding="16dp"
+                android:clipChildren="false"
+                android:clipToPadding="false">
 
                 <TextView
                     android:layout_width="wrap_content"
@@ -257,7 +259,9 @@
                     android:gravity="center_vertical"
                     android:paddingVertical="12dp"
                     android:layout_marginTop="8dp"
-                    android:visibility="gone">
+                    android:visibility="gone"
+                    android:clipChildren="false"
+                    android:clipToPadding="false">
 
                     <ImageView
                         android:id="@+id/torStatusIcon"
@@ -533,7 +537,7 @@
                             android:id="@+id/recordingDirectoryPath"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
-                            android:text="Default (Music/i2pradio)"
+                            android:text="Default (Music/deutsia_radio)"
                             android:textSize="12sp"
                             android:textColor="?attr/colorOnSurfaceVariant"
                             android:maxLines="1"


### PR DESCRIPTION
- Update default recording directory from Music/i2pradio to Music/deutsia_radio
- Fix Tor status container clipping issues during theme/Material You toggles
- Add clipChildren/clipToPadding attributes to prevent UI elements from clipping during animations