### PR TITLE
Add custom proxy enhancements and new force mode

### DIFF
--- a/app/src/main/java/com/opensource/i2pradio/MainActivity.kt
+++ b/app/src/main/java/com/opensource/i2pradio/MainActivity.kt
@@ -227,12 +227,13 @@ class MainActivity : AppCompatActivity() {
     }
 
     /**
-     * Update proxy status view visibility based on Force Custom Proxy setting
+     * Update proxy status view visibility based on Force Custom Proxy settings
      */
     private fun updateProxyStatusViewVisibility() {
         val isForceCustomProxy = PreferencesHelper.isForceCustomProxy(this)
+        val isForceCustomProxyExceptTorI2P = PreferencesHelper.isForceCustomProxyExceptTorI2P(this)
 
-        if (isForceCustomProxy) {
+        if (isForceCustomProxy || isForceCustomProxyExceptTorI2P) {
             // Show custom proxy status, hide Tor status
             torStatusView.visibility = View.GONE
             customProxyStatusView.visibility = View.VISIBLE

--- a/app/src/main/java/com/opensource/i2pradio/ui/PreferenceHelper.kt
+++ b/app/src/main/java/com/opensource/i2pradio/ui/PreferenceHelper.kt
@@ -41,6 +41,7 @@ object PreferencesHelper {
     private const val KEY_CUSTOM_PROXY_CONNECTION_TIMEOUT = "custom_proxy_connection_timeout"
     private const val KEY_CUSTOM_PROXY_BYPASS_LOCAL = "custom_proxy_bypass_local"
     private const val KEY_FORCE_CUSTOM_PROXY = "force_custom_proxy"
+    private const val KEY_FORCE_CUSTOM_PROXY_EXCEPT_TOR_I2P = "force_custom_proxy_except_tor_i2p"
     private const val KEY_BANDWIDTH_USAGE_TOTAL = "bandwidth_usage_total"
     private const val KEY_BANDWIDTH_USAGE_SESSION = "bandwidth_usage_session"
     private const val KEY_BANDWIDTH_USAGE_LAST_RESET = "bandwidth_usage_last_reset"
@@ -241,6 +242,7 @@ object PreferencesHelper {
             context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
                 .edit()
                 .putBoolean(KEY_FORCE_CUSTOM_PROXY, false)
+                .putBoolean(KEY_FORCE_CUSTOM_PROXY_EXCEPT_TOR_I2P, false)
                 .apply()
         }
     }
@@ -267,6 +269,7 @@ object PreferencesHelper {
             context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
                 .edit()
                 .putBoolean(KEY_FORCE_CUSTOM_PROXY, false)
+                .putBoolean(KEY_FORCE_CUSTOM_PROXY_EXCEPT_TOR_I2P, false)
                 .apply()
         }
     }
@@ -418,7 +421,7 @@ object PreferencesHelper {
 
     fun getCustomProxyProtocol(context: Context): String {
         return context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
-            .getString(KEY_CUSTOM_PROXY_PROTOCOL, "HTTP") ?: "HTTP"
+            .getString(KEY_CUSTOM_PROXY_PROTOCOL, "HTTPS") ?: "HTTPS"
     }
 
     /**
@@ -527,12 +530,41 @@ object PreferencesHelper {
         if (enabled) {
             setForceTorAll(context, false)
             setForceTorExceptI2P(context, false)
+            context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+                .edit()
+                .putBoolean(KEY_FORCE_CUSTOM_PROXY_EXCEPT_TOR_I2P, false)
+                .apply()
         }
     }
 
     fun isForceCustomProxy(context: Context): Boolean {
         return context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
             .getBoolean(KEY_FORCE_CUSTOM_PROXY, false)
+    }
+
+    /**
+     * Force Custom Proxy Except Tor/I2P setting - forces clearnet traffic through custom proxy
+     * but allows Tor and I2P stations to use their native proxies.
+     * When enabled, clearnet traffic goes through the configured custom proxy.
+     * Tor and I2P stations use their native Tor SOCKS proxy and I2P HTTP proxy respectively.
+     * Mutually exclusive with Force Tor modes and Force Custom Proxy.
+     */
+    fun setForceCustomProxyExceptTorI2P(context: Context, enabled: Boolean) {
+        context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+            .edit()
+            .putBoolean(KEY_FORCE_CUSTOM_PROXY_EXCEPT_TOR_I2P, enabled)
+            .apply()
+        // If enabling this, disable other force options (mutual exclusivity)
+        if (enabled) {
+            setForceTorAll(context, false)
+            setForceTorExceptI2P(context, false)
+            setForceCustomProxy(context, false)
+        }
+    }
+
+    fun isForceCustomProxyExceptTorI2P(context: Context): Boolean {
+        return context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+            .getBoolean(KEY_FORCE_CUSTOM_PROXY_EXCEPT_TOR_I2P, false)
     }
 
     // Bandwidth Usage Tracking

--- a/app/src/main/res/layout/dialog_configure_proxy.xml
+++ b/app/src/main/res/layout/dialog_configure_proxy.xml
@@ -58,7 +58,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:inputType="none"
-                android:text="@string/default_protocol_http" />
+                android:text="@string/default_protocol_https" />
 
         </com.google.android.material.textfield.TextInputLayout>
 

--- a/app/src/main/res/layout/fragment_settings.xml
+++ b/app/src/main/res/layout/fragment_settings.xml
@@ -507,6 +507,14 @@
 
                 </LinearLayout>
 
+                <!-- Custom Proxy Status View -->
+                <com.opensource.i2pradio.ui.CustomProxyStatusView
+                    android:id="@+id/customProxyStatusViewSettings"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="16dp"
+                    android:padding="8dp" />
+
                 <!-- Force Custom Proxy -->
                 <LinearLayout
                     android:layout_width="match_parent"
@@ -542,6 +550,47 @@
 
                     <com.google.android.material.materialswitch.MaterialSwitch
                         android:id="@+id/forceCustomProxySwitch"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content" />
+
+                </LinearLayout>
+
+                <!-- Force Custom Proxy Except Tor/I2P -->
+                <LinearLayout
+                    android:id="@+id/forceCustomProxyExceptContainer"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="horizontal"
+                    android:gravity="center_vertical"
+                    android:paddingVertical="8dp"
+                    android:layout_marginTop="8dp"
+                    android:background="?attr/selectableItemBackground">
+
+                    <LinearLayout
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:orientation="vertical">
+
+                        <TextView
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="@string/settings_force_custom_proxy_except_tor_i2p"
+                            android:textSize="16sp"
+                            android:textStyle="bold"
+                            android:textColor="?attr/colorOnSurface" />
+
+                        <TextView
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="@string/settings_force_custom_proxy_except_tor_i2p_description"
+                            android:textSize="12sp"
+                            android:textColor="?attr/colorOnSurfaceVariant" />
+
+                    </LinearLayout>
+
+                    <com.google.android.material.materialswitch.MaterialSwitch
+                        android:id="@+id/forceCustomProxyExceptTorI2pSwitch"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content" />
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -136,6 +136,8 @@
     <string name="settings_apply_to_all_stations_description">Route all stations through global custom proxy</string>
     <string name="settings_force_custom_proxy">Force Custom Proxy</string>
     <string name="settings_force_custom_proxy_description">Route all traffic through custom proxy. Won\'t connect without proxy.</string>
+    <string name="settings_force_custom_proxy_except_tor_i2p">Force Custom Proxy Except Tor/I2P Stations</string>
+    <string name="settings_force_custom_proxy_except_tor_i2p_description">Route all clearnet traffic through custom proxy, but allow Tor and I2P stations to use their native proxies.</string>
 
     <!-- Settings - Bandwidth -->
     <string name="settings_bandwidth_usage">Bandwidth Usage</string>
@@ -214,7 +216,7 @@
     <string name="default_proxy_host_i2p">127.0.0.1</string>
     <string name="default_proxy_port_i2p">4444</string>
     <string name="default_proxy_port_http">8080</string>
-    <string name="default_protocol_http">HTTP</string>
+    <string name="default_protocol_https">HTTPS</string>
     <string name="default_auth_none">None</string>
     <string name="default_timeout">30</string>
     <string name="default_equalizer_db">0 dB</string>


### PR DESCRIPTION
Changes:
- Change custom proxy default protocol from HTTP to HTTPS for better security
- Add custom proxy status indicator in settings showing connection state
- Add custom proxy status view in toolbar (replaces Tor status when force custom proxy is enabled)
- Add new "Force Custom Proxy Except Tor/I2P Stations" setting
  - Routes clearnet traffic through custom proxy
  - Allows Tor (.onion) stations to use Tor SOCKS proxy
  - Allows I2P (.i2p) stations to use I2P HTTP proxy
  - Mutually exclusive with other force modes
- Update routing logic in RadioService to support new force mode
- Update both playback and recording clients to enforce new proxy routing
- Add mutual exclusivity between all force modes (Force Tor All, Force Tor Except I2P, Force Custom Proxy, Force Custom Proxy Except Tor/I2P)

The new mode provides users with more granular control over proxy routing, allowing them to secure clearnet connections with a custom proxy while still accessing Tor and I2P networks through their native proxies.