### PR TITLE
Fix duplicate stopCurrentStream() function definition

### DIFF
--- a/app/src/main/java/com/opensource/i2pradio/ui/SettingsFragment.kt
+++ b/app/src/main/java/com/opensource/i2pradio/ui/SettingsFragment.kt
@@ -1458,12 +1458,4 @@ class SettingsFragment : Fragment() {
             }
         }
     }
-
-    private fun stopCurrentStream() {
-        // Stop current playback when proxy settings change
-        val serviceIntent = Intent(requireContext(), RadioService::class.java).apply {
-            action = "ACTION_STOP"
-        }
-        requireContext().startService(serviceIntent)
-    }
 }


### PR DESCRIPTION
Removed duplicate stopCurrentStream() function at line 1462 that was causing overload resolution ambiguity. The function is already defined at line 748 with proper implementation.