### PR TITLE
Fix database query error in RadioDatabase.kt

### DIFF
--- a/app/src/main/java/com/opensource/i2pradio/data/RadioDatabase.kt
+++ b/app/src/main/java/com/opensource/i2pradio/data/RadioDatabase.kt
@@ -204,7 +204,7 @@ abstract class RadioDatabase : RoomDatabase() {
                 try {
                     // Checkpoint WAL to ensure all data is written to main database file
                     INSTANCE?.openHelper?.writableDatabase?.let { db ->
-                        db.query("PRAGMA wal_checkpoint(FULL)", null)
+                        db.query("PRAGMA wal_checkpoint(FULL)", emptyArray())
                     }
                 } catch (e: Exception) {
                     android.util.Log.w("RadioDatabase", "Failed to checkpoint WAL", e)


### PR DESCRIPTION
Changed null to emptyArray() in query call at line 207 to match the expected signature query(String, Array<out Any?>). This resolves the compilation error where the query method call was ambiguous.