### PR TITLE
Fix database encryption crash by not clearing passphrase in getSuppor…

### DIFF
--- a/app/src/main/java/com/opensource/i2pradio/utils/DatabaseEncryptionManager.kt
+++ b/app/src/main/java/com/opensource/i2pradio/utils/DatabaseEncryptionManager.kt
@@ -115,16 +115,16 @@ object DatabaseEncryptionManager {
     fun getSupportFactory(context: Context): SupportFactory? {
         val passphrase = getDatabasePassphrase(context) ?: return null
 
-        return try {
-            // Use clearPassphrase = false to prevent SupportFactory from automatically
-            // clearing the passphrase after first use. This is required for Room which
-            // may close and reopen the database multiple times (e.g., for LiveData queries).
-            // We still clear our local passphrase copy in the finally block.
-            SupportFactory(passphrase, null, false)
-        } finally {
-            // Clear passphrase from memory
-            passphrase.fill(0)
-        }
+        // Use clearPassphrase = false to prevent SupportFactory from automatically
+        // clearing the passphrase after first use. This is required for Room which
+        // may close and reopen the database multiple times (e.g., for LiveData queries).
+        //
+        // IMPORTANT: We do NOT clear the passphrase here because SupportFactory holds
+        // a reference to the ByteArray. Clearing it would zero out the passphrase that
+        // SupportFactory is using, causing "file is not a database" errors when Room
+        // reopens the database. The passphrase will remain in memory as long as the
+        // SupportFactory instance exists, which is necessary for Room's operation.
+        return SupportFactory(passphrase, null, false)
     }
 
     /**


### PR DESCRIPTION
…tFactory

The crash occurred because getSupportFactory was clearing the passphrase ByteArray in a finally block after passing it to SupportFactory. Since SupportFactory holds a reference to the same ByteArray, clearing it would zero out the passphrase that SupportFactory was using. When Room closed and reopened the database for LiveData queries, SupportFactory would try to decrypt with an all-zeros passphrase, causing "file is not a database" SQLiteException.

The fix removes the finally block that clears the passphrase. Since we explicitly pass clearPassphrase=false to SupportFactory, we want the passphrase to remain in memory for Room's multiple open/close cycles. The passphrase will be managed by the SupportFactory instance lifecycle.

Fixes the crash:
- java.lang.RuntimeException: Exception while computing database live data
- Caused by: IllegalStateException: The passphrase appears to be cleared
- Caused by: SQLiteException: file is not a database