### PR TITLE
Fix SupportFactory constructor type mismatch

### DIFF
--- a/app/src/main/java/com/opensource/i2pradio/utils/DatabaseEncryptionManager.kt
+++ b/app/src/main/java/com/opensource/i2pradio/utils/DatabaseEncryptionManager.kt
@@ -120,7 +120,7 @@ object DatabaseEncryptionManager {
             // clearing the passphrase after first use. This is required for Room which
             // may close and reopen the database multiple times (e.g., for LiveData queries).
             // We still clear our local passphrase copy in the finally block.
-            SupportFactory(passphrase, false)
+            SupportFactory(passphrase, null, false)
         } finally {
             // Clear passphrase from memory
             passphrase.fill(0)


### PR DESCRIPTION
The SupportFactory constructor was being called with (ByteArray, Boolean) which doesn't exist. To use the clearPassphrase parameter, we need to use the 3-parameter constructor (ByteArray, SQLiteDatabaseHook?, Boolean). Fixed by passing null for the hook parameter.