### PR TITLE
Fix build error: Add public importFromJson overload

### DIFF
--- a/app/src/main/java/com/opensource/i2pradio/util/StationImportExport.kt
+++ b/app/src/main/java/com/opensource/i2pradio/util/StationImportExport.kt
@@ -302,6 +302,14 @@ object StationImportExport {
     }
 
     /**
+     * Import stations from JSON content (public convenience method)
+     */
+    fun importFromJson(content: String): ImportResult {
+        val errors = mutableListOf<String>()
+        return importFromJson(content, errors)
+    }
+
+    /**
      * Import stations from JSON content
      */
     private fun importFromJson(content: String, errors: MutableList<String>): ImportResult {


### PR DESCRIPTION
Added a public convenience method importFromJson(content: String) that SettingsFragment can call. This method internally creates the errors list and delegates to the existing private implementation.

Fixes compilation error in SettingsFragment.kt:985 where it was trying to access the private importFromJson function.