### PR TITLE
Fix critical build errors in RadioService and SecureImageLoader

### DIFF
--- a/app/src/main/java/com/opensource/i2pradio/RadioService.kt
+++ b/app/src/main/java/com/opensource/i2pradio/RadioService.kt
@@ -1473,10 +1473,6 @@ class RadioService : Service() {
                         }
                     }
                 })
-            } finally {
-                // Always reset flag when player setup completes (success or failure)
-                // This ensures old player IDLE states can clear buffering animations again
-                isStartingNewStream = false
             }
 
             // Note: startForeground is called in onStartCommand before playStream()
@@ -1486,6 +1482,10 @@ class RadioService : Service() {
             // Broadcast failure to UI
             broadcastPlaybackStateChanged(isBuffering = false, isPlaying = false)
             scheduleReconnect()
+        } finally {
+            // Always reset flag when player setup completes (success or failure)
+            // This ensures old player IDLE states can clear buffering animations again
+            isStartingNewStream = false
         }
     }
 

--- a/app/src/main/java/com/opensource/i2pradio/util/SecureImageLoader.kt
+++ b/app/src/main/java/com/opensource/i2pradio/util/SecureImageLoader.kt
@@ -113,8 +113,10 @@ object SecureImageLoader {
 
             builder.okHttpClient(okHttpClient)
 
+            android.util.Log.d("SecureImageLoader",
                 "Created image loader with Tor proxy: ${config.host}:${config.port}")
         } else {
+            android.util.Log.d("SecureImageLoader",
                 "Created image loader without proxy (Tor not active or not required)")
         }
 


### PR DESCRIPTION
- RadioService.kt: Fix try-catch-finally block order (catch must come before finally)
- SecureImageLoader.kt: Complete incomplete log statements