### PR TITLE
Fix missing drawable resource in custom proxy status view

### DIFF
--- a/app/src/main/res/layout/view_custom_proxy_status.xml
+++ b/app/src/main/res/layout/view_custom_proxy_status.xml
@@ -19,9 +19,9 @@
             android:id="@+id/customProxyStatusIcon"
             android:layout_width="24dp"
             android:layout_height="24dp"
-            android:src="@drawable/ic_network"
+            android:src="@drawable/ic_proxy_custom"
             android:contentDescription="Custom proxy status"
-            tools:src="@drawable/ic_network" />
+            tools:src="@drawable/ic_proxy_custom" />
 
         <TextView
             android:id="@+id/customProxyStatusText"


### PR DESCRIPTION
Replace non-existent ic_network drawable with existing ic_proxy_custom drawable in view_custom_proxy_status.xml to resolve build error.