### PR TITLE
Fix critical concurrency bugs and prepare for production

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -18,7 +18,8 @@ android {
 
     buildTypes {
         release {
-            isMinifyEnabled = false
+            isMinifyEnabled = true
+            isShrinkResources = true
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -12,10 +12,44 @@
 #   public *;
 #}
 
-# Uncomment this to preserve the line number information for
-# debugging stack traces.
-#-keepattributes SourceFile,LineNumberTable
+# Preserve line number information for debugging stack traces in production
+-keepattributes SourceFile,LineNumberTable
+
+# Remove debug and verbose logging in release builds for performance
+-assumenosideeffects class android.util.Log {
+    public static *** d(...);
+    public static *** v(...);
+}
+
+# Keep error and warning logs for crash reporting
+# (Log.e, Log.w, and Log.wtf are kept)
 
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
+
+# Keep OkHttp platform classes for SOCKS proxy support
+-dontwarn okhttp3.internal.platform.**
+-keep class okhttp3.internal.platform.** { *; }
+
+# Keep ExoPlayer classes for audio streaming
+-keep class androidx.media3.** { *; }
+-dontwarn androidx.media3.**
+
+# Keep Room database classes
+-keep class * extends androidx.room.RoomDatabase
+-keep @androidx.room.Entity class *
+-keepclassmembers class * extends androidx.room.RoomDatabase {
+    public static ** Companion;
+}
+
+# Keep Coroutines
+-keepnames class kotlinx.coroutines.internal.MainDispatcherFactory {}
+-keepnames class kotlinx.coroutines.CoroutineExceptionHandler {}
+-keepclassmembers class kotlinx.** {
+    volatile <fields>;
+}
+
+# Keep Coil image loader
+-keep class coil.** { *; }
+-dontwarn coil.**

--- a/app/src/main/java/com/opensource/i2pradio/ui/AddEditRadioDialog.kt
+++ b/app/src/main/java/com/opensource/i2pradio/ui/AddEditRadioDialog.kt
@@ -19,7 +19,7 @@ import com.opensource.i2pradio.R
 import com.opensource.i2pradio.data.ProxyType
 import com.opensource.i2pradio.data.RadioRepository
 import com.opensource.i2pradio.data.RadioStation
-import kotlinx.coroutines.CoroutineScope
+import androidx.lifecycle.lifecycleScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 
@@ -143,7 +143,7 @@ class AddEditRadioDialog : DialogFragment() {
         // Load station data if editing
         val stationId = arguments?.getLong("station_id", -1L) ?: -1L
         if (stationId != -1L) {
-            CoroutineScope(Dispatchers.Main).launch {
+            lifecycleScope.launch(Dispatchers.Main) {
                 val station = repository.getStationById(stationId)
                 station?.let {
                     stationToEdit = it
@@ -218,7 +218,7 @@ class AddEditRadioDialog : DialogFragment() {
                         isPreset = stationToEdit?.isPreset ?: false
                     )
 
-                    CoroutineScope(Dispatchers.IO).launch {
+                    lifecycleScope.launch(Dispatchers.IO) {
                         if (stationToEdit == null) {
                             repository.insertStation(station)
                         } else {


### PR DESCRIPTION
Critical Fixes:
- Fix isStartingNewStream race condition (#2): Changed to AtomicBoolean for thread-safe access from player callbacks and UI thread
- Fix currentOkHttpClient thread safety (#4): Added @Volatile and synchronized blocks to prevent race conditions during rapid stream switching
- Fix unscoped coroutines (#3):
  * RadioService: Added service-scoped CoroutineScope that gets cancelled in onDestroy()
  * AddEditRadioDialog: Migrated to lifecycleScope for proper lifecycle management

Production Readiness:
- Enable ProGuard/R8 minification and resource shrinking for release builds (#9)
- Add ProGuard rules to automatically strip Log.d/v calls in production
- Add comprehensive ProGuard keep rules for OkHttp, ExoPlayer, Room, Coroutines, and Coil

Verified (No Changes Needed):
- BroadcastReceiver cleanup (#5): Already properly handled via TorManager.cleanup()
- TorManager listeners (#1): Application-context listeners are appropriate for singleton

All changes maintain backward compatibility and improve production stability.