### PR TITLE
Fix MaterialSwitch type mismatch in SettingsFragment

### DIFF
--- a/app/src/main/java/com/opensource/i2pradio/ui/SettingsFragment.kt
+++ b/app/src/main/java/com/opensource/i2pradio/ui/SettingsFragment.kt
@@ -2162,10 +2162,10 @@ class SettingsFragment : Fragment() {
                 }
 
                 // Show password prompt for enabling encryption
-                showPasswordPromptForEncryption(switch)
+                showPasswordPromptForEncryption(switch as MaterialSwitch)
             } else {
                 // Show password prompt for disabling encryption
-                showPasswordPromptForDecryption(switch)
+                showPasswordPromptForDecryption(switch as MaterialSwitch)
             }
         }
     }


### PR DESCRIPTION
Cast CompoundButton parameter to MaterialSwitch in setOnCheckedChangeListener callbacks to match the expected parameter type for password prompt functions.

Fixes build errors at lines 2165 and 2168.