### PR TITLE
Move bandwidth icon further left to center over Reset text

### DIFF
--- a/app/src/main/res/layout/fragment_settings.xml
+++ b/app/src/main/res/layout/fragment_settings.xml
@@ -618,6 +618,7 @@
                             android:layout_width="24dp"
                             android:layout_height="24dp"
                             android:layout_gravity="center"
+                            android:layout_marginEnd="20dp"
                             android:src="@drawable/ic_bandwidth"
                             android:contentDescription="Bandwidth icon"
                             app:tint="?attr/colorPrimary" />


### PR DESCRIPTION
Added 20dp right margin to the bandwidth icon to better align it horizontally with the Reset button text below.