### PR TITLE
Fix database encryption crash by correcting ATTACH DATABASE KEY syntax

### DIFF
--- a/app/src/main/java/com/opensource/i2pradio/utils/DatabaseEncryptionManager.kt
+++ b/app/src/main/java/com/opensource/i2pradio/utils/DatabaseEncryptionManager.kt
@@ -213,8 +213,10 @@ object DatabaseEncryptionManager {
             val passphraseHex = passphrase.toHexString()
 
             // Export to encrypted database using proper SQLCipher syntax
-            // Note: The KEY parameter must use double quotes around x'...'
-            unencryptedDb.rawExecSQL("ATTACH DATABASE '$tempDbPath' AS encrypted KEY \"x'$passphraseHex'\";")
+            // The x'...' blob literal must NOT be quoted with double quotes
+            // Double quotes denote identifiers in SQL, not literals
+            // The blob literal x'hexstring' should be used directly as the KEY value
+            unencryptedDb.rawExecSQL("ATTACH DATABASE '$tempDbPath' AS encrypted KEY x'$passphraseHex';")
             unencryptedDb.rawExecSQL("SELECT sqlcipher_export('encrypted');")
             unencryptedDb.rawExecSQL("DETACH DATABASE encrypted;")
             unencryptedDb.close()


### PR DESCRIPTION
Root cause: SQL syntax error in encryption command causing database to be encrypted with wrong key, resulting in "file is not a database" crash on restart.

The bug was in DatabaseEncryptionManager.kt:217 where ATTACH DATABASE used:
  KEY "x'hexstring'"  (WRONG - double quotes make it an identifier)

Instead of:
  KEY x'hexstring'    (CORRECT - unquoted blob literal)

In SQL syntax:
- 'string' (single quotes) = string literal
- "identifier" (double quotes) = identifier/column name
- x'hex' (unquoted) = BLOB literal

The double quotes caused SQL to interpret x'...' as an IDENTIFIER rather than a blob literal. This meant the database was encrypted with either:
1. NULL/empty key (identifier doesn't exist), OR
2. Wrong key from identifier resolution

When the app restarted, SupportFactory tried to open with the correct passphrase, but the database was encrypted with the wrong key, causing SQLiteException: "file is not a database".

The fix removes the double quotes, allowing the blob literal to be interpreted correctly as a raw encryption key.

Fixes crash sequence:
1. User enables encryption → "Database encrypted successfully"
2. App restarts (SIGKILL)
3. Room tries to open encrypted database
4. SQLiteException: file is not a database
5. java.lang.RuntimeException: Exception while computing database live data

This matches the error pattern in the logcat showing the crash occurring at net.sqlcipher.database.SQLiteDatabase.keyDatabase during the key verification step when executing "select count(*) from sqlite_master".