### PR TITLE
Fix build error by adding missing proxyConfigContainer ID to layout

### DIFF
--- a/app/src/main/res/layout/dialog_configure_proxy.xml
+++ b/app/src/main/res/layout/dialog_configure_proxy.xml
@@ -6,6 +6,7 @@
     android:fillViewport="true">
 
     <LinearLayout
+        android:id="@+id/proxyConfigContainer"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="vertical"


### PR DESCRIPTION
The password dialog functions were referencing R.id.proxyConfigContainer which didn't exist in the dialog_configure_proxy.xml layout file. Added the missing ID to the LinearLayout container to resolve the unresolved reference compilation errors at lines 1947 and 2012.