### PR TITLE
Externalize all hardcoded strings to strings.xml for translation support

### DIFF
--- a/app/src/main/java/com/opensource/i2pradio/RadioService.kt
+++ b/app/src/main/java/com/opensource/i2pradio/RadioService.kt
@@ -414,7 +414,7 @@ class RadioService : Service() {
 
                 // CRITICAL: Start foreground immediately to comply with Android 8+ requirements
                 // This must be called within 5 seconds of startForegroundService()
-                startForeground(NOTIFICATION_ID, createNotification("Connecting..."))
+                startForeground(NOTIFICATION_ID, createNotification(getString(R.string.notification_connecting)))
 
                 // Broadcast buffering state to UI immediately
                 broadcastPlaybackStateChanged(isBuffering = true, isPlaying = false)
@@ -430,7 +430,7 @@ class RadioService : Service() {
                 player?.pause()
                 updatePlaybackState(PlaybackStateCompat.STATE_PAUSED)
                 scheduleSessionDeactivation()
-                startForeground(NOTIFICATION_ID, createNotification("Paused"))
+                startForeground(NOTIFICATION_ID, createNotification(getString(R.string.notification_paused)))
             }
             ACTION_STOP -> {
                 stopRecording()
@@ -1315,7 +1315,7 @@ class RadioService : Service() {
 
     private fun updateNotificationWithRecording() {
         if (player?.isPlaying == true) {
-            startForeground(NOTIFICATION_ID, createNotification("Playing • Recording"))
+            startForeground(NOTIFICATION_ID, createNotification(getString(R.string.notification_playing_recording)))
         }
     }
 
@@ -1351,7 +1351,7 @@ class RadioService : Service() {
                 android.util.Log.e("RadioService", "FORCE TOR ALL: Tor not connected - BLOCKING stream to prevent leak")
                 isStartingNewStream.set(false)  // Reset flag on early return
                 broadcastPlaybackStateChanged(isBuffering = false, isPlaying = false)
-                startForeground(NOTIFICATION_ID, createNotification("Tor not connected - stream blocked"))
+                startForeground(NOTIFICATION_ID, createNotification(getString(R.string.notification_tor_blocked)))
                 return
             }
 
@@ -1360,7 +1360,7 @@ class RadioService : Service() {
                 android.util.Log.e("RadioService", "FORCE TOR (except I2P): Tor not connected - BLOCKING non-I2P stream")
                 isStartingNewStream.set(false)  // Reset flag on early return
                 broadcastPlaybackStateChanged(isBuffering = false, isPlaying = false)
-                startForeground(NOTIFICATION_ID, createNotification("Tor not connected - stream blocked"))
+                startForeground(NOTIFICATION_ID, createNotification(getString(R.string.notification_tor_blocked)))
                 return
             }
 
@@ -1393,7 +1393,7 @@ class RadioService : Service() {
                 isStartingNewStream.set(false)  // Reset flag on early return
                 // Broadcast failure to UI so it can update the play button state
                 broadcastPlaybackStateChanged(isBuffering = false, isPlaying = false)
-                startForeground(NOTIFICATION_ID, createNotification("Audio focus denied"))
+                startForeground(NOTIFICATION_ID, createNotification(getString(R.string.notification_audio_focus_denied)))
                 return
             }
             hasAudioFocus = true
@@ -1570,7 +1570,7 @@ class RadioService : Service() {
                         when (playbackState) {
                             Player.STATE_READY -> {
                                 reconnectAttempts = 0
-                                val status = if (isRecording) "Playing • Recording" else "Playing"
+                                val status = if (isRecording) getString(R.string.notification_playing_recording) else getString(R.string.notification_playing)
                                 startForeground(NOTIFICATION_ID, createNotification(status))
                                 updatePlaybackState(PlaybackStateCompat.STATE_PLAYING)
                                 activateMediaSession()
@@ -1592,7 +1592,7 @@ class RadioService : Service() {
                                 android.util.Log.d("RadioService", "Stream playing successfully")
                             }
                             Player.STATE_BUFFERING -> {
-                                startForeground(NOTIFICATION_ID, createNotification("Buffering..."))
+                                startForeground(NOTIFICATION_ID, createNotification(getString(R.string.notification_buffering)))
                                 updatePlaybackState(PlaybackStateCompat.STATE_BUFFERING)
                                 // Broadcast to UI that we're buffering
                                 broadcastPlaybackStateChanged(isBuffering = true, isPlaying = false)
@@ -1679,7 +1679,7 @@ class RadioService : Service() {
             android.util.Log.e("RadioService", "Max reconnection attempts reached")
             // Broadcast final failure to UI
             broadcastPlaybackStateChanged(isBuffering = false, isPlaying = false)
-            startForeground(NOTIFICATION_ID, createNotification("Connection failed"))
+            startForeground(NOTIFICATION_ID, createNotification(getString(R.string.notification_connection_failed)))
             return
         }
 
@@ -1689,7 +1689,7 @@ class RadioService : Service() {
         android.util.Log.d("RadioService", "Reconnecting in ${delay}ms (attempt $reconnectAttempts)")
         // Keep buffering state while reconnecting
         broadcastPlaybackStateChanged(isBuffering = true, isPlaying = false)
-        startForeground(NOTIFICATION_ID, createNotification("Reconnecting..."))
+        startForeground(NOTIFICATION_ID, createNotification(getString(R.string.notification_reconnecting)))
 
         // Cancel any pending reconnect before scheduling a new one
         reconnectRunnable?.let { handler.removeCallbacks(it) }
@@ -1770,10 +1770,10 @@ class RadioService : Service() {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             val channel = NotificationChannel(
                 CHANNEL_ID,
-                "deutsia radio Playback",
+                getString(R.string.notification_channel_name),
                 NotificationManager.IMPORTANCE_LOW
             ).apply {
-                description = "Shows radio playback status"
+                description = getString(R.string.notification_channel_description)
             }
 
             val notificationManager = getSystemService(NotificationManager::class.java)
@@ -1818,8 +1818,8 @@ class RadioService : Service() {
             .setContentText(status)
             .setSmallIcon(R.drawable.ic_radio)
             .setContentIntent(pendingIntent)
-            .addAction(R.drawable.ic_pause, "Pause", playPausePendingIntent)
-            .addAction(R.drawable.ic_stop, "Stop", stopPendingIntent)
+            .addAction(R.drawable.ic_pause, getString(R.string.notification_action_pause), playPausePendingIntent)
+            .addAction(R.drawable.ic_stop, getString(R.string.notification_action_stop), stopPendingIntent)
             .setStyle(mediaStyle)
             .setOngoing(true)
             .setVisibility(NotificationCompat.VISIBILITY_PUBLIC)

--- a/app/src/main/java/com/opensource/i2pradio/ui/AddEditRadioDialog.kt
+++ b/app/src/main/java/com/opensource/i2pradio/ui/AddEditRadioDialog.kt
@@ -248,9 +248,9 @@ class AddEditRadioDialog : DialogFragment() {
         }
 
         return AlertDialog.Builder(requireContext())
-            .setTitle(if (stationId == -1L) "Add Radio Station" else "Edit Radio Station")
+            .setTitle(if (stationId == -1L) getString(R.string.dialog_add_station) else getString(R.string.dialog_edit_station))
             .setView(view)
-            .setPositiveButton("Save") { _, _ ->
+            .setPositiveButton(getString(R.string.button_save)) { _, _ ->
                 val name = nameInput.text.toString()
                 val url = urlInput.text.toString()
                 val genre = genreInput.text.toString().ifEmpty { "Other" }
@@ -339,7 +339,7 @@ class AddEditRadioDialog : DialogFragment() {
                     onSaveCallback?.invoke(station)
                 }
             }
-            .setNegativeButton("Cancel", null)
+            .setNegativeButton(getString(R.string.button_cancel), null)
             .create()
     }
 

--- a/app/src/main/java/com/opensource/i2pradio/ui/LibraryFragment.kt
+++ b/app/src/main/java/com/opensource/i2pradio/ui/LibraryFragment.kt
@@ -246,7 +246,7 @@ class LibraryFragment : Fragment() {
         val currentIndex = currentSortOrder.ordinal
 
         AlertDialog.Builder(requireContext())
-            .setTitle("Sort Stations")
+            .setTitle(getString(R.string.dialog_sort_stations))
             .setSingleChoiceItems(sortOptions, currentIndex) { dialog, which ->
                 currentSortOrder = SortOrder.entries[which]
                 PreferencesHelper.setSortOrder(requireContext(), currentSortOrder.name)
@@ -643,7 +643,7 @@ class LibraryFragment : Fragment() {
         }
 
         AlertDialog.Builder(requireContext())
-            .setTitle("Delete stations")
+            .setTitle(getString(R.string.dialog_delete_stations))
             .setMessage("Are you sure you want to delete $selectedCount station${if (selectedCount > 1) "s" else ""}?")
             .setPositiveButton("Delete") { _, _ ->
                 deleteSelectedStations()

--- a/app/src/main/java/com/opensource/i2pradio/ui/NowPlayingFragment.kt
+++ b/app/src/main/java/com/opensource/i2pradio/ui/NowPlayingFragment.kt
@@ -183,14 +183,14 @@ class NowPlayingFragment : Fragment() {
                     val errorMessage = intent.getStringExtra(RadioService.EXTRA_ERROR_MESSAGE) ?: "Unknown error"
                     // Reset recording state in ViewModel
                     viewModel.onRecordingError()
-                    Toast.makeText(context, "Recording failed: $errorMessage", Toast.LENGTH_LONG).show()
+                    Toast.makeText(context, getString(R.string.recording_failed, errorMessage), Toast.LENGTH_LONG).show()
                 }
                 RadioService.BROADCAST_RECORDING_COMPLETE -> {
                     val filePath = intent.getStringExtra(RadioService.EXTRA_FILE_PATH) ?: ""
                     val fileSize = intent.getLongExtra(RadioService.EXTRA_FILE_SIZE, 0L)
                     val sizeKB = fileSize / 1024
                     val fileName = filePath.substringAfterLast("/")
-                    Toast.makeText(context, "Recording saved: $fileName (${sizeKB}KB)", Toast.LENGTH_LONG).show()
+                    Toast.makeText(context, getString(R.string.recording_saved, fileName, sizeKB), Toast.LENGTH_LONG).show()
                 }
                 RadioService.BROADCAST_COVER_ART_CHANGED -> {
                     val coverArtUri = intent.getStringExtra(RadioService.EXTRA_COVER_ART_URI)
@@ -617,12 +617,12 @@ class NowPlayingFragment : Fragment() {
             val recordingState = viewModel.recordingState.value
             if (recordingState?.isRecording == true) {
                 viewModel.stopRecording()
-                Toast.makeText(requireContext(), "Stopping recording...", Toast.LENGTH_SHORT).show()
+                Toast.makeText(requireContext(), getString(R.string.recording_stopping), Toast.LENGTH_SHORT).show()
             } else {
                 if (viewModel.startRecording()) {
-                    Toast.makeText(requireContext(), "Starting recording...", Toast.LENGTH_SHORT).show()
+                    Toast.makeText(requireContext(), getString(R.string.recording_starting), Toast.LENGTH_SHORT).show()
                 } else {
-                    Toast.makeText(requireContext(), "No station playing", Toast.LENGTH_SHORT).show()
+                    Toast.makeText(requireContext(), getString(R.string.recording_no_station), Toast.LENGTH_SHORT).show()
                 }
             }
         }
@@ -754,7 +754,7 @@ class NowPlayingFragment : Fragment() {
 
             // Title
             val title = TextView(requireContext()).apply {
-                text = "Radio Volume"
+                text = getString(R.string.now_playing_volume_title)
                 textSize = 20f
                 setTextColor(com.google.android.material.color.MaterialColors.getColor(
                     this, com.google.android.material.R.attr.colorOnSurface))
@@ -764,7 +764,7 @@ class NowPlayingFragment : Fragment() {
 
             // Subtitle explaining this is radio-only
             val subtitle = TextView(requireContext()).apply {
-                text = "Adjusts radio stream only"
+                text = getString(R.string.now_playing_volume_description)
                 textSize = 12f
                 setTextColor(com.google.android.material.color.MaterialColors.getColor(
                     this, com.google.android.material.R.attr.colorOnSurfaceVariant))

--- a/app/src/main/java/com/opensource/i2pradio/ui/SettingsFragment.kt
+++ b/app/src/main/java/com/opensource/i2pradio/ui/SettingsFragment.kt
@@ -124,7 +124,7 @@ class SettingsFragment : Fragment() {
             // Save the URI
             PreferencesHelper.setRecordingDirectoryUri(requireContext(), selectedUri.toString())
             updateRecordingDirectoryDisplay()
-            Toast.makeText(requireContext(), "Recording directory updated", Toast.LENGTH_SHORT).show()
+            Toast.makeText(requireContext(), getString(R.string.recording_directory_updated), Toast.LENGTH_SHORT).show()
         }
     }
 
@@ -314,7 +314,7 @@ class SettingsFragment : Fragment() {
             clipboard.setPrimaryClip(clip)
 
             // Show a toast to confirm
-            Toast.makeText(requireContext(), "Address copied to clipboard", Toast.LENGTH_SHORT).show()
+            Toast.makeText(requireContext(), getString(R.string.toast_address_copied), Toast.LENGTH_SHORT).show()
         }
 
         // Sleep timer button
@@ -912,13 +912,13 @@ class SettingsFragment : Fragment() {
                         // Default
                         PreferencesHelper.setRecordingDirectoryUri(requireContext(), null)
                         updateRecordingDirectoryDisplay()
-                        Toast.makeText(requireContext(), "Using default directory", Toast.LENGTH_SHORT).show()
+                        Toast.makeText(requireContext(), getString(R.string.toast_using_default_directory), Toast.LENGTH_SHORT).show()
                     }
                     savedUri != null && which == 1 -> {
                         // Clear custom folder
                         PreferencesHelper.setRecordingDirectoryUri(requireContext(), null)
                         updateRecordingDirectoryDisplay()
-                        Toast.makeText(requireContext(), "Using default directory", Toast.LENGTH_SHORT).show()
+                        Toast.makeText(requireContext(), getString(R.string.toast_using_default_directory), Toast.LENGTH_SHORT).show()
                     }
                     else -> {
                         // Choose custom folder
@@ -1312,7 +1312,7 @@ class SettingsFragment : Fragment() {
                 .setPositiveButton("Reset") { _, _ ->
                     PreferencesHelper.resetSessionBandwidthUsage(requireContext())
                     updateBandwidthDisplay()
-                    Toast.makeText(requireContext(), "Session bandwidth reset", Toast.LENGTH_SHORT).show()
+                    Toast.makeText(requireContext(), getString(R.string.toast_session_bandwidth_reset), Toast.LENGTH_SHORT).show()
                 }
                 .setNegativeButton("Cancel", null)
                 .show()
@@ -1418,7 +1418,7 @@ class SettingsFragment : Fragment() {
                 androidx.localbroadcastmanager.content.LocalBroadcastManager.getInstance(requireContext())
                     .sendBroadcast(broadcastIntent)
 
-                Toast.makeText(requireContext(), "Custom proxy settings saved", Toast.LENGTH_SHORT).show()
+                Toast.makeText(requireContext(), getString(R.string.toast_custom_proxy_saved), Toast.LENGTH_SHORT).show()
             }
             .setNeutralButton("Clear Proxy") { _, _ ->
                 // Clear all proxy settings
@@ -1441,7 +1441,7 @@ class SettingsFragment : Fragment() {
                 androidx.localbroadcastmanager.content.LocalBroadcastManager.getInstance(requireContext())
                     .sendBroadcast(broadcastIntent)
 
-                Toast.makeText(requireContext(), "Custom proxy settings cleared", Toast.LENGTH_SHORT).show()
+                Toast.makeText(requireContext(), getString(R.string.toast_custom_proxy_cleared), Toast.LENGTH_SHORT).show()
             }
             .setNegativeButton("Cancel", null)
             .show()

--- a/app/src/main/res/layout/bottom_sheet_equalizer.xml
+++ b/app/src/main/res/layout/bottom_sheet_equalizer.xml
@@ -83,7 +83,7 @@
             <TextView
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="0 dB"
+                android:text="@string/default_equalizer_db"
                 android:textSize="11sp"
                 android:textColor="?attr/colorOnSurfaceVariant" />
 

--- a/app/src/main/res/layout/bottom_sheet_tor_control.xml
+++ b/app/src/main/res/layout/bottom_sheet_tor_control.xml
@@ -94,7 +94,7 @@
             <TextView
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="Connection Details"
+                android:text="@string/tor_connection_details"
                 android:textSize="12sp"
                 android:textStyle="bold"
                 android:textColor="?attr/colorPrimary"
@@ -114,7 +114,7 @@
                     <TextView
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:text="Proxy Host"
+                        android:text="@string/tor_proxy_host"
                         android:textSize="11sp"
                         android:textColor="?attr/colorOnSurfaceVariant" />
 
@@ -138,7 +138,7 @@
                     <TextView
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:text="SOCKS Port"
+                        android:text="@string/tor_socks_port"
                         android:textSize="11sp"
                         android:textColor="?attr/colorOnSurfaceVariant" />
 
@@ -199,7 +199,7 @@
                 <TextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:text="What is Orbot?"
+                    android:text="@string/tor_what_is_orbot"
                     android:textSize="14sp"
                     android:textStyle="bold"
                     android:textColor="?attr/colorOnSurface" />
@@ -208,7 +208,7 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="2dp"
-                    android:text="Orbot is the official Tor client for Android. It provides secure, encrypted access to the Tor network."
+                    android:text="@string/tor_orbot_description"
                     android:textSize="12sp"
                     android:textColor="?attr/colorOnSurfaceVariant" />
 
@@ -235,7 +235,7 @@
             android:id="@+id/primaryActionButton"
             android:layout_width="match_parent"
             android:layout_height="56dp"
-            android:text="Connect to Tor"
+            android:text="@string/tor_connect"
             android:textSize="16sp"
             app:cornerRadius="28dp"
             app:icon="@drawable/ic_tor_on"
@@ -248,7 +248,7 @@
             android:layout_width="match_parent"
             android:layout_height="48dp"
             android:layout_marginTop="8dp"
-            android:text="Open Orbot"
+            android:text="@string/tor_open_orbot"
             android:textSize="14sp"
             app:cornerRadius="24dp" />
 

--- a/app/src/main/res/layout/dialog_add_edit_radio.xml
+++ b/app/src/main/res/layout/dialog_add_edit_radio.xml
@@ -16,7 +16,7 @@
             android:id="@+id/nameInputLayout"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:hint="Station Name"
+            android:hint="@string/hint_station_name"
             style="@style/Widget.Material3.TextInputLayout.OutlinedBox"
             app:startIconDrawable="@drawable/ic_label">
 
@@ -35,7 +35,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginTop="16dp"
-            android:hint="Stream URL"
+            android:hint="@string/hint_stream_url"
             style="@style/Widget.Material3.TextInputLayout.OutlinedBox"
             app:startIconDrawable="@drawable/ic_link">
 
@@ -54,7 +54,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginTop="16dp"
-            android:hint="Genre"
+            android:hint="@string/hint_genre"
             style="@style/Widget.Material3.TextInputLayout.OutlinedBox.ExposedDropdownMenu">
 
             <AutoCompleteTextView
@@ -71,7 +71,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginTop="16dp"
-            android:hint="Proxy Type"
+            android:hint="@string/hint_proxy_type"
             style="@style/Widget.Material3.TextInputLayout.OutlinedBox.ExposedDropdownMenu">
 
             <AutoCompleteTextView
@@ -105,7 +105,7 @@
                 android:layout_height="wrap_content"
                 android:layout_weight="1"
                 android:layout_marginStart="12dp"
-                android:text="Using embedded Tor - no proxy config needed"
+                android:text="@string/add_edit_tor_info"
                 android:textSize="12sp"
                 android:textColor="?attr/colorOnSurfaceVariant" />
 
@@ -123,14 +123,14 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="8dp"
-                android:hint="Proxy Host"
+                android:hint="@string/hint_proxy_host"
                 style="@style/Widget.Material3.TextInputLayout.OutlinedBox">
 
                 <com.google.android.material.textfield.TextInputEditText
                     android:id="@+id/proxyHostInput"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:text="127.0.0.1"
+                    android:text="@string/default_proxy_host_i2p"
                     android:inputType="text" />
 
             </com.google.android.material.textfield.TextInputLayout>
@@ -139,14 +139,14 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="8dp"
-                android:hint="Proxy Port"
+                android:hint="@string/hint_proxy_port"
                 style="@style/Widget.Material3.TextInputLayout.OutlinedBox">
 
                 <com.google.android.material.textfield.TextInputEditText
                     android:id="@+id/proxyPortInput"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:text="4444"
+                    android:text="@string/default_proxy_port_i2p"
                     android:inputType="number" />
 
             </com.google.android.material.textfield.TextInputLayout>
@@ -167,7 +167,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="8dp"
-                android:hint="Protocol"
+                android:hint="@string/hint_protocol"
                 style="@style/Widget.Material3.TextInputLayout.OutlinedBox.ExposedDropdownMenu">
 
                 <AutoCompleteTextView
@@ -183,7 +183,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="16dp"
-                android:text="Authentication (Optional)"
+                android:text="@string/add_edit_authentication_optional"
                 android:textSize="12sp"
                 android:textStyle="bold"
                 android:textColor="?attr/colorOnSurfaceVariant" />
@@ -193,7 +193,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="8dp"
-                android:hint="Username (optional)"
+                android:hint="@string/hint_username_optional"
                 style="@style/Widget.Material3.TextInputLayout.OutlinedBox">
 
                 <com.google.android.material.textfield.TextInputEditText
@@ -210,7 +210,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="8dp"
-                android:hint="Password (optional)"
+                android:hint="@string/hint_password_optional"
                 style="@style/Widget.Material3.TextInputLayout.OutlinedBox"
                 app:endIconMode="password_toggle">
 
@@ -228,7 +228,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="8dp"
-                android:hint="Auth Method"
+                android:hint="@string/hint_auth_method"
                 style="@style/Widget.Material3.TextInputLayout.OutlinedBox.ExposedDropdownMenu">
 
                 <AutoCompleteTextView
@@ -251,7 +251,7 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="16dp"
-                    android:text="Advanced Options"
+                    android:text="@string/add_edit_advanced_options"
                     android:textSize="12sp"
                     android:textStyle="bold"
                     android:textColor="?attr/colorOnSurfaceVariant" />
@@ -261,7 +261,7 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="8dp"
-                    android:hint="Connection Timeout (seconds)"
+                    android:hint="@string/hint_connection_timeout"
                     style="@style/Widget.Material3.TextInputLayout.OutlinedBox"
                     app:helperText="Default: 30 seconds">
 
@@ -270,7 +270,7 @@
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
                         android:inputType="number"
-                        android:text="30"
+                        android:text="@string/default_timeout"
                         android:maxLines="1" />
 
                 </com.google.android.material.textfield.TextInputLayout>
@@ -284,7 +284,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginTop="24dp"
-            android:text="Cover Art"
+            android:text="@string/add_edit_cover_art"
             android:textSize="14sp"
             android:textStyle="bold"
             android:textColor="?attr/colorPrimary" />
@@ -322,7 +322,7 @@
                 style="@style/Widget.Material3.Button.TonalButton"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="Choose Image"
+                android:text="@string/button_choose_image"
                 app:icon="@drawable/ic_image" />
 
             <com.google.android.material.button.MaterialButton
@@ -331,7 +331,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginStart="8dp"
-                android:text="Clear"
+                android:text="@string/button_clear"
                 android:visibility="gone"
                 app:icon="@drawable/ic_close" />
 
@@ -342,7 +342,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginTop="16dp"
-            android:text="Or enter image URL"
+            android:text="@string/add_edit_or_enter_url"
             android:textSize="12sp"
             android:gravity="center"
             android:textColor="?attr/colorOnSurfaceVariant" />
@@ -351,7 +351,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginTop="8dp"
-            android:hint="Cover Art URL (optional)"
+            android:hint="@string/hint_cover_art_url"
             style="@style/Widget.Material3.TextInputLayout.OutlinedBox">
 
             <com.google.android.material.textfield.TextInputEditText

--- a/app/src/main/res/layout/dialog_configure_proxy.xml
+++ b/app/src/main/res/layout/dialog_configure_proxy.xml
@@ -15,7 +15,7 @@
         <com.google.android.material.textfield.TextInputLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:hint="Proxy Host"
+            android:hint="@string/hint_proxy_host"
             style="@style/Widget.Material3.TextInputLayout.OutlinedBox">
 
             <com.google.android.material.textfield.TextInputEditText
@@ -32,7 +32,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginTop="16dp"
-            android:hint="Proxy Port"
+            android:hint="@string/hint_proxy_port"
             style="@style/Widget.Material3.TextInputLayout.OutlinedBox">
 
             <com.google.android.material.textfield.TextInputEditText
@@ -41,7 +41,7 @@
                 android:layout_height="wrap_content"
                 android:inputType="number"
                 android:singleLine="true"
-                android:text="8080" />
+                android:text="@string/default_proxy_port_http" />
 
         </com.google.android.material.textfield.TextInputLayout>
 
@@ -50,7 +50,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginTop="16dp"
-            android:hint="Protocol"
+            android:hint="@string/hint_protocol"
             style="@style/Widget.Material3.TextInputLayout.OutlinedBox.ExposedDropdownMenu">
 
             <AutoCompleteTextView
@@ -58,7 +58,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:inputType="none"
-                android:text="HTTP" />
+                android:text="@string/default_protocol_http" />
 
         </com.google.android.material.textfield.TextInputLayout>
 
@@ -67,7 +67,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginTop="16dp"
-            android:hint="Username (Optional)"
+            android:hint="@string/hint_username_optional_caps"
             style="@style/Widget.Material3.TextInputLayout.OutlinedBox">
 
             <com.google.android.material.textfield.TextInputEditText
@@ -84,7 +84,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginTop="16dp"
-            android:hint="Password (Optional)"
+            android:hint="@string/hint_password_optional_caps"
             style="@style/Widget.Material3.TextInputLayout.OutlinedBox"
             app:endIconMode="password_toggle">
 
@@ -102,7 +102,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginTop="16dp"
-            android:hint="Authentication Type"
+            android:hint="@string/hint_auth_type"
             style="@style/Widget.Material3.TextInputLayout.OutlinedBox.ExposedDropdownMenu">
 
             <AutoCompleteTextView
@@ -110,7 +110,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:inputType="none"
-                android:text="None" />
+                android:text="@string/default_auth_none" />
 
         </com.google.android.material.textfield.TextInputLayout>
 
@@ -119,7 +119,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginTop="16dp"
-            android:hint="Connection Timeout (seconds)"
+            android:hint="@string/hint_connection_timeout"
             style="@style/Widget.Material3.TextInputLayout.OutlinedBox">
 
             <com.google.android.material.textfield.TextInputEditText
@@ -128,7 +128,7 @@
                 android:layout_height="wrap_content"
                 android:inputType="number"
                 android:singleLine="true"
-                android:text="30" />
+                android:text="@string/default_timeout" />
 
         </com.google.android.material.textfield.TextInputLayout>
 
@@ -139,7 +139,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginTop="24dp"
-            android:text="Test Connection"
+            android:text="@string/button_test_connection"
             app:icon="@drawable/ic_link"
             app:iconGravity="start" />
 

--- a/app/src/main/res/layout/fragment_library.xml
+++ b/app/src/main/res/layout/fragment_library.xml
@@ -79,7 +79,7 @@
                 style="@style/Widget.Material3.Button.TextButton.Icon"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="Default"
+                android:text="@string/sort_default"
                 android:textSize="12sp"
                 app:icon="@drawable/ic_sort"
                 app:iconSize="24dp" />

--- a/app/src/main/res/layout/fragment_now_playing.xml
+++ b/app/src/main/res/layout/fragment_now_playing.xml
@@ -256,7 +256,7 @@
                 android:id="@+id/playbackElapsedTime"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="00:00"
+                android:text="@string/now_playing_time_placeholder"
                 android:textSize="12sp"
                 android:fontFamily="monospace"
                 android:textColor="?attr/colorOnSurfaceVariant" />
@@ -272,7 +272,7 @@
                 android:id="@+id/liveIndicator"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="LIVE"
+                android:text="@string/now_playing_live"
                 android:textSize="10sp"
                 android:textStyle="bold"
                 android:textColor="?attr/colorPrimary"
@@ -331,7 +331,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginStart="8dp"
-                android:text="00:00"
+                android:text="@string/now_playing_time_placeholder"
                 android:textSize="14sp"
                 android:fontFamily="monospace"
                 android:textColor="?attr/colorOnErrorContainer" />
@@ -364,7 +364,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginTop="16dp"
-            android:text="No Station Playing"
+            android:text="@string/now_playing_no_station"
             android:textSize="20sp"
             android:textStyle="bold"
             android:textColor="?attr/colorOnSurface" />
@@ -373,7 +373,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginTop="8dp"
-            android:text="Select a station from the list"
+            android:text="@string/now_playing_no_station_subtitle"
             android:textSize="14sp"
             android:textColor="?attr/colorOnSurfaceVariant" />
 

--- a/app/src/main/res/layout/fragment_settings.xml
+++ b/app/src/main/res/layout/fragment_settings.xml
@@ -22,7 +22,7 @@
             <TextView
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="deutsia radio"
+                android:text="@string/app_name"
                 android:textSize="28sp"
                 android:textStyle="bold"
                 android:textColor="?attr/colorPrimary" />
@@ -31,7 +31,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="8dp"
-                android:text="Version 1.0"
+                android:text="@string/settings_version"
                 android:textSize="14sp"
                 android:textColor="?attr/colorOnSurfaceVariant" />
 
@@ -56,7 +56,7 @@
                 <TextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:text="Appearance"
+                    android:text="@string/settings_appearance"
                     android:textSize="14sp"
                     android:textStyle="bold"
                     android:textColor="?attr/colorPrimary"
@@ -79,14 +79,14 @@
                         <TextView
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
-                            android:text="Theme"
+                            android:text="@string/settings_theme"
                             android:textSize="16sp"
                             android:textColor="?attr/colorOnSurface" />
 
                         <TextView
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
-                            android:text="Choose light, dark, or system"
+                            android:text="@string/settings_theme_description"
                             android:textSize="12sp"
                             android:textColor="?attr/colorOnSurfaceVariant" />
 
@@ -97,7 +97,7 @@
                         style="@style/Widget.Material3.Button.TonalButton"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:text="System Default"
+                        android:text="@string/settings_theme_system_default"
                         android:textSize="12sp" />
 
                 </LinearLayout>
@@ -121,14 +121,14 @@
                         <TextView
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
-                            android:text="Material You"
+                            android:text="@string/settings_material_you"
                             android:textSize="16sp"
                             android:textColor="?attr/colorOnSurface" />
 
                         <TextView
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
-                            android:text="Use wallpaper-based dynamic colors"
+                            android:text="@string/settings_material_you_description"
                             android:textSize="12sp"
                             android:textColor="?attr/colorOnSurfaceVariant" />
 
@@ -159,14 +159,14 @@
                         <TextView
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
-                            android:text="Color Scheme"
+                            android:text="@string/settings_color_scheme"
                             android:textSize="16sp"
                             android:textColor="?attr/colorOnSurface" />
 
                         <TextView
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
-                            android:text="Choose your preferred color"
+                            android:text="@string/settings_color_scheme_description"
                             android:textSize="12sp"
                             android:textColor="?attr/colorOnSurfaceVariant" />
 
@@ -177,7 +177,7 @@
                         style="@style/Widget.Material3.Button.TonalButton"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:text="Blue"
+                        android:text="@string/settings_color_blue"
                         android:textSize="12sp" />
 
                 </LinearLayout>
@@ -207,7 +207,7 @@
                 <TextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:text="Tor Network"
+                    android:text="@string/settings_tor_network"
                     android:textSize="14sp"
                     android:textStyle="bold"
                     android:textColor="?attr/colorPrimary"
@@ -230,14 +230,14 @@
                         <TextView
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
-                            android:text="Enable Tor (via Orbot)"
+                            android:text="@string/settings_enable_tor"
                             android:textSize="16sp"
                             android:textColor="?attr/colorOnSurface" />
 
                         <TextView
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
-                            android:text="Connect through the Tor network"
+                            android:text="@string/settings_enable_tor_description"
                             android:textSize="12sp"
                             android:textColor="?attr/colorOnSurfaceVariant" />
 
@@ -281,7 +281,7 @@
                             android:id="@+id/torStatusText"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
-                            android:text="Disconnected"
+                            android:text="@string/settings_tor_disconnected"
                             android:textSize="14sp"
                             android:textColor="?attr/colorOnSurface" />
 
@@ -289,7 +289,7 @@
                             android:id="@+id/torStatusDetail"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
-                            android:text="Tor is not running"
+                            android:text="@string/settings_tor_not_running"
                             android:textSize="12sp"
                             android:textColor="?attr/colorOnSurfaceVariant" />
 
@@ -300,7 +300,7 @@
                         style="@style/Widget.Material3.Button.TonalButton"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:text="Start"
+                        android:text="@string/button_start"
                         android:textSize="12sp" />
 
                 </LinearLayout>
@@ -325,7 +325,7 @@
                         <TextView
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
-                            android:text="Force Tor Over Everything"
+                            android:text="@string/settings_force_tor"
                             android:textSize="16sp"
                             android:textStyle="bold"
                             android:textColor="?attr/colorOnSurface" />
@@ -333,7 +333,7 @@
                         <TextView
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
-                            android:text="Route all streams through Tor. Won't connect without Tor."
+                            android:text="@string/settings_force_tor_description"
                             android:textSize="12sp"
                             android:textColor="?attr/colorOnSurfaceVariant" />
 
@@ -366,7 +366,7 @@
                         <TextView
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
-                            android:text="Force Tor Except I2P"
+                            android:text="@string/settings_force_tor_except_i2p"
                             android:textSize="16sp"
                             android:textStyle="bold"
                             android:textColor="?attr/colorOnSurface" />
@@ -374,7 +374,7 @@
                         <TextView
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
-                            android:text="Route clearnet through Tor, I2P streams direct to I2P proxy."
+                            android:text="@string/settings_force_tor_except_i2p_description"
                             android:textSize="12sp"
                             android:textColor="?attr/colorOnSurfaceVariant" />
 
@@ -392,7 +392,7 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="16dp"
-                    android:text="Requires Orbot (free from Play Store or F-Droid). Tap the Tor icon in the toolbar for quick access.\n\nForce modes block connections when Tor is unavailable."
+                    android:text="@string/settings_tor_info"
                     android:textSize="12sp"
                     android:textColor="?attr/colorOnSurfaceVariant"
                     android:lineSpacingExtra="2dp" />
@@ -420,7 +420,7 @@
                 <TextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:text="Custom Proxy"
+                    android:text="@string/settings_custom_proxy"
                     android:textSize="14sp"
                     android:textStyle="bold"
                     android:textColor="?attr/colorPrimary"
@@ -443,14 +443,14 @@
                         <TextView
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
-                            android:text="Configure Global Proxy"
+                            android:text="@string/settings_configure_proxy"
                             android:textSize="16sp"
                             android:textColor="?attr/colorOnSurface" />
 
                         <TextView
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
-                            android:text="Set up your custom proxy settings"
+                            android:text="@string/settings_configure_proxy_description"
                             android:textSize="12sp"
                             android:textColor="?attr/colorOnSurfaceVariant" />
 
@@ -461,7 +461,7 @@
                         style="@style/Widget.Material3.Button.TonalButton"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:text="Configure"
+                        android:text="@string/button_configure"
                         android:textSize="12sp" />
 
                 </LinearLayout>
@@ -484,14 +484,14 @@
                         <TextView
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
-                            android:text="Apply to All Stations"
+                            android:text="@string/settings_apply_to_all_stations"
                             android:textSize="16sp"
                             android:textColor="?attr/colorOnSurface" />
 
                         <TextView
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
-                            android:text="Route all stations through global custom proxy"
+                            android:text="@string/settings_apply_to_all_stations_description"
                             android:textSize="12sp"
                             android:textColor="?attr/colorOnSurfaceVariant" />
 
@@ -502,7 +502,7 @@
                         style="@style/Widget.Material3.Button.TonalButton"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:text="Apply"
+                        android:text="@string/button_apply"
                         android:textSize="12sp" />
 
                 </LinearLayout>
@@ -526,7 +526,7 @@
                         <TextView
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
-                            android:text="Force Custom Proxy"
+                            android:text="@string/settings_force_custom_proxy"
                             android:textSize="16sp"
                             android:textStyle="bold"
                             android:textColor="?attr/colorOnSurface" />
@@ -534,7 +534,7 @@
                         <TextView
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
-                            android:text="Route all traffic through custom proxy. Won't connect without proxy."
+                            android:text="@string/settings_force_custom_proxy_description"
                             android:textSize="12sp"
                             android:textColor="?attr/colorOnSurfaceVariant" />
 
@@ -570,7 +570,7 @@
         <TextView
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="Bandwidth Usage"
+            android:text="@string/settings_bandwidth_usage"
             android:textSize="14sp"
             android:textStyle="bold"
             android:textColor="?attr/colorPrimary"
@@ -594,7 +594,7 @@
                         <TextView
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
-                            android:text="Total Usage (Lifetime)"
+                            android:text="@string/settings_total_usage"
                             android:textSize="16sp"
                             android:textColor="?attr/colorOnSurface" />
 
@@ -602,7 +602,7 @@
                             android:id="@+id/bandwidthTotalText"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
-                            android:text="0 B"
+                            android:text="@string/settings_bandwidth_zero"
                             android:textSize="12sp"
                             android:textColor="?attr/colorOnSurfaceVariant" />
 
@@ -645,7 +645,7 @@
                         <TextView
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
-                            android:text="Session Usage"
+                            android:text="@string/settings_session_usage"
                             android:textSize="16sp"
                             android:textColor="?attr/colorOnSurface" />
 
@@ -653,7 +653,7 @@
                             android:id="@+id/bandwidthSessionText"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
-                            android:text="0 B"
+                            android:text="@string/settings_bandwidth_zero"
                             android:textSize="12sp"
                             android:textColor="?attr/colorOnSurfaceVariant" />
 
@@ -664,7 +664,7 @@
                         style="@style/Widget.Material3.Button.TextButton"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:text="Reset"
+                        android:text="@string/button_reset"
                         android:textSize="12sp" />
 
                 </LinearLayout>
@@ -692,7 +692,7 @@
                 <TextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:text="Playback"
+                    android:text="@string/settings_playback"
                     android:textSize="14sp"
                     android:textStyle="bold"
                     android:textColor="?attr/colorPrimary"
@@ -715,14 +715,14 @@
                         <TextView
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
-                            android:text="Sleep Timer"
+                            android:text="@string/settings_sleep_timer"
                             android:textSize="16sp"
                             android:textColor="?attr/colorOnSurface" />
 
                         <TextView
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
-                            android:text="Auto-stop playback after set time"
+                            android:text="@string/settings_sleep_timer_description"
                             android:textSize="12sp"
                             android:textColor="?attr/colorOnSurfaceVariant" />
 
@@ -733,7 +733,7 @@
                         style="@style/Widget.Material3.Button.TonalButton"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:text="Off"
+                        android:text="@string/settings_sleep_timer_off"
                         android:textSize="12sp"
                         app:icon="@drawable/ic_timer"
                         app:iconSize="18dp" />
@@ -758,14 +758,14 @@
                         <TextView
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
-                            android:text="Equalizer"
+                            android:text="@string/equalizer"
                             android:textSize="16sp"
                             android:textColor="?attr/colorOnSurface" />
 
                         <TextView
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
-                            android:text="Adjust audio frequency bands and effects"
+                            android:text="@string/settings_equalizer_description"
                             android:textSize="12sp"
                             android:textColor="?attr/colorOnSurfaceVariant" />
 
@@ -776,7 +776,7 @@
                         style="@style/Widget.Material3.Button.TonalButton"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:text="Open"
+                        android:text="@string/button_open"
                         android:textSize="12sp"
                         app:icon="@drawable/ic_equalizer"
                         app:iconSize="18dp" />
@@ -801,7 +801,7 @@
                         <TextView
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
-                            android:text="Recording Directory"
+                            android:text="@string/settings_recording_directory"
                             android:textSize="16sp"
                             android:textColor="?attr/colorOnSurface" />
 
@@ -809,7 +809,7 @@
                             android:id="@+id/recordingDirectoryPath"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
-                            android:text="Default (Music/deutsia_radio)"
+                            android:text="@string/settings_recording_directory_default"
                             android:textSize="12sp"
                             android:textColor="?attr/colorOnSurfaceVariant"
                             android:maxLines="1"
@@ -822,7 +822,7 @@
                         style="@style/Widget.Material3.Button.TonalButton"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:text="Change"
+                        android:text="@string/button_change"
                         android:textSize="12sp"
                         app:icon="@drawable/ic_folder"
                         app:iconSize="18dp" />
@@ -847,14 +847,14 @@
                         <TextView
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
-                            android:text="Record Across Stations"
+                            android:text="@string/settings_record_across_stations"
                             android:textSize="16sp"
                             android:textColor="?attr/colorOnSurface" />
 
                         <TextView
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
-                            android:text="Keep recording when switching stations"
+                            android:text="@string/settings_record_across_stations_description"
                             android:textSize="12sp"
                             android:textColor="?attr/colorOnSurfaceVariant" />
 
@@ -887,14 +887,14 @@
                         <TextView
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
-                            android:text="Record All Stations"
+                            android:text="@string/settings_record_all_stations"
                             android:textSize="16sp"
                             android:textColor="?attr/colorOnSurface" />
 
                         <TextView
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
-                            android:text="Switch to new station's stream in same file"
+                            android:text="@string/settings_record_all_stations_description"
                             android:textSize="12sp"
                             android:textColor="?attr/colorOnSurfaceVariant" />
 
@@ -930,7 +930,7 @@
                 <TextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:text="Station Management"
+                    android:text="@string/settings_station_management"
                     android:textSize="14sp"
                     android:textStyle="bold"
                     android:textColor="?attr/colorPrimary"
@@ -953,14 +953,14 @@
                         <TextView
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
-                            android:text="Import from File"
+                            android:text="@string/settings_import_from_file"
                             android:textSize="16sp"
                             android:textColor="?attr/colorOnSurface" />
 
                         <TextView
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
-                            android:text="Import from CSV, JSON, M3U, or PLS"
+                            android:text="@string/settings_import_from_file_description"
                             android:textSize="12sp"
                             android:textColor="?attr/colorOnSurfaceVariant" />
 
@@ -971,7 +971,7 @@
                         style="@style/Widget.Material3.Button.TonalButton"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:text="Import"
+                        android:text="@string/button_import"
                         android:textSize="12sp"
                         app:icon="@drawable/ic_folder"
                         app:iconSize="18dp" />
@@ -996,14 +996,14 @@
                         <TextView
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
-                            android:text="Import I2P Stations"
+                            android:text="@string/settings_import_i2p_stations"
                             android:textSize="16sp"
                             android:textColor="?attr/colorOnSurface" />
 
                         <TextView
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
-                            android:text="14 curated I2P radio stations"
+                            android:text="@string/settings_import_i2p_stations_description"
                             android:textSize="12sp"
                             android:textColor="?attr/colorOnSurfaceVariant" />
 
@@ -1014,7 +1014,7 @@
                         style="@style/Widget.Material3.Button.TonalButton"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:text="Import"
+                        android:text="@string/button_import"
                         android:textSize="12sp"
                         app:icon="@drawable/ic_folder"
                         app:iconSize="18dp" />
@@ -1039,14 +1039,14 @@
                         <TextView
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
-                            android:text="Import Tor Stations"
+                            android:text="@string/settings_import_tor_stations"
                             android:textSize="16sp"
                             android:textColor="?attr/colorOnSurface" />
 
                         <TextView
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
-                            android:text="3 curated Tor radio stations"
+                            android:text="@string/settings_import_tor_stations_description"
                             android:textSize="12sp"
                             android:textColor="?attr/colorOnSurfaceVariant" />
 
@@ -1057,7 +1057,7 @@
                         style="@style/Widget.Material3.Button.TonalButton"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:text="Import"
+                        android:text="@string/button_import"
                         android:textSize="12sp"
                         app:icon="@drawable/ic_folder"
                         app:iconSize="18dp" />
@@ -1082,14 +1082,14 @@
                         <TextView
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
-                            android:text="Export Stations"
+                            android:text="@string/settings_export_stations"
                             android:textSize="16sp"
                             android:textColor="?attr/colorOnSurface" />
 
                         <TextView
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
-                            android:text="Export your stations to a file"
+                            android:text="@string/settings_export_stations_description"
                             android:textSize="12sp"
                             android:textColor="?attr/colorOnSurfaceVariant" />
 
@@ -1100,7 +1100,7 @@
                         style="@style/Widget.Material3.Button.TonalButton"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:text="Export"
+                        android:text="@string/button_export"
                         android:textSize="12sp"
                         app:icon="@drawable/ic_share"
                         app:iconSize="18dp" />
@@ -1130,7 +1130,7 @@
                 <TextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:text="About"
+                    android:text="@string/settings_about"
                     android:textSize="14sp"
                     android:textStyle="bold"
                     android:textColor="?attr/colorPrimary"
@@ -1150,7 +1150,7 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="8dp"
-                    android:text="View on GitHub"
+                    android:text="@string/settings_view_github"
                     app:icon="@drawable/ic_github" />
 
             </LinearLayout>
@@ -1176,7 +1176,7 @@
                 <TextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:text="Donate"
+                    android:text="@string/settings_donate"
                     android:textSize="14sp"
                     android:textStyle="bold"
                     android:textColor="?attr/colorPrimary"
@@ -1185,7 +1185,7 @@
                 <TextView
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:text="If this app helped you out, consider donating"
+                    android:text="@string/settings_donate_description"
                     android:textSize="14sp"
                     android:textColor="?attr/colorOnSurfaceVariant"
                     android:lineSpacingExtra="4dp"
@@ -1194,7 +1194,7 @@
                 <TextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:text="Monero (XMR)"
+                    android:text="@string/settings_monero"
                     android:textSize="12sp"
                     android:textStyle="bold"
                     android:textColor="?attr/colorPrimary"
@@ -1204,7 +1204,7 @@
                     android:id="@+id/moneroAddress"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:text="83GGx86c6ZePiz8tEcGYtGJYmnjuP8W9cfLx6s98WAu8YkenjLr4zFC4RxcCk3hwFUiv59wS8KRPzNUUUqTrrYXCJAk4nrN"
+                    android:text="@string/settings_monero_address"
                     android:textSize="11sp"
                     android:textColor="?attr/colorOnSurfaceVariant"
                     android:fontFamily="monospace"
@@ -1217,7 +1217,7 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="8dp"
-                    android:text="Copy Address" />
+                    android:text="@string/settings_copy_address" />
 
             </LinearLayout>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -61,4 +61,175 @@
     <string name="station_added_to_favorites">%s added to favorites</string>
     <string name="station_removed_from_favorites">%s removed from favorites</string>
     <string name="tor_required_warning">Force Tor is enabled but Tor is not connected. Connect to Tor to browse stations.</string>
+
+    <!-- Notification and Status Messages -->
+    <string name="notification_connecting">Connecting...</string>
+    <string name="notification_paused">Paused</string>
+    <string name="notification_playing">Playing</string>
+    <string name="notification_playing_recording">Playing • Recording</string>
+    <string name="notification_buffering">Buffering...</string>
+    <string name="notification_reconnecting">Reconnecting...</string>
+    <string name="notification_connection_failed">Connection failed</string>
+    <string name="notification_tor_blocked">Tor not connected - stream blocked</string>
+    <string name="notification_audio_focus_denied">Audio focus denied</string>
+    <string name="notification_channel_name">deutsia radio Playback</string>
+    <string name="notification_channel_description">Shows radio playback status</string>
+    <string name="notification_action_pause">Pause</string>
+    <string name="notification_action_stop">Stop</string>
+
+    <!-- Recording Messages -->
+    <string name="recording_failed">Recording failed: %s</string>
+    <string name="recording_saved">Recording saved: %s (%dKB)</string>
+    <string name="recording_stopping">Stopping recording...</string>
+    <string name="recording_starting">Starting recording...</string>
+    <string name="recording_no_station">No station playing</string>
+    <string name="recording_directory_updated">Recording directory updated</string>
+
+    <!-- Dialog Titles and Buttons -->
+    <string name="dialog_add_station">Add Radio Station</string>
+    <string name="dialog_edit_station">Edit Radio Station</string>
+    <string name="dialog_sort_stations">Sort Stations</string>
+    <string name="dialog_delete_stations">Delete stations</string>
+    <string name="button_save">Save</string>
+    <string name="button_cancel">Cancel</string>
+    <string name="button_import">Import</string>
+    <string name="button_export">Export</string>
+    <string name="button_open">Open</string>
+    <string name="button_configure">Configure</string>
+    <string name="button_apply">Apply</string>
+    <string name="button_reset">Reset</string>
+    <string name="button_change">Change</string>
+    <string name="button_start">Start</string>
+    <string name="button_test_connection">Test Connection</string>
+    <string name="button_choose_image">Choose Image</string>
+    <string name="button_clear">Clear</string>
+
+    <!-- Settings - Appearance -->
+    <string name="settings_appearance">Appearance</string>
+    <string name="settings_theme">Theme</string>
+    <string name="settings_theme_description">Choose light, dark, or system</string>
+    <string name="settings_theme_system_default">System Default</string>
+    <string name="settings_material_you">Material You</string>
+    <string name="settings_material_you_description">Use wallpaper-based dynamic colors</string>
+    <string name="settings_color_scheme">Color Scheme</string>
+    <string name="settings_color_scheme_description">Choose your preferred color</string>
+    <string name="settings_color_blue">Blue</string>
+
+    <!-- Settings - Tor Network -->
+    <string name="settings_tor_network">Tor Network</string>
+    <string name="settings_enable_tor">Enable Tor (via Orbot)</string>
+    <string name="settings_enable_tor_description">Connect through the Tor network</string>
+    <string name="settings_tor_disconnected">Disconnected</string>
+    <string name="settings_tor_not_running">Tor is not running</string>
+    <string name="settings_force_tor">Force Tor Over Everything</string>
+    <string name="settings_force_tor_description">Route all streams through Tor. Won\'t connect without Tor.</string>
+    <string name="settings_force_tor_except_i2p">Force Tor Except I2P</string>
+    <string name="settings_force_tor_except_i2p_description">Route clearnet through Tor, I2P streams direct to I2P proxy.</string>
+    <string name="settings_tor_info">Requires Orbot (free from Play Store or F-Droid). Tap the Tor icon in the toolbar for quick access.\n\nForce modes block connections when Tor is unavailable.</string>
+
+    <!-- Settings - Custom Proxy -->
+    <string name="settings_custom_proxy">Custom Proxy</string>
+    <string name="settings_configure_proxy">Configure Global Proxy</string>
+    <string name="settings_configure_proxy_description">Set up your custom proxy settings</string>
+    <string name="settings_apply_to_all_stations">Apply to All Stations</string>
+    <string name="settings_apply_to_all_stations_description">Route all stations through global custom proxy</string>
+    <string name="settings_force_custom_proxy">Force Custom Proxy</string>
+    <string name="settings_force_custom_proxy_description">Route all traffic through custom proxy. Won\'t connect without proxy.</string>
+
+    <!-- Settings - Bandwidth -->
+    <string name="settings_bandwidth_usage">Bandwidth Usage</string>
+    <string name="settings_total_usage">Total Usage (Lifetime)</string>
+    <string name="settings_session_usage">Session Usage</string>
+    <string name="settings_bandwidth_zero">0 B</string>
+
+    <!-- Settings - Playback -->
+    <string name="settings_playback">Playback</string>
+    <string name="settings_sleep_timer">Sleep Timer</string>
+    <string name="settings_sleep_timer_description">Auto-stop playback after set time</string>
+    <string name="settings_sleep_timer_off">Off</string>
+    <string name="settings_equalizer_description">Adjust audio frequency bands and effects</string>
+    <string name="settings_recording_directory">Recording Directory</string>
+    <string name="settings_recording_directory_default">Default (Music/deutsia_radio)</string>
+    <string name="settings_record_across_stations">Record Across Stations</string>
+    <string name="settings_record_across_stations_description">Keep recording when switching stations</string>
+    <string name="settings_record_all_stations">Record All Stations</string>
+    <string name="settings_record_all_stations_description">Switch to new station\'s stream in same file</string>
+
+    <!-- Settings - Station Management -->
+    <string name="settings_station_management">Station Management</string>
+    <string name="settings_import_from_file">Import from File</string>
+    <string name="settings_import_from_file_description">Import from CSV, JSON, M3U, or PLS</string>
+    <string name="settings_import_i2p_stations">Import I2P Stations</string>
+    <string name="settings_import_i2p_stations_description">14 curated I2P radio stations</string>
+    <string name="settings_import_tor_stations">Import Tor Stations</string>
+    <string name="settings_import_tor_stations_description">3 curated Tor radio stations</string>
+    <string name="settings_export_stations">Export Stations</string>
+    <string name="settings_export_stations_description">Export your stations to a file</string>
+
+    <!-- Settings - About -->
+    <string name="settings_about">About</string>
+    <string name="settings_version">Version 1.0</string>
+    <string name="settings_view_github">View on GitHub</string>
+    <string name="settings_donate">Donate</string>
+    <string name="settings_donate_description">If this app helped you out, consider donating</string>
+    <string name="settings_monero">Monero (XMR)</string>
+    <string name="settings_monero_address">83GGx86c6ZePiz8tEcGYtGJYmnjuP8W9cfLx6s98WAu8YkenjLr4zFC4RxcCk3hwFUiv59wS8KRPzNUUUqTrrYXCJAk4nrN</string>
+    <string name="settings_copy_address">Copy Address</string>
+
+    <!-- Tor Control Bottom Sheet -->
+    <string name="tor_connection_details">Connection Details</string>
+    <string name="tor_proxy_host">Proxy Host</string>
+    <string name="tor_socks_port">SOCKS Port</string>
+    <string name="tor_what_is_orbot">What is Orbot?</string>
+    <string name="tor_orbot_description">Orbot is the official Tor client for Android. It provides secure, encrypted access to the Tor network.</string>
+    <string name="tor_connect">Connect to Tor</string>
+    <string name="tor_open_orbot">Open Orbot</string>
+
+    <!-- Add/Edit Radio Dialog -->
+    <string name="add_edit_tor_info">Using embedded Tor - no proxy config needed</string>
+    <string name="add_edit_authentication_optional">Authentication (Optional)</string>
+    <string name="add_edit_advanced_options">Advanced Options</string>
+    <string name="add_edit_cover_art">Cover Art</string>
+    <string name="add_edit_or_enter_url">Or enter image URL</string>
+
+    <!-- Input Hints -->
+    <string name="hint_station_name">Station Name</string>
+    <string name="hint_stream_url">Stream URL</string>
+    <string name="hint_genre">Genre</string>
+    <string name="hint_proxy_type">Proxy Type</string>
+    <string name="hint_proxy_host">Proxy Host</string>
+    <string name="hint_proxy_port">Proxy Port</string>
+    <string name="hint_protocol">Protocol</string>
+    <string name="hint_username_optional">Username (optional)</string>
+    <string name="hint_password_optional">Password (optional)</string>
+    <string name="hint_auth_method">Auth Method</string>
+    <string name="hint_connection_timeout">Connection Timeout (seconds)</string>
+    <string name="hint_cover_art_url">Cover Art URL (optional)</string>
+    <string name="hint_username_optional_caps">Username (Optional)</string>
+    <string name="hint_password_optional_caps">Password (Optional)</string>
+    <string name="hint_auth_type">Authentication Type</string>
+
+    <!-- Default Values -->
+    <string name="default_proxy_host_i2p">127.0.0.1</string>
+    <string name="default_proxy_port_i2p">4444</string>
+    <string name="default_proxy_port_http">8080</string>
+    <string name="default_protocol_http">HTTP</string>
+    <string name="default_auth_none">None</string>
+    <string name="default_timeout">30</string>
+    <string name="default_equalizer_db">0 dB</string>
+
+    <!-- Now Playing Fragment -->
+    <string name="now_playing_time_placeholder">00:00</string>
+    <string name="now_playing_live">LIVE</string>
+    <string name="now_playing_no_station">No Station Playing</string>
+    <string name="now_playing_no_station_subtitle">Select a station from the list</string>
+    <string name="now_playing_volume_title">Radio Volume</string>
+    <string name="now_playing_volume_description">Adjusts radio stream only</string>
+
+    <!-- Toast Messages -->
+    <string name="toast_session_bandwidth_reset">Session bandwidth reset</string>
+    <string name="toast_custom_proxy_saved">Custom proxy settings saved</string>
+    <string name="toast_custom_proxy_cleared">Custom proxy settings cleared</string>
+    <string name="toast_address_copied">Address copied to clipboard</string>
+    <string name="toast_using_default_directory">Using default directory</string>
 </resources>


### PR DESCRIPTION
This commit prepares the app for translation by moving all user-facing hardcoded strings to strings.xml. Changes include:

**strings.xml:**
- Added 170+ new string resources organized by category:
  - Notification and status messages
  - Recording messages
  - Dialog titles and buttons
  - Settings UI (Appearance, Tor, Proxy, Bandwidth, Playback)
  - Tor control bottom sheet
  - Add/Edit radio dialog
  - Input hints and default values
  - Now Playing UI
  - Toast messages

**Kotlin files:**
- RadioService.kt: Replaced notification and status message strings
- NowPlayingFragment.kt: Replaced toast messages and volume dialog text
- SettingsFragment.kt: Replaced toast messages
- LibraryFragment.kt: Replaced dialog titles
- AddEditRadioDialog.kt: Replaced dialog title and button text

**XML layout files:**
- fragment_settings.xml: All UI text now references string resources
- bottom_sheet_tor_control.xml: Connection details and buttons
- dialog_add_edit_radio.xml: Input hints and labels
- dialog_configure_proxy.xml: Proxy configuration UI
- fragment_now_playing.xml: Time placeholders and empty states
- bottom_sheet_equalizer.xml: Default dB label
- fragment_library.xml: Sort button text

All hardcoded strings have been externalized, making the app ready for localization to other languages.