### PR TITLE
Fix exhaustive when expression errors for CUSTOM proxy type

### DIFF
--- a/app/src/main/java/com/opensource/i2pradio/ui/LibraryFragment.kt
+++ b/app/src/main/java/com/opensource/i2pradio/ui/LibraryFragment.kt
@@ -774,6 +774,7 @@ class RadioStationAdapter(
                 when (station.getProxyTypeEnum()) {
                     ProxyType.I2P -> " • I2P"
                     ProxyType.TOR -> " • Tor"
+                    ProxyType.CUSTOM -> " • Custom"
                     ProxyType.NONE -> ""
                 }
             } else ""

--- a/app/src/main/java/com/opensource/i2pradio/ui/MiniPlayerView.kt
+++ b/app/src/main/java/com/opensource/i2pradio/ui/MiniPlayerView.kt
@@ -186,6 +186,7 @@ class MiniPlayerView @JvmOverloads constructor(
             when (station.getProxyTypeEnum()) {
                 ProxyType.I2P -> " • I2P"
                 ProxyType.TOR -> " • Tor"
+                ProxyType.CUSTOM -> " • Custom"
                 ProxyType.NONE -> ""
             }
         } else ""

--- a/app/src/main/java/com/opensource/i2pradio/ui/NowPlayingFragment.kt
+++ b/app/src/main/java/com/opensource/i2pradio/ui/NowPlayingFragment.kt
@@ -510,6 +510,7 @@ class NowPlayingFragment : Fragment() {
                     when (station.getProxyTypeEnum()) {
                         ProxyType.I2P -> " • I2P"
                         ProxyType.TOR -> " • Tor"
+                        ProxyType.CUSTOM -> " • Custom"
                         ProxyType.NONE -> ""
                     }
                 } else ""

--- a/app/src/main/java/com/opensource/i2pradio/util/StationImportExport.kt
+++ b/app/src/main/java/com/opensource/i2pradio/util/StationImportExport.kt
@@ -108,6 +108,7 @@ object StationImportExport {
                     when (ProxyType.fromString(station.proxyType)) {
                         ProxyType.I2P -> " [I2P]"
                         ProxyType.TOR -> " [Tor]"
+                        ProxyType.CUSTOM -> " [Custom]"
                         ProxyType.NONE -> ""
                     }
                 } else ""
@@ -149,6 +150,7 @@ object StationImportExport {
                     when (ProxyType.fromString(station.proxyType)) {
                         ProxyType.I2P -> " [I2P]"
                         ProxyType.TOR -> " [Tor]"
+                        ProxyType.CUSTOM -> " [Custom]"
                         ProxyType.NONE -> ""
                     }
                 } else ""
@@ -388,7 +390,7 @@ object StationImportExport {
                     // Parse: #EXTINF:duration,title [info]
                     val info = trimmed.substringAfter(",").trim()
                     // Remove proxy indicators from name
-                    currentName = info.replace(Regex("\\s*\\[(I2P|Tor)\\]\\s*$"), "").trim()
+                    currentName = info.replace(Regex("\\s*\\[(I2P|Tor|Custom)\\]\\s*$"), "").trim()
 
                     // Detect proxy type from indicator
                     when {
@@ -401,6 +403,10 @@ object StationImportExport {
                             currentProxyType = ProxyType.TOR
                             currentProxyHost = ProxyType.TOR.getDefaultHost()
                             currentProxyPort = ProxyType.TOR.getDefaultPort()
+                        }
+                        info.contains("[Custom]") -> {
+                            currentProxyType = ProxyType.CUSTOM
+                            // Custom proxy requires explicit host/port from metadata
                         }
                     }
                 }
@@ -507,6 +513,10 @@ object StationImportExport {
                             title.contains("[Tor]") -> {
                                 proxyTypes[num] = ProxyType.TOR
                                 title = title.replace(Regex("\\s*\\[Tor\\]\\s*"), "")
+                            }
+                            title.contains("[Custom]") -> {
+                                proxyTypes[num] = ProxyType.CUSTOM
+                                title = title.replace(Regex("\\s*\\[Custom\\]\\s*"), "")
                             }
                         }
                         titles[num] = title.trim()


### PR DESCRIPTION
Add missing CUSTOM case to all when expressions handling ProxyType:
- LibraryFragment.kt: Add CUSTOM proxy indicator display
- MiniPlayerView.kt: Add CUSTOM proxy indicator display
- NowPlayingFragment.kt: Add CUSTOM proxy indicator display
- StationImportExport.kt: Add CUSTOM support to M3U/PLS import/export

This fixes the build errors introduced when CUSTOM proxy type was added but not all when expressions were updated to handle the new case.