### PR TITLE
Use Tor shield icons for custom proxy status

### DIFF
--- a/app/src/main/res/drawable/ic_proxy_custom_error.xml
+++ b/app/src/main/res/drawable/ic_proxy_custom_error.xml
@@ -4,12 +4,11 @@
     android:height="24dp"
     android:viewportWidth="24"
     android:viewportHeight="24">
-    <!-- Toggle/switch with warning indicator for leak warning -->
+    <!-- Cloud with X icon for leak warning (same as Tor error icon) -->
     <path
-        android:fillColor="#F44336"
-        android:pathData="M17,7L7,7c-2.76,0 -5,2.24 -5,5s2.24,5 5,5h10c2.76,0 5,-2.24 5,-5s-2.24,-5 -5,-5zM7,15c-1.66,0 -3,-1.34 -3,-3s1.34,-3 3,-3 3,1.34 3,3 -1.34,3 -3,3z"/>
-    <!-- Warning exclamation mark -->
+        android:fillColor="#638d65ff"
+        android:pathData="M19.35,10.04C18.67,6.59 15.64,4 12,4 9.11,4 6.6,5.64 5.35,8.04 2.34,8.36 0,10.91 0,14c0,3.31 2.69,6 6,6h13c2.76,0 5,-2.24 5,-5 0,-2.64 -2.05,-4.78 -4.65,-4.96z"/>
     <path
         android:fillColor="#FFFFFF"
-        android:pathData="M17,9h-1v4h1zM17,14h-1v1h1z"/>
+        android:pathData="M14.5,9.5L12,12l-2.5,-2.5L8,11l2.5,2.5L8,16l1.5,1.5L12,15l2.5,2.5L16,16l-2.5,-2.5L16,11z"/>
 </vector>

--- a/app/src/main/res/drawable/ic_proxy_custom_off.xml
+++ b/app/src/main/res/drawable/ic_proxy_custom_off.xml
@@ -4,8 +4,8 @@
     android:height="24dp"
     android:viewportWidth="24"
     android:viewportHeight="24">
-    <!-- Toggle/switch icon in gray for custom proxy not configured -->
+    <!-- Shield icon representing custom proxy disconnected (same as Tor) -->
     <path
         android:fillColor="#9E9E9E"
-        android:pathData="M17,7L7,7c-2.76,0 -5,2.24 -5,5s2.24,5 5,5h10c2.76,0 5,-2.24 5,-5s-2.24,-5 -5,-5zM7,15c-1.66,0 -3,-1.34 -3,-3s1.34,-3 3,-3 3,1.34 3,3 -1.34,3 -3,3z"/>
+        android:pathData="M12,1L3,5v6c0,5.55 3.84,10.74 9,12 5.16,-1.26 9,-6.45 9,-12V5L12,1zM12,11.99h7c-0.53,4.12 -3.28,7.79 -7,8.94V12H5V6.3l7,-3.11v8.8z"/>
 </vector>

--- a/app/src/main/res/drawable/ic_proxy_custom_on.xml
+++ b/app/src/main/res/drawable/ic_proxy_custom_on.xml
@@ -4,8 +4,8 @@
     android:height="24dp"
     android:viewportWidth="24"
     android:viewportHeight="24">
-    <!-- Toggle/switch icon in green for custom proxy connected -->
+    <!-- Shield icon representing custom proxy connected (same as Tor) -->
     <path
         android:fillColor="#4CAF50"
-        android:pathData="M17,7L7,7c-2.76,0 -5,2.24 -5,5s2.24,5 5,5h10c2.76,0 5,-2.24 5,-5s-2.24,-5 -5,-5zM17,15c-1.66,0 -3,-1.34 -3,-3s1.34,-3 3,-3 3,1.34 3,3 -1.34,3 -3,3z"/>
+        android:pathData="M12,1L3,5v6c0,5.55 3.84,10.74 9,12 5.16,-1.26 9,-6.45 9,-12V5L12,1zM12,11.99h7c-0.53,4.12 -3.28,7.79 -7,8.94V12H5V6.3l7,-3.11v8.8z"/>
 </vector>


### PR DESCRIPTION
Replace custom proxy toggle/switch icons with the same shield icons used by Tor for consistency:
- Use green shield for proxy configured (same as Tor connected)
- Use gray shield for proxy not configured (same as Tor disconnected)
- Use cloud with X icon for leak warning (same as Tor error)