### PR TITLE
Fix crash when mass deleting stations

### DIFF
--- a/app/src/main/java/com/opensource/i2pradio/ui/LibraryFragment.kt
+++ b/app/src/main/java/com/opensource/i2pradio/ui/LibraryFragment.kt
@@ -848,9 +848,7 @@ class RadioStationAdapter(
             )
 
             // Apply stroke for clear selection indicator
-            cardView.strokeWidth = itemView.resources.getDimensionPixelSize(
-                com.google.android.material.R.dimen.material_emphasis_medium
-            ).coerceAtLeast(3) // Ensure at least 3dp
+            cardView.strokeWidth = (2 * itemView.resources.displayMetrics.density).toInt() // 2dp stroke
             cardView.strokeColor = primaryColor
 
             // Apply subtle background tint using primaryContainer color


### PR DESCRIPTION
The app was crashing with Resources$NotFoundException when selecting stations for mass delete in the library tab.

Root cause: The applySelectionHighlight() function at LibraryFragment.kt:851 was trying to access a non-existent Material Design dimension resource (com.google.android.material.R.dimen.material_emphasis_medium). This resource doesn't exist - material_emphasis values are for opacity/alpha, not dimensions.

Fix: Replaced the invalid resource reference with a direct calculation of 2dp stroke width using display metrics. This provides a clean, consistent selection indicator without relying on non-existent resources.

This ensures mass delete selection works correctly without crashing.