### PR TITLE
Center bandwidth icon over reset button

### DIFF
--- a/app/src/main/res/layout/fragment_settings.xml
+++ b/app/src/main/res/layout/fragment_settings.xml
@@ -607,13 +607,21 @@
 
                     </LinearLayout>
 
-                    <ImageView
-                        android:layout_width="24dp"
-                        android:layout_height="24dp"
-                        android:layout_marginStart="8dp"
-                        android:src="@drawable/ic_bandwidth"
-                        android:contentDescription="Bandwidth icon"
-                        app:tint="?attr/colorPrimary" />
+                    <FrameLayout
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:minWidth="72dp">
+
+                        <ImageView
+                            android:id="@+id/ic_bandwidth"
+                            android:layout_width="24dp"
+                            android:layout_height="24dp"
+                            android:layout_gravity="center"
+                            android:src="@drawable/ic_bandwidth"
+                            android:contentDescription="Bandwidth icon"
+                            app:tint="?attr/colorPrimary" />
+
+                    </FrameLayout>
 
                 </LinearLayout>
 


### PR DESCRIPTION
Wrapped the bandwidth icon in a FrameLayout with minWidth to match the Reset button width, and centered the icon within the FrameLayout using layout_gravity. This ensures the icon is horizontally centered over the Reset button below it.