### PR TITLE
Remove "Apply Custom Proxy to Browse" option and improve proxy status…

### DIFF
--- a/app/src/main/java/com/opensource/i2pradio/MainActivity.kt
+++ b/app/src/main/java/com/opensource/i2pradio/MainActivity.kt
@@ -240,7 +240,9 @@ class MainActivity : AppCompatActivity() {
 
             // Update custom proxy state
             val proxyHost = PreferencesHelper.getCustomProxyHost(this)
-            customProxyStatusView.updateStateFromConfig(true, proxyHost)
+            val protocol = PreferencesHelper.getCustomProxyProtocol(this)
+            val port = PreferencesHelper.getCustomProxyPort(this)
+            customProxyStatusView.updateStateFromConfig(true, proxyHost, protocol, port)
         } else {
             // Show Tor status, hide custom proxy status
             torStatusView.visibility = View.VISIBLE

--- a/app/src/main/java/com/opensource/i2pradio/ui/CustomProxyStatusView.kt
+++ b/app/src/main/java/com/opensource/i2pradio/ui/CustomProxyStatusView.kt
@@ -73,14 +73,19 @@ class CustomProxyStatusView @JvmOverloads constructor(
         }
     }
 
-    fun updateState(state: ProxyState) {
+    fun updateState(state: ProxyState, protocol: String = "", port: Int = 0) {
         stopAnimations()
 
         when (state) {
             ProxyState.CONNECTED -> {
                 statusIcon.setImageResource(R.drawable.ic_proxy_custom_on)
                 statusIcon.alpha = 1f
-                statusText.text = "Proxy Configured"
+                // Display protocol and port like Tor does (e.g., "HTTP:8080" or "SOCKS5:9050")
+                statusText.text = if (protocol.isNotEmpty() && port > 0) {
+                    "$protocol:$port"
+                } else {
+                    "Proxy Configured"
+                }
                 statusText.setTextColor(context.getColor(R.color.tor_connected))
                 contentDescription = "Custom proxy is configured. Tap to view details."
                 showConnectedAnimation()
@@ -106,7 +111,7 @@ class CustomProxyStatusView @JvmOverloads constructor(
     /**
      * Update state based on current proxy configuration
      */
-    fun updateStateFromConfig(forceEnabled: Boolean, proxyHost: String) {
+    fun updateStateFromConfig(forceEnabled: Boolean, proxyHost: String, protocol: String = "", port: Int = 0) {
         val state = when {
             // Force enabled but no proxy configured = privacy leak warning
             forceEnabled && proxyHost.isEmpty() -> ProxyState.LEAK_WARNING
@@ -115,7 +120,7 @@ class CustomProxyStatusView @JvmOverloads constructor(
             // No force, no proxy configured = not configured
             else -> ProxyState.NOT_CONFIGURED
         }
-        updateState(state)
+        updateState(state, protocol, port)
     }
 
     private fun showConnectedAnimation() {

--- a/app/src/main/java/com/opensource/i2pradio/ui/SettingsFragment.kt
+++ b/app/src/main/java/com/opensource/i2pradio/ui/SettingsFragment.kt
@@ -77,7 +77,6 @@ class SettingsFragment : Fragment() {
 
     // Custom Proxy UI elements
     private var configureProxyButton: MaterialButton? = null
-    private var applyProxyToAllButton: MaterialButton? = null
     private var forceCustomProxySwitch: MaterialSwitch? = null
     private var forceCustomProxyExceptTorI2pSwitch: MaterialSwitch? = null
     private var customProxyStatusViewSettings: CustomProxyStatusView? = null
@@ -426,7 +425,6 @@ class SettingsFragment : Fragment() {
 
         // Custom Proxy UI elements
         configureProxyButton = view.findViewById(R.id.configureProxyButton)
-        applyProxyToAllButton = view.findViewById(R.id.applyProxyToAllButton)
         forceCustomProxySwitch = view.findViewById(R.id.forceCustomProxySwitch)
         forceCustomProxyExceptTorI2pSwitch = view.findViewById(R.id.forceCustomProxyExceptTorI2pSwitch)
         customProxyStatusViewSettings = view.findViewById(R.id.customProxyStatusViewSettings)
@@ -1254,28 +1252,6 @@ class SettingsFragment : Fragment() {
             showConfigureProxyDialog()
         }
 
-        // Apply Custom Proxy to Browse button - toggles whether browse uses custom proxy
-        applyProxyToAllButton?.setOnClickListener {
-            val isApplied = PreferencesHelper.isCustomProxyAppliedToClearnet(requireContext())
-
-            // Simple toggle - just flip the flag
-            PreferencesHelper.setCustomProxyAppliedToClearnet(requireContext(), !isApplied)
-
-            // Update button text
-            updateApplyProxyButtonText()
-
-            // Show confirmation
-            val message = if (!isApplied) {
-                "Custom proxy will be used for browsing stations"
-            } else {
-                "Custom proxy removed from browsing"
-            }
-            Toast.makeText(requireContext(), message, Toast.LENGTH_SHORT).show()
-        }
-
-        // Initialize button text based on current state
-        updateApplyProxyButtonText()
-
         // Update custom proxy status view
         updateCustomProxyStatusView()
 
@@ -1392,7 +1368,9 @@ class SettingsFragment : Fragment() {
         val isForceCustomProxy = PreferencesHelper.isForceCustomProxy(requireContext()) ||
                                  PreferencesHelper.isForceCustomProxyExceptTorI2P(requireContext())
         val proxyHost = PreferencesHelper.getCustomProxyHost(requireContext())
-        customProxyStatusViewSettings?.updateStateFromConfig(isForceCustomProxy, proxyHost)
+        val protocol = PreferencesHelper.getCustomProxyProtocol(requireContext())
+        val port = PreferencesHelper.getCustomProxyPort(requireContext())
+        customProxyStatusViewSettings?.updateStateFromConfig(isForceCustomProxy, proxyHost, protocol, port)
     }
 
     private fun setupBandwidthDisplay() {
@@ -1693,16 +1671,4 @@ class SettingsFragment : Fragment() {
     }
 
 
-    /**
-     * Updates the Apply Proxy button text based on whether custom proxy
-     * is currently applied to browsing (RadioBrowser API).
-     */
-    private fun updateApplyProxyButtonText() {
-        val isApplied = PreferencesHelper.isCustomProxyAppliedToClearnet(requireContext())
-        applyProxyToAllButton?.text = if (isApplied) {
-            getString(R.string.settings_unapply_custom_proxy_from_browse)
-        } else {
-            getString(R.string.settings_apply_custom_proxy_to_browse)
-        }
-    }
 }

--- a/app/src/main/res/layout/fragment_settings.xml
+++ b/app/src/main/res/layout/fragment_settings.xml
@@ -466,47 +466,6 @@
 
                 </LinearLayout>
 
-                <!-- Apply Custom Proxy to Browse -->
-                <LinearLayout
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:orientation="horizontal"
-                    android:gravity="center_vertical"
-                    android:paddingVertical="8dp"
-                    android:layout_marginTop="8dp">
-
-                    <LinearLayout
-                        android:layout_width="0dp"
-                        android:layout_height="wrap_content"
-                        android:layout_weight="1"
-                        android:orientation="vertical">
-
-                        <TextView
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:text="@string/settings_apply_custom_proxy_to_browse"
-                            android:textSize="16sp"
-                            android:textColor="?attr/colorOnSurface" />
-
-                        <TextView
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:text="@string/settings_apply_custom_proxy_to_browse_description"
-                            android:textSize="12sp"
-                            android:textColor="?attr/colorOnSurfaceVariant" />
-
-                    </LinearLayout>
-
-                    <com.google.android.material.button.MaterialButton
-                        android:id="@+id/applyProxyToAllButton"
-                        style="@style/Widget.Material3.Button.TonalButton"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:text="@string/button_apply"
-                        android:textSize="12sp" />
-
-                </LinearLayout>
-
                 <!-- Custom Proxy Status View -->
                 <com.opensource.i2pradio.ui.CustomProxyStatusView
                     android:id="@+id/customProxyStatusViewSettings"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -132,9 +132,6 @@
     <string name="settings_custom_proxy">Custom Proxy</string>
     <string name="settings_configure_proxy">Configure Global Proxy</string>
     <string name="settings_configure_proxy_description">Set up your custom proxy settings</string>
-    <string name="settings_apply_custom_proxy_to_browse">Apply Custom Proxy to Browse</string>
-    <string name="settings_unapply_custom_proxy_from_browse">Unapply Custom Proxy from Browse</string>
-    <string name="settings_apply_custom_proxy_to_browse_description">Route RadioBrowser API requests through custom proxy</string>
     <string name="settings_force_custom_proxy">Force Custom Proxy</string>
     <string name="settings_force_custom_proxy_description">Route all traffic through custom proxy. Won\'t connect without proxy.</string>
     <string name="settings_force_custom_proxy_except_tor_i2p">Force Custom Proxy Except Tor/I2P Stations</string>


### PR DESCRIPTION
… display

- Remove unnecessary "Apply Custom Proxy to Browse" toggle button from settings
- Remove associated UI elements from fragment_settings.xml
- Remove related code from SettingsFragment.kt
- Remove unused string resources from strings.xml
- Update CustomProxyStatusView to display protocol and port (e.g., "HTTP:8080") similar to how Tor section displays "SOCKS port: 9050"
- Update MainActivity and SettingsFragment to pass protocol and port to proxy status view