### PR TITLE
Move bandwidth icon further left for better centering

### DIFF
--- a/app/src/main/res/layout/fragment_settings.xml
+++ b/app/src/main/res/layout/fragment_settings.xml
@@ -610,7 +610,7 @@
                     <FrameLayout
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:minWidth="72dp">
+                        android:minWidth="56dp">
 
                         <ImageView
                             android:id="@+id/ic_bandwidth"


### PR DESCRIPTION
Reduced FrameLayout minWidth from 72dp to 56dp to better align the bandwidth icon with the reset button below.