### PR TITLE
Add searchable filter dialogs with improved UI

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -24,6 +24,8 @@
 
     <!-- Search -->
     <string name="search_stations">Search library</string>
+    <string name="search_countries">Search countries…</string>
+    <string name="search_genres">Search genres…</string>
 
     <!-- Genre filter -->
     <string name="genre_all">All Genres</string>


### PR DESCRIPTION
- Reorganize genre filter dialog in Library tab:
  - Move Cancel button to bottom left
  - Add OK button to bottom right
  - Apply selection only when OK is clicked

- Add search functionality to Browse tab filters:
  - Country filter now has searchable list
  - Genre/Tag filter now has searchable list
  - Both use same button layout (Cancel left, OK right)

- UI improvements across all filter dialogs:
  - Add search icon and clear button
  - Add visual divider between search and list
  - Use filled background style for search input
  - Set maximum height for better scrolling
  - Improve spacing and padding

- Add string resources for search hints:
  - search_countries
  - search_genres