### PR TITLE
Enhance search with intelligent multi-word and multi-field support

### DIFF
--- a/app/src/main/java/com/opensource/i2pradio/ui/LibraryFragment.kt
+++ b/app/src/main/java/com/opensource/i2pradio/ui/LibraryFragment.kt
@@ -200,9 +200,28 @@ class LibraryFragment : Fragment() {
         val filteredStations = if (currentSearchQuery.isEmpty()) {
             allStationsCache
         } else {
+            // Intelligent multi-word search across multiple fields
+            val searchTerms = currentSearchQuery.split("\\s+".toRegex())
+                .filter { it.isNotBlank() }
+                .map { it.lowercase() }
+
             allStationsCache.filter { station ->
-                station.name.contains(currentSearchQuery, ignoreCase = true) ||
-                station.genre.contains(currentSearchQuery, ignoreCase = true)
+                // Create a searchable text combining all relevant fields
+                val searchableText = buildString {
+                    append(station.name.lowercase())
+                    append(" ")
+                    append(station.genre.lowercase())
+                    append(" ")
+                    append(station.country.lowercase())
+                    append(" ")
+                    append(station.countryCode.lowercase())
+                }
+
+                // Check if all search terms match somewhere in the searchable text
+                // This allows multi-word queries like "BBC London" or "Jazz Germany"
+                searchTerms.all { term ->
+                    searchableText.contains(term)
+                }
             }
         }
 


### PR DESCRIPTION
Improvements to browse and library search functionality:

Browse Screen:
- Replaced separate searchByName + getByTag API calls with unified searchStations method
- Now searches across name, tag/genre, and country fields simultaneously
- Added multi-word query support (e.g., "BBC London", "Rock Germany")
- Individual words in multi-word queries are also searched to maximize results
- Results are deduplicated and prioritized (exact matches first)

Library Screen:
- Enhanced search to include country and country code fields
- Added intelligent multi-word query support
- All search terms must match somewhere in the searchable fields
- Searches name, genre, country, and country code fields

Users can now:
- Search by genre and get stations with that genre (not just in title)
- Search by country and get stations from that country (not just in title)
- Combine search terms like "Jazz Germany" to find Jazz stations from Germany
- Use multiple words to narrow down results more effectively