### PR TITLE
Simplify "Apply Custom Proxy to Browse" toggle

### DIFF
--- a/app/src/main/res/layout/fragment_settings.xml
+++ b/app/src/main/res/layout/fragment_settings.xml
@@ -466,7 +466,7 @@
 
                 </LinearLayout>
 
-                <!-- Apply to All Stations -->
+                <!-- Apply Custom Proxy to Browse -->
                 <LinearLayout
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
@@ -484,14 +484,14 @@
                         <TextView
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
-                            android:text="@string/settings_apply_to_all_clearnet_stations"
+                            android:text="@string/settings_apply_custom_proxy_to_browse"
                             android:textSize="16sp"
                             android:textColor="?attr/colorOnSurface" />
 
                         <TextView
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
-                            android:text="@string/settings_apply_to_all_clearnet_stations_description"
+                            android:text="@string/settings_apply_custom_proxy_to_browse_description"
                             android:textSize="12sp"
                             android:textColor="?attr/colorOnSurfaceVariant" />
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -132,9 +132,9 @@
     <string name="settings_custom_proxy">Custom Proxy</string>
     <string name="settings_configure_proxy">Configure Global Proxy</string>
     <string name="settings_configure_proxy_description">Set up your custom proxy settings</string>
-    <string name="settings_apply_to_all_clearnet_stations">Apply to All Clearnet Stations</string>
-    <string name="settings_unapply_from_all_clearnet_stations">Unapply from All Clearnet Stations</string>
-    <string name="settings_apply_to_all_clearnet_stations_description">Route all clearnet stations through global custom proxy (excludes Tor/I2P)</string>
+    <string name="settings_apply_custom_proxy_to_browse">Apply Custom Proxy to Browse</string>
+    <string name="settings_unapply_custom_proxy_from_browse">Unapply Custom Proxy from Browse</string>
+    <string name="settings_apply_custom_proxy_to_browse_description">Route RadioBrowser API requests through custom proxy</string>
     <string name="settings_force_custom_proxy">Force Custom Proxy</string>
     <string name="settings_force_custom_proxy_description">Route all traffic through custom proxy. Won\'t connect without proxy.</string>
     <string name="settings_force_custom_proxy_except_tor_i2p">Force Custom Proxy Except Tor/I2P Stations</string>


### PR DESCRIPTION
Renamed "Apply to All Clearnet Stations" to "Apply Custom Proxy to Browse" and simplified its implementation to just toggle the browse flag, without modifying individual station records.

Changes:
- Updated UI strings to clarify the option controls browsing behavior
- Replaced complex station modification logic with simple flag toggle
- Removed 4 helper methods (140+ lines of code)
- The toggle now only affects RadioBrowser API requests
- Force proxy modes already override individual station settings, making station record modifications redundant

This makes the UI clearer and eliminates unnecessary database operations.