### PR TITLE
Fix database encryption implementation to properly handle SQLCipher

### DIFF
--- a/app/src/main/java/com/opensource/i2pradio/I2PRadioApplication.kt
+++ b/app/src/main/java/com/opensource/i2pradio/I2PRadioApplication.kt
@@ -5,6 +5,7 @@ import com.opensource.i2pradio.tor.TorManager
 import com.opensource.i2pradio.tor.TorService
 import com.opensource.i2pradio.ui.PreferencesHelper
 import com.opensource.i2pradio.util.SecureImageLoader
+import com.opensource.i2pradio.utils.DatabaseEncryptionManager
 
 class I2PRadioApplication : Application() {
 
@@ -16,6 +17,11 @@ class I2PRadioApplication : Application() {
 
     override fun onCreate() {
         super.onCreate()
+
+        // Initialize SQLCipher library early
+        // This must be done before any database operations
+        DatabaseEncryptionManager.initializeSQLCipher(this)
+
         // Dynamic colors are now applied at Activity level in MainActivity
         // to allow toggling Material You on/off without requiring app restart
 

--- a/app/src/main/java/com/opensource/i2pradio/data/RadioDatabase.kt
+++ b/app/src/main/java/com/opensource/i2pradio/data/RadioDatabase.kt
@@ -201,6 +201,15 @@ abstract class RadioDatabase : RoomDatabase() {
          */
         fun closeDatabase() {
             synchronized(this) {
+                try {
+                    // Checkpoint WAL to ensure all data is written to main database file
+                    INSTANCE?.openHelper?.writableDatabase?.let { db ->
+                        db.query("PRAGMA wal_checkpoint(FULL)", null)
+                    }
+                } catch (e: Exception) {
+                    android.util.Log.w("RadioDatabase", "Failed to checkpoint WAL", e)
+                }
+
                 INSTANCE?.close()
                 INSTANCE = null
             }


### PR DESCRIPTION
Fixed multiple critical issues in the database encryption/decryption system:

Database Encryption Manager:
- Fixed ATTACH DATABASE syntax to use proper SQLCipher format with double quotes: KEY "x'hexkey'"
- Changed from openDatabase() to openOrCreateDatabase() for proper handling
- Added explicit PRAGMA key = '' for opening plaintext databases
- Added verification step (SELECT count) before export operations
- Implemented proper WAL file cleanup (wal, shm, journal files)
- Added validation that encrypted/decrypted files are created before rename
- Improved error handling and cleanup of temporary files
- Fixed resource management with proper try-finally for database connections

Radio Database:
- Added WAL checkpoint (PRAGMA wal_checkpoint(FULL)) in closeDatabase()
- Ensures all data is flushed from WAL to main database before encryption

Application:
- Added early SQLCipher initialization in Application.onCreate()
- Ensures library is loaded before any database operations

Settings Fragment:
- Moved encryption/decryption operations to background threads using coroutines
- Added progress dialogs during encryption/decryption operations
- Added 500ms delay after closing database to ensure file handles are released
- Improved error messages to show specific error details
- Better exception handling with proper UI state restoration

These changes resolve the "unable to open database" error that occurred when trying to enable database encryption.