### PR TITLE
Encrypt proxy passwords using Android Jetpack Security library

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -101,6 +101,10 @@ dependencies {
     // Material 3
     implementation("com.google.android.material:material:1.11.0")
     implementation("androidx.media:media:1.7.0")
+
+    // Security - EncryptedSharedPreferences for secure password storage
+    implementation("androidx.security:security-crypto:1.1.0-alpha06")
+
     // Test dependencies
     testImplementation("junit:junit:4.13.2")
     androidTestImplementation("androidx.test.ext:junit:1.1.5")

--- a/app/src/main/java/com/opensource/i2pradio/data/RadioStationPasswordHelper.kt
+++ b/app/src/main/java/com/opensource/i2pradio/data/RadioStationPasswordHelper.kt
@@ -1,0 +1,84 @@
+package com.opensource.i2pradio.data
+
+import android.content.Context
+import com.opensource.i2pradio.utils.PasswordEncryptionUtil
+
+/**
+ * Helper class for managing encrypted passwords in RadioStation entities.
+ * Provides methods to safely get/set passwords with automatic encryption.
+ */
+object RadioStationPasswordHelper {
+
+    /**
+     * Get the decrypted password from a RadioStation
+     * Handles both plain-text (legacy) and encrypted passwords
+     */
+    fun getDecryptedPassword(context: Context, station: RadioStation): String {
+        if (station.proxyPassword.isEmpty()) return ""
+
+        // Check if password is already encrypted
+        return if (PasswordEncryptionUtil.isEncrypted(station.proxyPassword)) {
+            // Decrypt it
+            PasswordEncryptionUtil.decryptPassword(context, station.proxyPassword)
+        } else {
+            // Plain-text password (legacy), return as-is
+            station.proxyPassword
+        }
+    }
+
+    /**
+     * Create a copy of RadioStation with encrypted password
+     * If password is already encrypted, returns station as-is
+     * If password is plain-text, encrypts it and returns updated station
+     */
+    fun withEncryptedPassword(context: Context, station: RadioStation): RadioStation {
+        if (station.proxyPassword.isEmpty()) return station
+
+        // Check if password is already encrypted
+        return if (PasswordEncryptionUtil.isEncrypted(station.proxyPassword)) {
+            // Already encrypted
+            station
+        } else {
+            // Plain-text password, encrypt it
+            val encryptedPassword = PasswordEncryptionUtil.encryptPassword(context, station.proxyPassword)
+            station.copy(proxyPassword = encryptedPassword)
+        }
+    }
+
+    /**
+     * Create a copy of RadioStation with a new password (will be encrypted)
+     * Use this when setting a password from user input
+     */
+    fun withNewPassword(context: Context, station: RadioStation, plainPassword: String): RadioStation {
+        if (plainPassword.isEmpty()) {
+            return station.copy(proxyPassword = "")
+        }
+
+        val encryptedPassword = PasswordEncryptionUtil.encryptPassword(context, plainPassword)
+        return station.copy(proxyPassword = encryptedPassword)
+    }
+
+    /**
+     * Migrate a station's password to encrypted format if needed
+     * Returns updated station if migration occurred, otherwise returns original
+     */
+    fun migratePasswordIfNeeded(context: Context, station: RadioStation): RadioStation {
+        return withEncryptedPassword(context, station)
+    }
+
+    /**
+     * Check if a station has an encrypted password
+     */
+    fun hasEncryptedPassword(station: RadioStation): Boolean {
+        return station.proxyPassword.isNotEmpty() &&
+               PasswordEncryptionUtil.isEncrypted(station.proxyPassword)
+    }
+
+    /**
+     * Check if a station has a plain-text password that needs migration
+     */
+    fun needsPasswordMigration(station: RadioStation): Boolean {
+        return station.proxyPassword.isNotEmpty() &&
+               !PasswordEncryptionUtil.isEncrypted(station.proxyPassword)
+    }
+}

--- a/app/src/main/java/com/opensource/i2pradio/ui/LibraryFragment.kt
+++ b/app/src/main/java/com/opensource/i2pradio/ui/LibraryFragment.kt
@@ -42,6 +42,7 @@ import com.opensource.i2pradio.R
 import com.opensource.i2pradio.RadioService
 import com.opensource.i2pradio.data.ProxyType
 import com.opensource.i2pradio.data.RadioStation
+import com.opensource.i2pradio.data.RadioStationPasswordHelper
 import com.opensource.i2pradio.data.RadioRepository
 import com.opensource.i2pradio.data.SortOrder
 import kotlinx.coroutines.Dispatchers
@@ -477,10 +478,10 @@ class LibraryFragment : Fragment() {
             putExtra("proxy_port", station.proxyPort)
             putExtra("proxy_type", proxyType.name)
             putExtra("cover_art_uri", station.coverArtUri)
-            // Custom proxy fields
+            // Custom proxy fields - decrypt password before passing to service
             putExtra("custom_proxy_protocol", station.customProxyProtocol)
             putExtra("proxy_username", station.proxyUsername)
-            putExtra("proxy_password", station.proxyPassword)
+            putExtra("proxy_password", RadioStationPasswordHelper.getDecryptedPassword(requireContext(), station))
             putExtra("proxy_auth_type", station.proxyAuthType)
             putExtra("proxy_connection_timeout", station.proxyConnectionTimeout)
         }

--- a/app/src/main/java/com/opensource/i2pradio/utils/PasswordEncryptionUtil.kt
+++ b/app/src/main/java/com/opensource/i2pradio/utils/PasswordEncryptionUtil.kt
@@ -1,0 +1,218 @@
+package com.opensource.i2pradio.utils
+
+import android.content.Context
+import android.util.Base64
+import androidx.security.crypto.EncryptedSharedPreferences
+import androidx.security.crypto.MasterKey
+import java.security.GeneralSecurityException
+import javax.crypto.Cipher
+import javax.crypto.KeyGenerator
+import javax.crypto.SecretKey
+import javax.crypto.spec.GCMParameterSpec
+
+/**
+ * Utility class for encrypting and decrypting passwords.
+ * Uses Android Jetpack Security library with AES-256-GCM encryption.
+ *
+ * This provides two encryption methods:
+ * 1. EncryptedSharedPreferences for global settings
+ * 2. Direct encryption/decryption for database fields
+ */
+object PasswordEncryptionUtil {
+    private const val ENCRYPTED_PREFS_NAME = "encrypted_passwords"
+    private const val KEY_CUSTOM_PROXY_PASSWORD = "custom_proxy_password"
+
+    // For database field encryption
+    private const val TRANSFORMATION = "AES/GCM/NoPadding"
+    private const val KEY_SIZE = 256
+    private const val GCM_IV_LENGTH = 12
+    private const val GCM_TAG_LENGTH = 128
+
+    /**
+     * Get or create the master key for encryption
+     */
+    private fun getMasterKey(context: Context): MasterKey {
+        return MasterKey.Builder(context)
+            .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
+            .build()
+    }
+
+    /**
+     * Get EncryptedSharedPreferences instance for storing passwords
+     */
+    private fun getEncryptedPreferences(context: Context): android.content.SharedPreferences {
+        return try {
+            EncryptedSharedPreferences.create(
+                context,
+                ENCRYPTED_PREFS_NAME,
+                getMasterKey(context),
+                EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+                EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
+            )
+        } catch (e: GeneralSecurityException) {
+            throw RuntimeException("Failed to create EncryptedSharedPreferences", e)
+        }
+    }
+
+    // ===== Global Proxy Password (EncryptedSharedPreferences) =====
+
+    /**
+     * Save the global custom proxy password securely
+     */
+    fun saveCustomProxyPassword(context: Context, password: String) {
+        getEncryptedPreferences(context)
+            .edit()
+            .putString(KEY_CUSTOM_PROXY_PASSWORD, password)
+            .apply()
+    }
+
+    /**
+     * Retrieve the global custom proxy password
+     */
+    fun getCustomProxyPassword(context: Context): String {
+        return getEncryptedPreferences(context)
+            .getString(KEY_CUSTOM_PROXY_PASSWORD, "") ?: ""
+    }
+
+    /**
+     * Clear the global custom proxy password
+     */
+    fun clearCustomProxyPassword(context: Context) {
+        getEncryptedPreferences(context)
+            .edit()
+            .remove(KEY_CUSTOM_PROXY_PASSWORD)
+            .apply()
+    }
+
+    // ===== Database Field Encryption (for per-station passwords) =====
+
+    /**
+     * Get the encryption key for database fields
+     * This is stored in EncryptedSharedPreferences for security
+     */
+    private fun getDatabaseEncryptionKey(context: Context): SecretKey {
+        val prefs = getEncryptedPreferences(context)
+        val keyString = prefs.getString("db_encryption_key", null)
+
+        return if (keyString != null) {
+            // Decode existing key
+            val keyBytes = Base64.decode(keyString, Base64.DEFAULT)
+            object : SecretKey {
+                override fun getAlgorithm() = "AES"
+                override fun getFormat() = "RAW"
+                override fun getEncoded() = keyBytes
+            }
+        } else {
+            // Generate new key
+            val keyGenerator = KeyGenerator.getInstance("AES")
+            keyGenerator.init(KEY_SIZE)
+            val key = keyGenerator.generateKey()
+
+            // Save key for future use
+            val keyBytes = key.encoded
+            val keyString = Base64.encodeToString(keyBytes, Base64.DEFAULT)
+            prefs.edit().putString("db_encryption_key", keyString).apply()
+
+            key
+        }
+    }
+
+    /**
+     * Encrypt a password for storage in the database
+     * Returns Base64-encoded encrypted data with IV prepended
+     * Format: [IV(12 bytes)][Encrypted Data][Auth Tag(16 bytes)]
+     */
+    fun encryptPassword(context: Context, plaintext: String): String {
+        if (plaintext.isEmpty()) return ""
+
+        try {
+            val key = getDatabaseEncryptionKey(context)
+            val cipher = Cipher.getInstance(TRANSFORMATION)
+
+            // Generate random IV
+            val iv = ByteArray(GCM_IV_LENGTH)
+            java.security.SecureRandom().nextBytes(iv)
+
+            val gcmSpec = GCMParameterSpec(GCM_TAG_LENGTH, iv)
+            cipher.init(Cipher.ENCRYPT_MODE, key, gcmSpec)
+
+            val encryptedBytes = cipher.doFinal(plaintext.toByteArray(Charsets.UTF_8))
+
+            // Combine IV + encrypted data
+            val combined = iv + encryptedBytes
+
+            return Base64.encodeToString(combined, Base64.DEFAULT)
+        } catch (e: Exception) {
+            throw RuntimeException("Failed to encrypt password", e)
+        }
+    }
+
+    /**
+     * Decrypt a password from the database
+     * Expects Base64-encoded data with IV prepended
+     */
+    fun decryptPassword(context: Context, encrypted: String): String {
+        if (encrypted.isEmpty()) return ""
+
+        try {
+            val combined = Base64.decode(encrypted, Base64.DEFAULT)
+
+            // Extract IV and encrypted data
+            val iv = combined.copyOfRange(0, GCM_IV_LENGTH)
+            val encryptedBytes = combined.copyOfRange(GCM_IV_LENGTH, combined.size)
+
+            val key = getDatabaseEncryptionKey(context)
+            val cipher = Cipher.getInstance(TRANSFORMATION)
+
+            val gcmSpec = GCMParameterSpec(GCM_TAG_LENGTH, iv)
+            cipher.init(Cipher.DECRYPT_MODE, key, gcmSpec)
+
+            val decryptedBytes = cipher.doFinal(encryptedBytes)
+
+            return String(decryptedBytes, Charsets.UTF_8)
+        } catch (e: Exception) {
+            // Return empty string on decryption failure (corrupted data)
+            android.util.Log.e("PasswordEncryption", "Failed to decrypt password", e)
+            return ""
+        }
+    }
+
+    /**
+     * Migrate a plain-text password to encrypted format
+     * This is used during database migration
+     */
+    fun migratePasswordToEncrypted(context: Context, plainPassword: String?): String {
+        if (plainPassword.isNullOrEmpty()) return ""
+
+        // Check if already encrypted (starts with valid Base64 and has minimum length)
+        return try {
+            // Attempt to decrypt - if successful, it's already encrypted
+            val decoded = Base64.decode(plainPassword, Base64.DEFAULT)
+            if (decoded.size > GCM_IV_LENGTH) {
+                // Looks encrypted, return as-is
+                plainPassword
+            } else {
+                // Not encrypted, encrypt it
+                encryptPassword(context, plainPassword)
+            }
+        } catch (e: Exception) {
+            // Not valid Base64 or decryption failed, treat as plain text
+            encryptPassword(context, plainPassword)
+        }
+    }
+
+    /**
+     * Check if a password string is encrypted
+     */
+    fun isEncrypted(password: String): Boolean {
+        if (password.isEmpty()) return false
+
+        return try {
+            val decoded = Base64.decode(password, Base64.DEFAULT)
+            // Valid encrypted password should have at least IV + some data + auth tag
+            decoded.size > (GCM_IV_LENGTH + 16)
+        } catch (e: Exception) {
+            false
+        }
+    }
+}


### PR DESCRIPTION
For enhanced privacy and security, all proxy passwords are now encrypted:

Security Implementation:
- Added androidx.security:security-crypto dependency
- Global proxy passwords: Stored in EncryptedSharedPreferences
- Per-station passwords: Encrypted using AES-256-GCM before database storage
- Automatic migration: Plain-text passwords transparently migrated on first access

Files Changed:
- app/build.gradle.kts: Added security-crypto library
- PasswordEncryptionUtil.kt: Core encryption/decryption utility
- RadioStationPasswordHelper.kt: Helper for RadioStation password operations
- PreferenceHelper.kt: Updated to use EncryptedSharedPreferences
- RadioDatabase.kt: Added migration 7→8 for password encryption
- AddEditRadioDialog.kt: Encrypt on save, decrypt on load
- LibraryFragment.kt: Decrypt password before passing to RadioService

Security Features:
- AES-256-GCM encryption with randomly generated IVs
- Master key managed by Android Keystore
- Transparent migration from plain-text to encrypted storage
- Backward compatible with existing installations

Fixes password storage vulnerability in PreferenceHelper.kt:446-456 and RadioStation.kt:148 where passwords were stored in plain text.