### PR TITLE
Fix RadioBrowser API proxy routing and remove Custom label

### DIFF
--- a/app/src/main/java/com/opensource/i2pradio/data/radiobrowser/RadioBrowserClient.kt
+++ b/app/src/main/java/com/opensource/i2pradio/data/radiobrowser/RadioBrowserClient.kt
@@ -82,7 +82,7 @@ class RadioBrowserClient(private val context: Context) {
             }
         }
         // Priority 2: Force Custom Proxy for clearnet (RadioBrowser API is clearnet)
-        else if ((forceCustomProxy || (forceCustomProxyExceptTorI2P && customProxyAppliedToClearnet))) {
+        else if (forceCustomProxy || forceCustomProxyExceptTorI2P) {
             val proxyHost = PreferencesHelper.getCustomProxyHost(context)
             val proxyPort = PreferencesHelper.getCustomProxyPort(context)
             val proxyProtocol = PreferencesHelper.getCustomProxyProtocol(context)

--- a/app/src/main/java/com/opensource/i2pradio/ui/LibraryFragment.kt
+++ b/app/src/main/java/com/opensource/i2pradio/ui/LibraryFragment.kt
@@ -770,12 +770,12 @@ class RadioStationAdapter(
         fun bind(station: RadioStation) {
             stationName.text = station.name
 
-            // Show proxy type indicator (I2P or Tor)
+            // Show proxy type indicator (I2P or Tor only - Custom proxy is indicated by top-right icon)
             val proxyIndicator = if (station.useProxy) {
                 when (station.getProxyTypeEnum()) {
                     ProxyType.I2P -> " • I2P"
                     ProxyType.TOR -> " • Tor"
-                    ProxyType.CUSTOM -> " • Custom"
+                    ProxyType.CUSTOM -> ""
                     ProxyType.NONE -> ""
                 }
             } else ""


### PR DESCRIPTION
1. Fix RadioBrowser API not using custom proxy with "Force Custom Proxy Except Tor/I2P"
   - RadioBrowserClient.kt: Removed incorrect customProxyAppliedToClearnet flag check
   - Since RadioBrowser API is always clearnet, custom proxy should apply when forceCustomProxyExceptTorI2P is enabled
   - Flag was never set anywhere in codebase, causing proxy to not be applied

2. Remove "Custom" label from library station display
   - LibraryFragment.kt: Changed ProxyType.CUSTOM to return empty string instead of " • Custom"
   - Users already see proxy status via top-right connection icon
   - I2P and Tor labels remain as they indicate specific network types