### PR TITLE
Fix syntax errors in RadioService

### DIFF
--- a/app/src/main/java/com/opensource/i2pradio/RadioService.kt
+++ b/app/src/main/java/com/opensource/i2pradio/RadioService.kt
@@ -1487,6 +1487,11 @@ class RadioService : Service() {
             // This ensures old player IDLE states can clear buffering animations again
             isStartingNewStream = false
         }
+        } catch (e: Exception) {
+            android.util.Log.e("RadioService", "Error in playStream", e)
+            isStartingNewStream = false
+            broadcastPlaybackStateChanged(isBuffering = false, isPlaying = false)
+        }
     }
 
     private fun scheduleReconnect() {


### PR DESCRIPTION
- Add missing catch block for outer try statement in playStream function
- Fixes 'Expecting catch or finally' compilation error at line 1490
- Fixes 'Missing }' compilation error