### PR TITLE
Add release signing configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,8 @@
 .externalNativeBuild
 .cxx
 local.properties
+
+# Keystore files - NEVER commit these!
+*.keystore
+*.jks
+keystore.properties

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -16,8 +16,27 @@ android {
         versionName = "1.0"
     }
 
+    // Load keystore properties
+    val keystorePropertiesFile = rootProject.file("keystore.properties")
+    val keystoreProperties = java.util.Properties()
+    if (keystorePropertiesFile.exists()) {
+        keystoreProperties.load(java.io.FileInputStream(keystorePropertiesFile))
+    }
+
+    signingConfigs {
+        create("release") {
+            if (keystorePropertiesFile.exists()) {
+                storeFile = file(keystoreProperties["storeFile"] as String)
+                storePassword = keystoreProperties["storePassword"] as String
+                keyAlias = keystoreProperties["keyAlias"] as String
+                keyPassword = keystoreProperties["keyPassword"] as String
+            }
+        }
+    }
+
     buildTypes {
         release {
+            signingConfig = signingConfigs.getByName("release")
             isMinifyEnabled = true
             isShrinkResources = true
             proguardFiles(


### PR DESCRIPTION
- Add keystore protection to .gitignore
- Configure release build signing in app/build.gradle.kts
- Keystore credentials stored in local keystore.properties (not committed)