### PR TITLE
Fix database encryption crash with Room LiveData queries

### DIFF
--- a/app/src/main/java/com/opensource/i2pradio/utils/DatabaseEncryptionManager.kt
+++ b/app/src/main/java/com/opensource/i2pradio/utils/DatabaseEncryptionManager.kt
@@ -116,7 +116,11 @@ object DatabaseEncryptionManager {
         val passphrase = getDatabasePassphrase(context) ?: return null
 
         return try {
-            SupportFactory(passphrase)
+            // Use clearPassphrase = false to prevent SupportFactory from automatically
+            // clearing the passphrase after first use. This is required for Room which
+            // may close and reopen the database multiple times (e.g., for LiveData queries).
+            // We still clear our local passphrase copy in the finally block.
+            SupportFactory(passphrase, false)
         } finally {
             // Clear passphrase from memory
             passphrase.fill(0)


### PR DESCRIPTION
The SupportFactory was using the default constructor which automatically clears the passphrase after first database open. This caused crashes when Room closed and reopened the database (common with LiveData queries).

Fixed by passing clearPassphrase=false to SupportFactory constructor, allowing Room to reopen the database as needed while still clearing our local passphrase copy for security.

Fixes the crash: "The passphrase appears to be cleared"