### PR TITLE
Fix syntax errors in RadioService

### DIFF
--- a/app/src/main/java/com/opensource/i2pradio/RadioService.kt
+++ b/app/src/main/java/com/opensource/i2pradio/RadioService.kt
@@ -1487,11 +1487,6 @@ class RadioService : Service() {
             // This ensures old player IDLE states can clear buffering animations again
             isStartingNewStream = false
         }
-        } catch (e: Exception) {
-            android.util.Log.e("RadioService", "Error in playStream", e)
-            isStartingNewStream = false
-            broadcastPlaybackStateChanged(isBuffering = false, isPlaying = false)
-        }
     }
 
     private fun scheduleReconnect() {


### PR DESCRIPTION
- Remove duplicate catch block after finally (line 1490)
- Fix "Expecting 'catch' or 'finally'" error
- Fix "Missing '}'" error caused by invalid try-catch-finally structure

The playStream() method had an invalid try-catch-finally structure with a duplicate catch block after the finally block, which is not allowed in Kotlin/Java. Removed the redundant catch block to restore correct syntax.