### PR TITLE
Improve database encryption password UX clarity

### DIFF
--- a/app/src/main/java/com/opensource/i2pradio/ui/SettingsFragment.kt
+++ b/app/src/main/java/com/opensource/i2pradio/ui/SettingsFragment.kt
@@ -2053,6 +2053,7 @@ class SettingsFragment : Fragment() {
 
         val dialog = AlertDialog.Builder(requireContext())
             .setTitle(R.string.auth_dialog_change_title)
+            .setMessage(R.string.auth_dialog_change_message)
             .setView(dialogView)
             .setPositiveButton(R.string.auth_dialog_change) { _, _ ->
                 val currentPassword = currentInput.text.toString()
@@ -2075,7 +2076,7 @@ class SettingsFragment : Fragment() {
                         if (com.opensource.i2pradio.utils.DatabaseEncryptionManager.isDatabaseEncryptionEnabled(requireContext())) {
                             // Show progress dialog for re-keying
                             val progressDialog = AlertDialog.Builder(requireContext())
-                                .setMessage("Re-keying database with new password...")
+                                .setMessage(R.string.auth_rekeying_database)
                                 .setCancelable(false)
                                 .create()
                             progressDialog.show()
@@ -2235,7 +2236,7 @@ class SettingsFragment : Fragment() {
 
                 // Show progress dialog
                 val progressDialog = AlertDialog.Builder(requireContext())
-                    .setMessage("Encrypting database...")
+                    .setMessage(R.string.auth_encrypting_database)
                     .setCancelable(false)
                     .create()
                 progressDialog.show()
@@ -2332,7 +2333,7 @@ class SettingsFragment : Fragment() {
 
                 // Show progress dialog
                 val progressDialog = AlertDialog.Builder(requireContext())
-                    .setMessage("Decrypting database...")
+                    .setMessage(R.string.auth_decrypting_database)
                     .setCancelable(false)
                     .create()
                 progressDialog.show()

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -287,21 +287,22 @@
     <string name="settings_set_password">Set Password</string>
     <string name="settings_change_password">Change Password</string>
     <string name="settings_database_encryption">Database Encryption</string>
-    <string name="settings_database_encryption_description">Encrypt entire database with SQLCipher (requires app password and restart)</string>
+    <string name="settings_database_encryption_description">Encrypt entire database with SQLCipher using your app password (requires restart)</string>
     <string name="settings_database_encryption_warning">Warning: This is an experimental feature. Make sure you have a backup before enabling!</string>
     <string name="settings_database_encryption_enable_title">Enable Database Encryption?</string>
-    <string name="settings_database_encryption_enable_message">This will encrypt your entire radio database. The app will restart to apply changes.\n\nWARNING: This is experimental. Make sure you have a backup!</string>
+    <string name="settings_database_encryption_enable_message">This will encrypt your entire radio database using your app password. The app will restart to apply changes.\n\nWARNING: This is experimental. Make sure you have a backup!</string>
     <string name="settings_database_encryption_disable_title">Disable Database Encryption?</string>
     <string name="settings_database_encryption_disable_message">This will decrypt your database and remove encryption. The app will restart to apply changes.</string>
     <string name="settings_database_encryption_enabled">Database encryption enabled</string>
     <string name="settings_database_encryption_disabled">Database encryption disabled</string>
     <string name="settings_database_encryption_error">Failed to change encryption setting</string>
     <string name="settings_database_encryption_password_required_title">App Password Required</string>
-    <string name="settings_database_encryption_password_required_message">Database encryption requires an app password to be set first. This ensures your encrypted database is protected by authentication.\n\nPlease set an app password in the Security section before enabling database encryption.</string>
+    <string name="settings_database_encryption_password_required_message">Database encryption uses your app password to generate the encryption key. Please set an app password first by enabling \"App Lock\" above.\n\nOnce set, you can enable database encryption using the same password - no separate password needed.</string>
 
     <!-- Authentication Dialog -->
     <string name="auth_dialog_title">Set App Password</string>
     <string name="auth_dialog_change_title">Change Password</string>
+    <string name="auth_dialog_change_message">Note: If database encryption is enabled, it will be automatically updated to use the new password.</string>
     <string name="auth_dialog_current_password">Current Password</string>
     <string name="auth_dialog_new_password">New Password</string>
     <string name="auth_dialog_confirm_password">Confirm Password</string>
@@ -312,10 +313,13 @@
     <string name="auth_error_current_password_wrong">Current password is incorrect</string>
     <string name="auth_password_set">Password set successfully</string>
     <string name="auth_password_changed">Password changed successfully</string>
-    <string name="auth_enter_password_to_encrypt">Enter Password to Encrypt Database</string>
-    <string name="auth_enter_password_to_decrypt">Enter Password to Decrypt Database</string>
-    <string name="auth_password_for_encryption">Your password will be used to encrypt the database. You\'ll need to enter it each time you open the app.</string>
-    <string name="auth_password_for_decryption">Enter your password to decrypt the database before disabling encryption.</string>
+    <string name="auth_enter_password_to_encrypt">Verify Your App Password</string>
+    <string name="auth_enter_password_to_decrypt">Verify Your App Password</string>
+    <string name="auth_password_for_encryption">Enter your existing app password to enable database encryption.\n\nYour app password will be used to derive the encryption key. No separate password is needed.</string>
+    <string name="auth_password_for_decryption">Enter your app password to verify and decrypt the database before disabling encryption.</string>
+    <string name="auth_encrypting_database">Encrypting database with your app password…</string>
+    <string name="auth_decrypting_database">Decrypting database…</string>
+    <string name="auth_rekeying_database">Updating database encryption with new password…</string>
 
     <!-- Authentication Activity -->
     <string name="auth_unlock_app">Unlock deutsia radio</string>


### PR DESCRIPTION
Fixed confusing password prompts when enabling database encryption:
- Updated dialog titles to "Verify Your App Password" instead of "Enter Password to Encrypt Database"
- Added clear messaging that database encryption uses the same app password (no separate password needed)
- Updated descriptions to explain password derivation process
- Added note in change password dialog about automatic database re-keying
- Improved progress messages for encryption/decryption operations
- Moved hardcoded strings to strings.xml for proper localization

This resolves the duplicate password confusion where users thought they needed to set a separate password for database encryption when it actually uses the existing app password.