### PR TITLE
Add language switcher setting option

### DIFF
--- a/app/src/main/java/com/opensource/i2pradio/MainActivity.kt
+++ b/app/src/main/java/com/opensource/i2pradio/MainActivity.kt
@@ -36,6 +36,7 @@ import com.opensource.i2pradio.ui.LibraryFragment
 import com.opensource.i2pradio.ui.TorQuickControlBottomSheet
 import com.opensource.i2pradio.ui.TorStatusView
 import com.opensource.i2pradio.ui.CustomProxyStatusView
+import com.opensource.i2pradio.ui.LocaleHelper
 import com.opensource.i2pradio.ui.browse.BrowseStationsFragment
 import com.opensource.i2pradio.utils.BiometricAuthManager
 import kotlinx.coroutines.Dispatchers
@@ -153,6 +154,11 @@ class MainActivity : AppCompatActivity() {
         lifecycleScope.launch(Dispatchers.IO) {
             repository.initializePresetStations(this@MainActivity)
         }
+    }
+
+    override fun attachBaseContext(newBase: Context) {
+        // Apply saved language preference before activity is created
+        super.attachBaseContext(LocaleHelper.applyLanguage(newBase))
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/app/src/main/java/com/opensource/i2pradio/ui/LocaleHelper.kt
+++ b/app/src/main/java/com/opensource/i2pradio/ui/LocaleHelper.kt
@@ -1,0 +1,75 @@
+package com.opensource.i2pradio.ui
+
+import android.content.Context
+import android.content.res.Configuration
+import android.os.Build
+import java.util.Locale
+
+/**
+ * Helper object for managing app language/locale settings.
+ *
+ * Provides functionality to:
+ * - Set app language programmatically
+ * - Apply saved language preferences on app startup
+ * - Handle system default language
+ */
+object LocaleHelper {
+
+    /**
+     * Set the app's locale based on the language code.
+     *
+     * @param context The application context
+     * @param languageCode The language code (e.g., "en", "es", "fr") or "system" for device default
+     */
+    fun setLocale(context: Context, languageCode: String): Context {
+        val locale = if (languageCode == "system") {
+            // Use system default locale
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+                context.resources.configuration.locales[0]
+            } else {
+                @Suppress("DEPRECATION")
+                context.resources.configuration.locale
+            }
+        } else {
+            Locale(languageCode)
+        }
+
+        return updateResources(context, locale)
+    }
+
+    /**
+     * Apply the saved language preference to the context.
+     *
+     * @param context The application context
+     * @return Updated context with the applied locale
+     */
+    fun applyLanguage(context: Context): Context {
+        val languageCode = PreferencesHelper.getAppLanguage(context)
+        return setLocale(context, languageCode)
+    }
+
+    /**
+     * Update the resources configuration with the new locale.
+     *
+     * @param context The application context
+     * @param locale The locale to apply
+     * @return Updated context with the new locale
+     */
+    private fun updateResources(context: Context, locale: Locale): Context {
+        Locale.setDefault(locale)
+
+        val resources = context.resources
+        val configuration = Configuration(resources.configuration)
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            configuration.setLocale(locale)
+            return context.createConfigurationContext(configuration)
+        } else {
+            @Suppress("DEPRECATION")
+            configuration.locale = locale
+            @Suppress("DEPRECATION")
+            resources.updateConfiguration(configuration, resources.displayMetrics)
+            return context
+        }
+    }
+}

--- a/app/src/main/java/com/opensource/i2pradio/ui/PreferenceHelper.kt
+++ b/app/src/main/java/com/opensource/i2pradio/ui/PreferenceHelper.kt
@@ -29,6 +29,7 @@ object PreferencesHelper {
     private const val KEY_RECORD_ACROSS_STATIONS = "record_across_stations"
     private const val KEY_RECORD_ALL_STATIONS = "record_all_stations"
     private const val KEY_COLOR_SCHEME = "color_scheme"
+    private const val KEY_APP_LANGUAGE = "app_language"
 
     // Custom proxy settings (global defaults)
     private const val KEY_CUSTOM_PROXY_ENABLED = "custom_proxy_enabled"
@@ -364,6 +365,31 @@ object PreferencesHelper {
     fun getColorScheme(context: Context): String {
         return context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
             .getString(KEY_COLOR_SCHEME, "default") ?: "default"
+    }
+
+    // Language preferences
+    // Available languages: system (follow device), ar, de, es, fa, fr, hi, it, ja, ko, my, pt, ru, tr, uk, vi, zh
+
+    /**
+     * Set the app language.
+     * Available values: "system", "ar", "de", "es", "fa", "fr", "hi", "it", "ja", "ko", "my", "pt", "ru", "tr", "uk", "vi", "zh"
+     * Default: "system" (follow device language)
+     */
+    fun setAppLanguage(context: Context, languageCode: String) {
+        context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+            .edit()
+            .putString(KEY_APP_LANGUAGE, languageCode)
+            .apply()
+    }
+
+    /**
+     * Get the selected app language.
+     * Returns: language code or "system" for device default
+     * Default: "system"
+     */
+    fun getAppLanguage(context: Context): String {
+        return context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+            .getString(KEY_APP_LANGUAGE, "system") ?: "system"
     }
 
     // Custom Proxy Settings - Global defaults that can be applied to stations

--- a/app/src/main/java/com/opensource/i2pradio/ui/SettingsFragment.kt
+++ b/app/src/main/java/com/opensource/i2pradio/ui/SettingsFragment.kt
@@ -254,6 +254,7 @@ class SettingsFragment : Fragment() {
 
         val themeButton = view.findViewById<MaterialButton>(R.id.themeButton)
         val colorSchemeButton = view.findViewById<MaterialButton>(R.id.colorSchemeButton)
+        val languageButton = view.findViewById<MaterialButton>(R.id.languageButton)
         val githubButton = view.findViewById<MaterialButton>(R.id.githubButton)
         val materialYouSwitch = view.findViewById<MaterialSwitch>(R.id.materialYouSwitch)
         val materialYouContainer = view.findViewById<View>(R.id.materialYouContainer)
@@ -315,6 +316,14 @@ class SettingsFragment : Fragment() {
         // Color scheme selector
         colorSchemeButton.setOnClickListener {
             showColorSchemeDialog(colorSchemeButton)
+        }
+
+        // Update language button text
+        updateLanguageButtonText(languageButton)
+
+        // Language selector
+        languageButton.setOnClickListener {
+            showLanguageDialog(languageButton)
         }
 
         // GitHub button
@@ -1052,6 +1061,75 @@ class SettingsFragment : Fragment() {
                 PreferencesHelper.setColorScheme(requireContext(), newScheme)
                 updateColorSchemeButtonText(colorSchemeButton)
                 // Recreate activity to apply new color scheme
+                uiHandler.postDelayed({
+                    activity?.recreate()
+                }, 300)
+                dialog.dismiss()
+            }
+            .show()
+    }
+
+    private fun updateLanguageButtonText(button: MaterialButton) {
+        val currentLanguage = PreferencesHelper.getAppLanguage(requireContext())
+        button.text = when (currentLanguage) {
+            "ar" -> getString(R.string.language_arabic)
+            "de" -> getString(R.string.language_german)
+            "es" -> getString(R.string.language_spanish)
+            "fa" -> getString(R.string.language_farsi)
+            "fr" -> getString(R.string.language_french)
+            "hi" -> getString(R.string.language_hindi)
+            "it" -> getString(R.string.language_italian)
+            "ja" -> getString(R.string.language_japanese)
+            "ko" -> getString(R.string.language_korean)
+            "my" -> getString(R.string.language_burmese)
+            "pt" -> getString(R.string.language_portuguese)
+            "ru" -> getString(R.string.language_russian)
+            "tr" -> getString(R.string.language_turkish)
+            "uk" -> getString(R.string.language_ukrainian)
+            "vi" -> getString(R.string.language_vietnamese)
+            "zh" -> getString(R.string.language_chinese)
+            else -> getString(R.string.language_system_default)
+        }
+    }
+
+    private fun showLanguageDialog(languageButton: MaterialButton) {
+        val languages = arrayOf(
+            getString(R.string.language_system_default),
+            getString(R.string.language_arabic),
+            getString(R.string.language_german),
+            getString(R.string.language_english),
+            getString(R.string.language_spanish),
+            getString(R.string.language_farsi),
+            getString(R.string.language_french),
+            getString(R.string.language_hindi),
+            getString(R.string.language_italian),
+            getString(R.string.language_japanese),
+            getString(R.string.language_korean),
+            getString(R.string.language_burmese),
+            getString(R.string.language_portuguese),
+            getString(R.string.language_russian),
+            getString(R.string.language_turkish),
+            getString(R.string.language_ukrainian),
+            getString(R.string.language_vietnamese),
+            getString(R.string.language_chinese)
+        )
+        val languageCodes = arrayOf(
+            "system", "ar", "de", "en", "es", "fa", "fr", "hi", "it", "ja", "ko", "my", "pt", "ru", "tr", "uk", "vi", "zh"
+        )
+        val currentLanguage = PreferencesHelper.getAppLanguage(requireContext())
+        val selectedIndex = languageCodes.indexOf(currentLanguage).coerceAtLeast(0)
+
+        AlertDialog.Builder(requireContext())
+            .setTitle("Choose Language")
+            .setSingleChoiceItems(languages, selectedIndex) { dialog, which ->
+                val newLanguage = languageCodes[which]
+                PreferencesHelper.setAppLanguage(requireContext(), newLanguage)
+                updateLanguageButtonText(languageButton)
+
+                // Apply the new language
+                LocaleHelper.setLocale(requireContext(), newLanguage)
+
+                // Recreate activity to apply new language
                 uiHandler.postDelayed({
                     activity?.recreate()
                 }, 300)

--- a/app/src/main/res/layout/fragment_settings.xml
+++ b/app/src/main/res/layout/fragment_settings.xml
@@ -182,6 +182,47 @@
 
                 </LinearLayout>
 
+                <!-- Language -->
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="horizontal"
+                    android:gravity="center_vertical"
+                    android:paddingVertical="8dp"
+                    android:layout_marginTop="8dp">
+
+                    <LinearLayout
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:orientation="vertical">
+
+                        <TextView
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="@string/settings_language"
+                            android:textSize="16sp"
+                            android:textColor="?attr/colorOnSurface" />
+
+                        <TextView
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="@string/settings_language_description"
+                            android:textSize="12sp"
+                            android:textColor="?attr/colorOnSurfaceVariant" />
+
+                    </LinearLayout>
+
+                    <com.google.android.material.button.MaterialButton
+                        android:id="@+id/languageButton"
+                        style="@style/Widget.Material3.Button.TonalButton"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="@string/language_system_default"
+                        android:textSize="12sp" />
+
+                </LinearLayout>
+
             </LinearLayout>
 
         </com.google.android.material.card.MaterialCardView>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -115,6 +115,28 @@
     <string name="settings_color_scheme">Color Scheme</string>
     <string name="settings_color_scheme_description">Choose your preferred color</string>
     <string name="settings_color_blue">Blue</string>
+    <string name="settings_language">Language</string>
+    <string name="settings_language_description">Choose your preferred language</string>
+
+    <!-- Language Names -->
+    <string name="language_system_default">System Default</string>
+    <string name="language_arabic">العربية</string>
+    <string name="language_german">Deutsch</string>
+    <string name="language_english">English</string>
+    <string name="language_spanish">Español</string>
+    <string name="language_farsi">فارسی</string>
+    <string name="language_french">Français</string>
+    <string name="language_hindi">हिन्दी</string>
+    <string name="language_italian">Italiano</string>
+    <string name="language_japanese">日本語</string>
+    <string name="language_korean">한국어</string>
+    <string name="language_burmese">မြန်မာ</string>
+    <string name="language_portuguese">Português</string>
+    <string name="language_russian">Русский</string>
+    <string name="language_turkish">Türkçe</string>
+    <string name="language_ukrainian">Українська</string>
+    <string name="language_vietnamese">Tiếng Việt</string>
+    <string name="language_chinese">中文</string>
 
     <!-- Settings - Tor Network -->
     <string name="settings_tor_network">Tor Network</string>


### PR DESCRIPTION
Implemented a comprehensive language switching feature:

- Added language preference storage in PreferencesHelper with support for 17 languages (System default, Arabic, German, English, Spanish, Farsi, French, Hindi, Italian, Japanese, Korean, Burmese, Portuguese, Russian, Turkish, Ukrainian, Vietnamese, Chinese)

- Created LocaleHelper utility class to handle locale changes and apply language preferences on app startup

- Added language switcher UI to Settings fragment's Appearance section with a MaterialButton that displays the current language

- Implemented language selection dialog with native language names for better UX

- Updated MainActivity to apply saved language preference via attachBaseContext

- Added string resources for all language names (displayed in their native scripts)

The language switcher allows users to override their device language and choose from any of the 17 supported languages, or follow the system default.