### PR TITLE
Adjust buffer bar vertical position to reduce spacing

### DIFF
--- a/app/src/main/res/layout-land/fragment_now_playing.xml
+++ b/app/src/main/res/layout-land/fragment_now_playing.xml
@@ -280,7 +280,7 @@
             android:id="@+id/bufferBarContainer"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:layout_marginTop="16dp"
+            android:layout_marginTop="12dp"
             android:layout_marginBottom="8dp"
             android:orientation="vertical"
             android:visibility="gone"

--- a/app/src/main/res/layout/fragment_now_playing.xml
+++ b/app/src/main/res/layout/fragment_now_playing.xml
@@ -234,7 +234,7 @@
         android:id="@+id/bufferBarContainer"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_marginTop="32dp"
+        android:layout_marginTop="20dp"
         android:layout_marginBottom="16dp"
         android:orientation="vertical"
         android:visibility="gone"


### PR DESCRIPTION
Reduced top margin of buffer bar container to bring it closer to playback controls while maintaining clearance for the play/pause button shadow (6dp elevation).

- Portrait layout: 32dp → 20dp top margin
- Landscape layout: 16dp → 12dp top margin