### PR TITLE
Fix missing TextView import in BrowseStationsFragment

### DIFF
--- a/app/src/main/java/com/opensource/i2pradio/ui/browse/BrowseStationsFragment.kt
+++ b/app/src/main/java/com/opensource/i2pradio/ui/browse/BrowseStationsFragment.kt
@@ -14,6 +14,7 @@ import android.view.ViewGroup
 import android.view.inputmethod.EditorInfo
 import android.widget.FrameLayout
 import android.widget.LinearLayout
+import android.widget.TextView
 import android.widget.Toast
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment


### PR DESCRIPTION
Add missing android.widget.TextView import to resolve 8 build errors:
- Unresolved reference 'TextView' at lines 667, 730
- Cannot infer type parameter errors at lines 667, 730
- Unresolved reference 'text' at lines 683, 693, 746, 756