### PR TITLE
Update bandwidth icon to pulse line design

### DIFF
--- a/app/src/main/res/drawable/ic_bandwidth.xml
+++ b/app/src/main/res/drawable/ic_bandwidth.xml
@@ -3,10 +3,13 @@
     android:height="24dp"
     android:viewportWidth="24"
     android:viewportHeight="24">
+
+    <!-- The Bandwidth Pulse Line -->
     <path
-        android:fillColor="@android:color/white"
-        android:pathData="M15.5,14h-0.79l-0.28,-0.27C15.41,12.59 16,11.11 16,9.5 16,5.91 13.09,3 9.5,3S3,5.91 3,9.5 5.91,16 9.5,16c1.61,0 3.09,-0.59 4.23,-1.57l0.27,0.28v0.79l5,4.99L20.49,19l-4.99,-5zM9.5,14C7.01,14 5,11.99 5,9.5S7.01,5 9.5,5 14,7.01 14,9.5 11.99,14 9.5,14z"/>
-    <path
-        android:fillColor="@android:color/white"
-        android:pathData="M19,3H5C3.89,3 3,3.89 3,5v14c0,1.1 0.89,2 2,2h14c1.1,0 2,-0.9 2,-2V5c0,-1.11 -0.9,-2 -2,-2zM19,19H5V5h14v14zM7,10h2v7H7zm4,-3h2v10h-2zm4,6h2v4h-2z"/>
+        android:fillColor="#00000000"
+        android:pathData="M22,12H18L15,21L9,3L6,12H2"
+        android:strokeColor="@android:color/white"
+        android:strokeWidth="2"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round"/>
 </vector>


### PR DESCRIPTION
Replace the old search/chart icon with a new bandwidth pulse line icon that better represents network activity. The icon uses Material You compatible theming via white stroke color that gets tinted by the theme.