### PR TITLE
Fix SQLCipher package imports

### DIFF
--- a/app/src/main/java/com/opensource/i2pradio/data/RadioDatabase.kt
+++ b/app/src/main/java/com/opensource/i2pradio/data/RadioDatabase.kt
@@ -7,7 +7,7 @@ import androidx.room.RoomDatabase
 import androidx.room.migration.Migration
 import androidx.sqlite.db.SupportSQLiteDatabase
 import com.opensource.i2pradio.utils.DatabaseEncryptionManager
-import net.zetetic.database.sqlcipher.SupportFactory
+import net.sqlcipher.database.SupportFactory
 
 @Database(entities = [RadioStation::class, BrowseHistory::class], version = 8, exportSchema = false)
 abstract class RadioDatabase : RoomDatabase() {

--- a/app/src/main/java/com/opensource/i2pradio/utils/DatabaseEncryptionManager.kt
+++ b/app/src/main/java/com/opensource/i2pradio/utils/DatabaseEncryptionManager.kt
@@ -3,8 +3,8 @@ package com.opensource.i2pradio.utils
 import android.content.Context
 import androidx.security.crypto.EncryptedSharedPreferences
 import androidx.security.crypto.MasterKey
-import net.zetetic.database.sqlcipher.SQLiteDatabase
-import net.zetetic.database.sqlcipher.SupportFactory
+import net.sqlcipher.database.SQLiteDatabase
+import net.sqlcipher.database.SupportFactory
 import java.security.GeneralSecurityException
 import java.security.SecureRandom
 


### PR DESCRIPTION
Update SQLCipher imports from old package (net.zetetic.database.sqlcipher) to new package (net.sqlcipher.database) for SQLCipher Android 4.x compatibility.

Changes:
- RadioDatabase.kt: Update SupportFactory import
- DatabaseEncryptionManager.kt: Update SQLiteDatabase and SupportFactory imports

This resolves the build errors:
- Unresolved reference 'SupportFactory'
- Argument type mismatch in openHelperFactory()