### PR TITLE
Make proxy "Apply to All" clearnet-specific with toggle functionality

### DIFF
--- a/app/src/main/java/com/opensource/i2pradio/ui/PreferenceHelper.kt
+++ b/app/src/main/java/com/opensource/i2pradio/ui/PreferenceHelper.kt
@@ -42,6 +42,7 @@ object PreferencesHelper {
     private const val KEY_CUSTOM_PROXY_BYPASS_LOCAL = "custom_proxy_bypass_local"
     private const val KEY_FORCE_CUSTOM_PROXY = "force_custom_proxy"
     private const val KEY_FORCE_CUSTOM_PROXY_EXCEPT_TOR_I2P = "force_custom_proxy_except_tor_i2p"
+    private const val KEY_CUSTOM_PROXY_APPLIED_TO_CLEARNET = "custom_proxy_applied_to_clearnet"
     private const val KEY_BANDWIDTH_USAGE_TOTAL = "bandwidth_usage_total"
     private const val KEY_BANDWIDTH_USAGE_SESSION = "bandwidth_usage_session"
     private const val KEY_BANDWIDTH_USAGE_LAST_RESET = "bandwidth_usage_last_reset"
@@ -565,6 +566,22 @@ object PreferencesHelper {
     fun isForceCustomProxyExceptTorI2P(context: Context): Boolean {
         return context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
             .getBoolean(KEY_FORCE_CUSTOM_PROXY_EXCEPT_TOR_I2P, false)
+    }
+
+    /**
+     * Track whether custom proxy has been applied to all clearnet stations.
+     * This allows the UI to toggle between "Apply" and "Unapply" states.
+     */
+    fun setCustomProxyAppliedToClearnet(context: Context, applied: Boolean) {
+        context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+            .edit()
+            .putBoolean(KEY_CUSTOM_PROXY_APPLIED_TO_CLEARNET, applied)
+            .apply()
+    }
+
+    fun isCustomProxyAppliedToClearnet(context: Context): Boolean {
+        return context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+            .getBoolean(KEY_CUSTOM_PROXY_APPLIED_TO_CLEARNET, false)
     }
 
     // Bandwidth Usage Tracking

--- a/app/src/main/res/layout/fragment_settings.xml
+++ b/app/src/main/res/layout/fragment_settings.xml
@@ -484,14 +484,14 @@
                         <TextView
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
-                            android:text="@string/settings_apply_to_all_stations"
+                            android:text="@string/settings_apply_to_all_clearnet_stations"
                             android:textSize="16sp"
                             android:textColor="?attr/colorOnSurface" />
 
                         <TextView
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
-                            android:text="@string/settings_apply_to_all_stations_description"
+                            android:text="@string/settings_apply_to_all_clearnet_stations_description"
                             android:textSize="12sp"
                             android:textColor="?attr/colorOnSurfaceVariant" />
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -132,8 +132,9 @@
     <string name="settings_custom_proxy">Custom Proxy</string>
     <string name="settings_configure_proxy">Configure Global Proxy</string>
     <string name="settings_configure_proxy_description">Set up your custom proxy settings</string>
-    <string name="settings_apply_to_all_stations">Apply to All Stations</string>
-    <string name="settings_apply_to_all_stations_description">Route all stations through global custom proxy</string>
+    <string name="settings_apply_to_all_clearnet_stations">Apply to All Clearnet Stations</string>
+    <string name="settings_unapply_from_all_clearnet_stations">Unapply from All Clearnet Stations</string>
+    <string name="settings_apply_to_all_clearnet_stations_description">Route all clearnet stations through global custom proxy (excludes Tor/I2P)</string>
     <string name="settings_force_custom_proxy">Force Custom Proxy</string>
     <string name="settings_force_custom_proxy_description">Route all traffic through custom proxy. Won\'t connect without proxy.</string>
     <string name="settings_force_custom_proxy_except_tor_i2p">Force Custom Proxy Except Tor/I2P Stations</string>


### PR DESCRIPTION
This commit enhances the custom proxy settings to:
1. Apply only to clearnet stations (excluding Tor/I2P)
2. Toggle between "Apply" and "Unapply" states

Changes:
- Add state tracking for proxy application to clearnet stations
- Implement isClearnetStation() helper with URL-first validation
- Add unapply functionality to remove custom proxy from clearnet stations
- Update UI strings to reflect clearnet-specific behavior
- Set state flag before bulk updates for crash resilience

Key improvements from Gödelian analysis:
- URL checked FIRST as ground truth (.onion/.i2p always Tor/I2P)
- State flag set before updates to prevent double-application on crashes
- Idempotent operations allow safe retry on failures
- Asymmetric apply/unapply respects manual user changes

Modified files:
- PreferenceHelper.kt: Add state tracking preference
- SettingsFragment.kt: Add clearnet filtering and toggle logic
- fragment_settings.xml: Update UI labels
- strings.xml: Add clearnet-specific strings