### PR TITLE
Fix type checking recursive problem in SettingsFragment

### DIFF
--- a/app/src/main/java/com/opensource/i2pradio/ui/SettingsFragment.kt
+++ b/app/src/main/java/com/opensource/i2pradio/ui/SettingsFragment.kt
@@ -127,7 +127,7 @@ class SettingsFragment : Fragment() {
     private var lastTorStateChangeTime: Long = 0
     private var lastDisplayedTorState: TorManager.TorState? = null
 
-    private val torUiUpdateRunnable = Runnable {
+    private val torUiUpdateRunnable: Runnable = Runnable {
         pendingTorState?.let { state ->
             // Only update UI if this state has been stable for minimum duration
             val stateAge = System.currentTimeMillis() - lastTorStateChangeTime


### PR DESCRIPTION
Add explicit type annotation to torUiUpdateRunnable to resolve Kotlin type inference issue with recursive Runnable reference.