### PR TITLE
Fix SQLCipher ATTACH DATABASE syntax for encryption

### DIFF
--- a/app/src/main/java/com/opensource/i2pradio/utils/DatabaseEncryptionManager.kt
+++ b/app/src/main/java/com/opensource/i2pradio/utils/DatabaseEncryptionManager.kt
@@ -201,7 +201,7 @@ object DatabaseEncryptionManager {
             )
 
             // Export to encrypted database
-            unencryptedDb.rawExecSQL("ATTACH DATABASE '$tempDbPath' AS encrypted KEY '${passphrase.toHexString()}'")
+            unencryptedDb.rawExecSQL("ATTACH DATABASE '$tempDbPath' AS encrypted KEY x'${passphrase.toHexString()}'")
             unencryptedDb.rawExecSQL("SELECT sqlcipher_export('encrypted')")
             unencryptedDb.rawExecSQL("DETACH DATABASE encrypted")
             unencryptedDb.close()


### PR DESCRIPTION
The ATTACH DATABASE command in SQLCipher requires hex passphrases to use the x'...' literal syntax, not regular string quotes.

Changed:
- ATTACH DATABASE ... KEY 'hexstring' (incorrect)
- ATTACH DATABASE ... KEY x'hexstring' (correct)

This fixes the "unable to open database" error when attempting to encrypt the database at DatabaseEncryptionManager.kt:204.

Resolves database encryption failure reported in logcat.