### PR TITLE
Fix genre list and language switcher translations

### DIFF
--- a/app/src/main/java/com/opensource/i2pradio/ui/LibraryFragment.kt
+++ b/app/src/main/java/com/opensource/i2pradio/ui/LibraryFragment.kt
@@ -82,13 +82,43 @@ class LibraryFragment : Fragment() {
     }
 
     // Predefined genres list (sorted alphabetically)
-    private val allGenres = listOf(
-        "All Genres", "Alternative", "Ambient", "Blues", "Christian", "Classical",
-        "Comedy", "Country", "Dance", "EDM", "Electronic", "Folk",
-        "Funk", "Gospel", "Hip Hop", "Indie", "Jazz", "K-Pop",
-        "Latin", "Lo-Fi", "Metal", "News", "Oldies", "Pop", "Punk",
-        "R&B", "Reggae", "Rock", "Soul", "Sports", "Talk", "World", "Other"
-    )
+    private fun getAllGenres(): List<String> {
+        return listOf(
+            getString(R.string.genre_all),
+            getString(R.string.genre_alternative),
+            getString(R.string.genre_ambient),
+            getString(R.string.genre_blues),
+            getString(R.string.genre_christian),
+            getString(R.string.genre_classical),
+            getString(R.string.genre_comedy),
+            getString(R.string.genre_country),
+            getString(R.string.genre_dance),
+            getString(R.string.genre_edm),
+            getString(R.string.genre_electronic),
+            getString(R.string.genre_folk),
+            getString(R.string.genre_funk),
+            getString(R.string.genre_gospel),
+            getString(R.string.genre_hip_hop),
+            getString(R.string.genre_indie),
+            getString(R.string.genre_jazz),
+            getString(R.string.genre_k_pop),
+            getString(R.string.genre_latin),
+            getString(R.string.genre_lo_fi),
+            getString(R.string.genre_metal),
+            getString(R.string.genre_news),
+            getString(R.string.genre_oldies),
+            getString(R.string.genre_pop),
+            getString(R.string.genre_punk),
+            getString(R.string.genre_r_and_b),
+            getString(R.string.genre_reggae),
+            getString(R.string.genre_rock),
+            getString(R.string.genre_soul),
+            getString(R.string.genre_sports),
+            getString(R.string.genre_talk),
+            getString(R.string.genre_world),
+            getString(R.string.genre_other)
+        )
+    }
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -268,13 +298,15 @@ class LibraryFragment : Fragment() {
             }
 
             // Merge predefined genres with database genres, keeping alphabetical order
-            val combinedGenres = (allGenres + dbGenres)
+            val allGenresText = getString(R.string.genre_all)
+            val otherGenreText = getString(R.string.genre_other)
+            val combinedGenres = (getAllGenres() + dbGenres)
                 .distinct()
                 .sortedWith(compareBy {
                     // "All Genres" first, "Other" last, rest alphabetically
                     when (it) {
-                        "All Genres" -> "0$it"
-                        "Other" -> "ZZZ$it"
+                        allGenresText -> "0$it"
+                        otherGenreText -> "ZZZ$it"
                         else -> "A$it"
                     }
                 })
@@ -302,7 +334,7 @@ class LibraryFragment : Fragment() {
                 .setNegativeButton(android.R.string.cancel, null)
                 .setPositiveButton(android.R.string.ok) { _, _ ->
                     // Apply the selection when OK is clicked
-                    currentGenreFilter = if (tempSelectedGenre == "All Genres") null else tempSelectedGenre
+                    currentGenreFilter = if (tempSelectedGenre == allGenresText) null else tempSelectedGenre
                     PreferencesHelper.setGenreFilter(requireContext(), currentGenreFilter)
                     updateGenreFilterButtonText()
                     // Clear search when changing genre filter

--- a/app/src/main/java/com/opensource/i2pradio/ui/SettingsFragment.kt
+++ b/app/src/main/java/com/opensource/i2pradio/ui/SettingsFragment.kt
@@ -1120,7 +1120,7 @@ class SettingsFragment : Fragment() {
         val selectedIndex = languageCodes.indexOf(currentLanguage).coerceAtLeast(0)
 
         AlertDialog.Builder(requireContext())
-            .setTitle("Choose Language")
+            .setTitle(getString(R.string.language_choose))
             .setSingleChoiceItems(languages, selectedIndex) { dialog, which ->
                 val newLanguage = languageCodes[which]
                 PreferencesHelper.setAppLanguage(requireContext(), newLanguage)

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -34,6 +34,40 @@
     <string name="genre_all">جميع الأنواع</string>
     <string name="filter_by_genre">التصفية حسب النوع</string>
 
+    <!-- Genre Names -->
+    <string name="genre_alternative">Alternative</string>
+    <string name="genre_ambient">Ambient</string>
+    <string name="genre_blues">Blues</string>
+    <string name="genre_christian">Christian</string>
+    <string name="genre_classical">Classical</string>
+    <string name="genre_comedy">Comedy</string>
+    <string name="genre_country">Country</string>
+    <string name="genre_dance">Dance</string>
+    <string name="genre_edm">EDM</string>
+    <string name="genre_electronic">Electronic</string>
+    <string name="genre_folk">Folk</string>
+    <string name="genre_funk">Funk</string>
+    <string name="genre_gospel">Gospel</string>
+    <string name="genre_hip_hop">Hip Hop</string>
+    <string name="genre_indie">Indie</string>
+    <string name="genre_jazz">Jazz</string>
+    <string name="genre_k_pop">K-Pop</string>
+    <string name="genre_latin">Latin</string>
+    <string name="genre_lo_fi">Lo-Fi</string>
+    <string name="genre_metal">Metal</string>
+    <string name="genre_news">News</string>
+    <string name="genre_oldies">Oldies</string>
+    <string name="genre_pop">Pop</string>
+    <string name="genre_punk">Punk</string>
+    <string name="genre_r_and_b">R&amp;B</string>
+    <string name="genre_reggae">Reggae</string>
+    <string name="genre_rock">Rock</string>
+    <string name="genre_soul">Soul</string>
+    <string name="genre_sports">Sports</string>
+    <string name="genre_talk">Talk</string>
+    <string name="genre_world">World</string>
+    <string name="genre_other">Other</string>
+
      <!-- about -->
     <string name="about_description">deutsia radio هو مشغل راديو متعدد الشبكات مجاني ومفتوح المصدر يجمع البث من شبكات clearnet و Tor (.onion) و I2P. استمتع بمحطاتك المفضلة في واجهة Material You مع تكامل Orbot ومنع التسرب القابل للتكوين</string>
 
@@ -118,6 +152,29 @@
     <string name="settings_color_scheme">نظام الألوان</string>
     <string name="settings_color_scheme_description">اختر اللون المفضل لديك</string>
     <string name="settings_color_blue">أزرق</string>
+    <string name="settings_language">Language</string>
+    <string name="settings_language_description">Choose your preferred language</string>
+
+    <!-- Language Names -->
+    <string name="language_choose">Choose Language</string>
+    <string name="language_system_default">System Default</string>
+    <string name="language_arabic">العربية</string>
+    <string name="language_german">Deutsch</string>
+    <string name="language_english">English</string>
+    <string name="language_spanish">Español</string>
+    <string name="language_farsi">فارسی</string>
+    <string name="language_french">Français</string>
+    <string name="language_hindi">हिन्दी</string>
+    <string name="language_italian">Italiano</string>
+    <string name="language_japanese">日本語</string>
+    <string name="language_korean">한국어</string>
+    <string name="language_burmese">မြန်မာ</string>
+    <string name="language_portuguese">Português</string>
+    <string name="language_russian">Русский</string>
+    <string name="language_turkish">Türkçe</string>
+    <string name="language_ukrainian">Українська</string>
+    <string name="language_vietnamese">Tiếng Việt</string>
+    <string name="language_chinese">中文</string>
 
     <!-- Settings - Tor Network -->
     <string name="settings_tor_network">شبكة Tor</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -34,6 +34,40 @@
     <string name="genre_all">Alle Genres</string>
     <string name="filter_by_genre">Nach Genre filtern</string>
 
+    <!-- Genre Names -->
+    <string name="genre_alternative">Alternative</string>
+    <string name="genre_ambient">Ambient</string>
+    <string name="genre_blues">Blues</string>
+    <string name="genre_christian">Christian</string>
+    <string name="genre_classical">Classical</string>
+    <string name="genre_comedy">Comedy</string>
+    <string name="genre_country">Country</string>
+    <string name="genre_dance">Dance</string>
+    <string name="genre_edm">EDM</string>
+    <string name="genre_electronic">Electronic</string>
+    <string name="genre_folk">Folk</string>
+    <string name="genre_funk">Funk</string>
+    <string name="genre_gospel">Gospel</string>
+    <string name="genre_hip_hop">Hip Hop</string>
+    <string name="genre_indie">Indie</string>
+    <string name="genre_jazz">Jazz</string>
+    <string name="genre_k_pop">K-Pop</string>
+    <string name="genre_latin">Latin</string>
+    <string name="genre_lo_fi">Lo-Fi</string>
+    <string name="genre_metal">Metal</string>
+    <string name="genre_news">News</string>
+    <string name="genre_oldies">Oldies</string>
+    <string name="genre_pop">Pop</string>
+    <string name="genre_punk">Punk</string>
+    <string name="genre_r_and_b">R&amp;B</string>
+    <string name="genre_reggae">Reggae</string>
+    <string name="genre_rock">Rock</string>
+    <string name="genre_soul">Soul</string>
+    <string name="genre_sports">Sports</string>
+    <string name="genre_talk">Talk</string>
+    <string name="genre_world">World</string>
+    <string name="genre_other">Other</string>
+
      <!-- about -->
     <string name="about_description">deutsia radio ist ein kostenloser Open-Source-Multinetwork-Radioplayer, der Streams aus dem Clearnet, Tor (.onion) und I2P-Netzwerken zusammenführt. Genießen Sie Ihre Lieblingssender in einer Material You-Oberfläche mit Orbot-Integration und konfigurierbarer Leak-Prävention</string>
 
@@ -118,6 +152,29 @@
     <string name="settings_color_scheme">Farbschema</string>
     <string name="settings_color_scheme_description">Wählen Sie Ihre bevorzugte Farbe</string>
     <string name="settings_color_blue">Blau</string>
+    <string name="settings_language">Language</string>
+    <string name="settings_language_description">Choose your preferred language</string>
+
+    <!-- Language Names -->
+    <string name="language_choose">Choose Language</string>
+    <string name="language_system_default">System Default</string>
+    <string name="language_arabic">العربية</string>
+    <string name="language_german">Deutsch</string>
+    <string name="language_english">English</string>
+    <string name="language_spanish">Español</string>
+    <string name="language_farsi">فارسی</string>
+    <string name="language_french">Français</string>
+    <string name="language_hindi">हिन्दी</string>
+    <string name="language_italian">Italiano</string>
+    <string name="language_japanese">日本語</string>
+    <string name="language_korean">한국어</string>
+    <string name="language_burmese">မြန်မာ</string>
+    <string name="language_portuguese">Português</string>
+    <string name="language_russian">Русский</string>
+    <string name="language_turkish">Türkçe</string>
+    <string name="language_ukrainian">Українська</string>
+    <string name="language_vietnamese">Tiếng Việt</string>
+    <string name="language_chinese">中文</string>
 
     <!-- Settings - Tor Network -->
     <string name="settings_tor_network">Tor-Netzwerk</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -34,6 +34,40 @@
     <string name="genre_all">Todos los géneros</string>
     <string name="filter_by_genre">Filtrar por género</string>
 
+    <!-- Genre Names -->
+    <string name="genre_alternative">Alternativa</string>
+    <string name="genre_ambient">Ambiental</string>
+    <string name="genre_blues">Blues</string>
+    <string name="genre_christian">Cristiana</string>
+    <string name="genre_classical">Clásica</string>
+    <string name="genre_comedy">Comedia</string>
+    <string name="genre_country">Country</string>
+    <string name="genre_dance">Dance</string>
+    <string name="genre_edm">EDM</string>
+    <string name="genre_electronic">Electrónica</string>
+    <string name="genre_folk">Folk</string>
+    <string name="genre_funk">Funk</string>
+    <string name="genre_gospel">Gospel</string>
+    <string name="genre_hip_hop">Hip Hop</string>
+    <string name="genre_indie">Indie</string>
+    <string name="genre_jazz">Jazz</string>
+    <string name="genre_k_pop">K-Pop</string>
+    <string name="genre_latin">Latina</string>
+    <string name="genre_lo_fi">Lo-Fi</string>
+    <string name="genre_metal">Metal</string>
+    <string name="genre_news">Noticias</string>
+    <string name="genre_oldies">Clásicos</string>
+    <string name="genre_pop">Pop</string>
+    <string name="genre_punk">Punk</string>
+    <string name="genre_r_and_b">R&amp;B</string>
+    <string name="genre_reggae">Reggae</string>
+    <string name="genre_rock">Rock</string>
+    <string name="genre_soul">Soul</string>
+    <string name="genre_sports">Deportes</string>
+    <string name="genre_talk">Conversación</string>
+    <string name="genre_world">Mundial</string>
+    <string name="genre_other">Otro</string>
+
      <!-- about -->
     <string name="about_description">deutsia radio es un reproductor de radio multired gratuito y de código abierto que reúne transmisiones de clearnet, Tor (.onion) y redes I2P. Disfruta de tus estaciones favoritas en una interfaz Material You con integración Orbot y prevención de fugas configurable</string>
 
@@ -118,6 +152,29 @@
     <string name="settings_color_scheme">Esquema de color</string>
     <string name="settings_color_scheme_description">Elige tu color preferido</string>
     <string name="settings_color_blue">Azul</string>
+    <string name="settings_language">Idioma</string>
+    <string name="settings_language_description">Elige tu idioma preferido</string>
+
+    <!-- Language Names -->
+    <string name="language_choose">Elegir idioma</string>
+    <string name="language_system_default">Predeterminado del sistema</string>
+    <string name="language_arabic">العربية</string>
+    <string name="language_german">Deutsch</string>
+    <string name="language_english">English</string>
+    <string name="language_spanish">Español</string>
+    <string name="language_farsi">فارسی</string>
+    <string name="language_french">Français</string>
+    <string name="language_hindi">हिन्दी</string>
+    <string name="language_italian">Italiano</string>
+    <string name="language_japanese">日本語</string>
+    <string name="language_korean">한국어</string>
+    <string name="language_burmese">မြန်မာ</string>
+    <string name="language_portuguese">Português</string>
+    <string name="language_russian">Русский</string>
+    <string name="language_turkish">Türkçe</string>
+    <string name="language_ukrainian">Українська</string>
+    <string name="language_vietnamese">Tiếng Việt</string>
+    <string name="language_chinese">中文</string>
 
     <!-- Settings - Tor Network -->
     <string name="settings_tor_network">Red Tor</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -34,6 +34,40 @@
     <string name="genre_all">همه ژانرها</string>
     <string name="filter_by_genre">فیلتر بر اساس ژانر</string>
 
+    <!-- Genre Names -->
+    <string name="genre_alternative">Alternative</string>
+    <string name="genre_ambient">Ambient</string>
+    <string name="genre_blues">Blues</string>
+    <string name="genre_christian">Christian</string>
+    <string name="genre_classical">Classical</string>
+    <string name="genre_comedy">Comedy</string>
+    <string name="genre_country">Country</string>
+    <string name="genre_dance">Dance</string>
+    <string name="genre_edm">EDM</string>
+    <string name="genre_electronic">Electronic</string>
+    <string name="genre_folk">Folk</string>
+    <string name="genre_funk">Funk</string>
+    <string name="genre_gospel">Gospel</string>
+    <string name="genre_hip_hop">Hip Hop</string>
+    <string name="genre_indie">Indie</string>
+    <string name="genre_jazz">Jazz</string>
+    <string name="genre_k_pop">K-Pop</string>
+    <string name="genre_latin">Latin</string>
+    <string name="genre_lo_fi">Lo-Fi</string>
+    <string name="genre_metal">Metal</string>
+    <string name="genre_news">News</string>
+    <string name="genre_oldies">Oldies</string>
+    <string name="genre_pop">Pop</string>
+    <string name="genre_punk">Punk</string>
+    <string name="genre_r_and_b">R&amp;B</string>
+    <string name="genre_reggae">Reggae</string>
+    <string name="genre_rock">Rock</string>
+    <string name="genre_soul">Soul</string>
+    <string name="genre_sports">Sports</string>
+    <string name="genre_talk">Talk</string>
+    <string name="genre_world">World</string>
+    <string name="genre_other">Other</string>
+
      <!-- about -->
     <string name="about_description">deutsia radio یک پخش‌کننده رادیوی چند شبکه‌ای رایگان و متن‌باز است که جریان‌ها از شبکه‌های clearnet، Tor (.onion) و I2P را گرد هم می‌آورد. از ایستگاه‌های مورد علاقه خود در رابط Material You با یکپارچگی Orbot و جلوگیری از نشت قابل پیکربندی لذت ببرید</string>
 
@@ -118,6 +152,29 @@
     <string name="settings_color_scheme">طرح رنگی</string>
     <string name="settings_color_scheme_description">رنگ مورد نظر خود را انتخاب کنید</string>
     <string name="settings_color_blue">آبی</string>
+    <string name="settings_language">Language</string>
+    <string name="settings_language_description">Choose your preferred language</string>
+
+    <!-- Language Names -->
+    <string name="language_choose">Choose Language</string>
+    <string name="language_system_default">System Default</string>
+    <string name="language_arabic">العربية</string>
+    <string name="language_german">Deutsch</string>
+    <string name="language_english">English</string>
+    <string name="language_spanish">Español</string>
+    <string name="language_farsi">فارسی</string>
+    <string name="language_french">Français</string>
+    <string name="language_hindi">हिन्दी</string>
+    <string name="language_italian">Italiano</string>
+    <string name="language_japanese">日本語</string>
+    <string name="language_korean">한국어</string>
+    <string name="language_burmese">မြန်မာ</string>
+    <string name="language_portuguese">Português</string>
+    <string name="language_russian">Русский</string>
+    <string name="language_turkish">Türkçe</string>
+    <string name="language_ukrainian">Українська</string>
+    <string name="language_vietnamese">Tiếng Việt</string>
+    <string name="language_chinese">中文</string>
 
     <!-- Settings - Tor Network -->
     <string name="settings_tor_network">شبکه Tor</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -41,6 +41,40 @@
     <string name="genre_all">All Genres</string>
     <string name="filter_by_genre">Filter by Genre</string>
 
+    <!-- Genre Names -->
+    <string name="genre_alternative">Alternative</string>
+    <string name="genre_ambient">Ambient</string>
+    <string name="genre_blues">Blues</string>
+    <string name="genre_christian">Christian</string>
+    <string name="genre_classical">Classical</string>
+    <string name="genre_comedy">Comedy</string>
+    <string name="genre_country">Country</string>
+    <string name="genre_dance">Dance</string>
+    <string name="genre_edm">EDM</string>
+    <string name="genre_electronic">Electronic</string>
+    <string name="genre_folk">Folk</string>
+    <string name="genre_funk">Funk</string>
+    <string name="genre_gospel">Gospel</string>
+    <string name="genre_hip_hop">Hip Hop</string>
+    <string name="genre_indie">Indie</string>
+    <string name="genre_jazz">Jazz</string>
+    <string name="genre_k_pop">K-Pop</string>
+    <string name="genre_latin">Latin</string>
+    <string name="genre_lo_fi">Lo-Fi</string>
+    <string name="genre_metal">Metal</string>
+    <string name="genre_news">News</string>
+    <string name="genre_oldies">Oldies</string>
+    <string name="genre_pop">Pop</string>
+    <string name="genre_punk">Punk</string>
+    <string name="genre_r_and_b">R&amp;B</string>
+    <string name="genre_reggae">Reggae</string>
+    <string name="genre_rock">Rock</string>
+    <string name="genre_soul">Soul</string>
+    <string name="genre_sports">Sports</string>
+    <string name="genre_talk">Talk</string>
+    <string name="genre_world">World</string>
+    <string name="genre_other">Other</string>
+
      <!-- about -->
     <string name="about_description">deutsia radio is a free and open-source multinet radio player that brings together streams from the clearnet, Tor (.onion) and I2P networks. Enjoy your favorite stations in a Material You interface with Orbot integration and configurable leak prevention</string>
 
@@ -125,6 +159,29 @@
     <string name="settings_color_scheme">Color Scheme</string>
     <string name="settings_color_scheme_description">Choose your preferred color</string>
     <string name="settings_color_blue">Blue</string>
+    <string name="settings_language">Language</string>
+    <string name="settings_language_description">Choose your preferred language</string>
+
+    <!-- Language Names -->
+    <string name="language_choose">Choose Language</string>
+    <string name="language_system_default">System Default</string>
+    <string name="language_arabic">العربية</string>
+    <string name="language_german">Deutsch</string>
+    <string name="language_english">English</string>
+    <string name="language_spanish">Español</string>
+    <string name="language_farsi">فارسی</string>
+    <string name="language_french">Français</string>
+    <string name="language_hindi">हिन्दी</string>
+    <string name="language_italian">Italiano</string>
+    <string name="language_japanese">日本語</string>
+    <string name="language_korean">한국어</string>
+    <string name="language_burmese">မြန်မာ</string>
+    <string name="language_portuguese">Português</string>
+    <string name="language_russian">Русский</string>
+    <string name="language_turkish">Türkçe</string>
+    <string name="language_ukrainian">Українська</string>
+    <string name="language_vietnamese">Tiếng Việt</string>
+    <string name="language_chinese">中文</string>
 
     <!-- Settings - Tor Network -->
     <string name="settings_tor_network">Tor Network</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -31,6 +31,40 @@
     <string name="genre_all">All Genres</string>
     <string name="filter_by_genre">Filter by Genre</string>
 
+    <!-- Genre Names -->
+    <string name="genre_alternative">Alternative</string>
+    <string name="genre_ambient">Ambient</string>
+    <string name="genre_blues">Blues</string>
+    <string name="genre_christian">Christian</string>
+    <string name="genre_classical">Classical</string>
+    <string name="genre_comedy">Comedy</string>
+    <string name="genre_country">Country</string>
+    <string name="genre_dance">Dance</string>
+    <string name="genre_edm">EDM</string>
+    <string name="genre_electronic">Electronic</string>
+    <string name="genre_folk">Folk</string>
+    <string name="genre_funk">Funk</string>
+    <string name="genre_gospel">Gospel</string>
+    <string name="genre_hip_hop">Hip Hop</string>
+    <string name="genre_indie">Indie</string>
+    <string name="genre_jazz">Jazz</string>
+    <string name="genre_k_pop">K-Pop</string>
+    <string name="genre_latin">Latin</string>
+    <string name="genre_lo_fi">Lo-Fi</string>
+    <string name="genre_metal">Metal</string>
+    <string name="genre_news">News</string>
+    <string name="genre_oldies">Oldies</string>
+    <string name="genre_pop">Pop</string>
+    <string name="genre_punk">Punk</string>
+    <string name="genre_r_and_b">R&amp;B</string>
+    <string name="genre_reggae">Reggae</string>
+    <string name="genre_rock">Rock</string>
+    <string name="genre_soul">Soul</string>
+    <string name="genre_sports">Sports</string>
+    <string name="genre_talk">Talk</string>
+    <string name="genre_world">World</string>
+    <string name="genre_other">Other</string>
+
      <!-- about -->
     <string name="about_description">deutsia radio is a free and open-source multinet radio player that brings together streams from the clearnet, Tor (.onion) and I2P networks. Enjoy your favorite stations in a Material You interface with Orbot integration and configurable leak prevention</string>
 
@@ -115,6 +149,29 @@
     <string name="settings_color_scheme">Color Scheme</string>
     <string name="settings_color_scheme_description">Choose your preferred color</string>
     <string name="settings_color_blue">Blue</string>
+    <string name="settings_language">Language</string>
+    <string name="settings_language_description">Choose your preferred language</string>
+
+    <!-- Language Names -->
+    <string name="language_choose">Choose Language</string>
+    <string name="language_system_default">System Default</string>
+    <string name="language_arabic">العربية</string>
+    <string name="language_german">Deutsch</string>
+    <string name="language_english">English</string>
+    <string name="language_spanish">Español</string>
+    <string name="language_farsi">فارسی</string>
+    <string name="language_french">Français</string>
+    <string name="language_hindi">हिन्दी</string>
+    <string name="language_italian">Italiano</string>
+    <string name="language_japanese">日本語</string>
+    <string name="language_korean">한국어</string>
+    <string name="language_burmese">မြန်မာ</string>
+    <string name="language_portuguese">Português</string>
+    <string name="language_russian">Русский</string>
+    <string name="language_turkish">Türkçe</string>
+    <string name="language_ukrainian">Українська</string>
+    <string name="language_vietnamese">Tiếng Việt</string>
+    <string name="language_chinese">中文</string>
 
     <!-- Settings - Tor Network -->
     <string name="settings_tor_network">Tor Network</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -41,6 +41,40 @@
     <string name="genre_all">All Genres</string>
     <string name="filter_by_genre">Filter by Genre</string>
 
+    <!-- Genre Names -->
+    <string name="genre_alternative">Alternative</string>
+    <string name="genre_ambient">Ambient</string>
+    <string name="genre_blues">Blues</string>
+    <string name="genre_christian">Christian</string>
+    <string name="genre_classical">Classical</string>
+    <string name="genre_comedy">Comedy</string>
+    <string name="genre_country">Country</string>
+    <string name="genre_dance">Dance</string>
+    <string name="genre_edm">EDM</string>
+    <string name="genre_electronic">Electronic</string>
+    <string name="genre_folk">Folk</string>
+    <string name="genre_funk">Funk</string>
+    <string name="genre_gospel">Gospel</string>
+    <string name="genre_hip_hop">Hip Hop</string>
+    <string name="genre_indie">Indie</string>
+    <string name="genre_jazz">Jazz</string>
+    <string name="genre_k_pop">K-Pop</string>
+    <string name="genre_latin">Latin</string>
+    <string name="genre_lo_fi">Lo-Fi</string>
+    <string name="genre_metal">Metal</string>
+    <string name="genre_news">News</string>
+    <string name="genre_oldies">Oldies</string>
+    <string name="genre_pop">Pop</string>
+    <string name="genre_punk">Punk</string>
+    <string name="genre_r_and_b">R&amp;B</string>
+    <string name="genre_reggae">Reggae</string>
+    <string name="genre_rock">Rock</string>
+    <string name="genre_soul">Soul</string>
+    <string name="genre_sports">Sports</string>
+    <string name="genre_talk">Talk</string>
+    <string name="genre_world">World</string>
+    <string name="genre_other">Other</string>
+
      <!-- about -->
     <string name="about_description">deutsia radio is a free and open-source multinet radio player that brings together streams from the clearnet, Tor (.onion) and I2P networks. Enjoy your favorite stations in a Material You interface with Orbot integration and configurable leak prevention</string>
 
@@ -125,6 +159,29 @@
     <string name="settings_color_scheme">Color Scheme</string>
     <string name="settings_color_scheme_description">Choose your preferred color</string>
     <string name="settings_color_blue">Blue</string>
+    <string name="settings_language">Language</string>
+    <string name="settings_language_description">Choose your preferred language</string>
+
+    <!-- Language Names -->
+    <string name="language_choose">Choose Language</string>
+    <string name="language_system_default">System Default</string>
+    <string name="language_arabic">العربية</string>
+    <string name="language_german">Deutsch</string>
+    <string name="language_english">English</string>
+    <string name="language_spanish">Español</string>
+    <string name="language_farsi">فارسی</string>
+    <string name="language_french">Français</string>
+    <string name="language_hindi">हिन्दी</string>
+    <string name="language_italian">Italiano</string>
+    <string name="language_japanese">日本語</string>
+    <string name="language_korean">한국어</string>
+    <string name="language_burmese">မြန်မာ</string>
+    <string name="language_portuguese">Português</string>
+    <string name="language_russian">Русский</string>
+    <string name="language_turkish">Türkçe</string>
+    <string name="language_ukrainian">Українська</string>
+    <string name="language_vietnamese">Tiếng Việt</string>
+    <string name="language_chinese">中文</string>
 
     <!-- Settings - Tor Network -->
     <string name="settings_tor_network">Tor Network</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -34,6 +34,40 @@
     <string name="genre_all">すべてのジャンル</string>
     <string name="filter_by_genre">ジャンルでフィルター</string>
 
+    <!-- Genre Names -->
+    <string name="genre_alternative">Alternative</string>
+    <string name="genre_ambient">Ambient</string>
+    <string name="genre_blues">Blues</string>
+    <string name="genre_christian">Christian</string>
+    <string name="genre_classical">Classical</string>
+    <string name="genre_comedy">Comedy</string>
+    <string name="genre_country">Country</string>
+    <string name="genre_dance">Dance</string>
+    <string name="genre_edm">EDM</string>
+    <string name="genre_electronic">Electronic</string>
+    <string name="genre_folk">Folk</string>
+    <string name="genre_funk">Funk</string>
+    <string name="genre_gospel">Gospel</string>
+    <string name="genre_hip_hop">Hip Hop</string>
+    <string name="genre_indie">Indie</string>
+    <string name="genre_jazz">Jazz</string>
+    <string name="genre_k_pop">K-Pop</string>
+    <string name="genre_latin">Latin</string>
+    <string name="genre_lo_fi">Lo-Fi</string>
+    <string name="genre_metal">Metal</string>
+    <string name="genre_news">News</string>
+    <string name="genre_oldies">Oldies</string>
+    <string name="genre_pop">Pop</string>
+    <string name="genre_punk">Punk</string>
+    <string name="genre_r_and_b">R&amp;B</string>
+    <string name="genre_reggae">Reggae</string>
+    <string name="genre_rock">Rock</string>
+    <string name="genre_soul">Soul</string>
+    <string name="genre_sports">Sports</string>
+    <string name="genre_talk">Talk</string>
+    <string name="genre_world">World</string>
+    <string name="genre_other">Other</string>
+
      <!-- about -->
     <string name="about_description">deutsia radioは、clearnet、Tor（.onion）、I2Pネットワークからのストリームをまとめた無料のオープンソースマルチネットラジオプレーヤーです。Orbot統合と設定可能なリーク防止機能を備えたMaterial Youインターフェースでお気に入りのステーションをお楽しみください</string>
 
@@ -118,6 +152,29 @@
     <string name="settings_color_scheme">配色</string>
     <string name="settings_color_scheme_description">お好みの色を選択</string>
     <string name="settings_color_blue">青</string>
+    <string name="settings_language">Language</string>
+    <string name="settings_language_description">Choose your preferred language</string>
+
+    <!-- Language Names -->
+    <string name="language_choose">Choose Language</string>
+    <string name="language_system_default">System Default</string>
+    <string name="language_arabic">العربية</string>
+    <string name="language_german">Deutsch</string>
+    <string name="language_english">English</string>
+    <string name="language_spanish">Español</string>
+    <string name="language_farsi">فارسی</string>
+    <string name="language_french">Français</string>
+    <string name="language_hindi">हिन्दी</string>
+    <string name="language_italian">Italiano</string>
+    <string name="language_japanese">日本語</string>
+    <string name="language_korean">한국어</string>
+    <string name="language_burmese">မြန်မာ</string>
+    <string name="language_portuguese">Português</string>
+    <string name="language_russian">Русский</string>
+    <string name="language_turkish">Türkçe</string>
+    <string name="language_ukrainian">Українська</string>
+    <string name="language_vietnamese">Tiếng Việt</string>
+    <string name="language_chinese">中文</string>
 
     <!-- Settings - Tor Network -->
     <string name="settings_tor_network">Torネットワーク</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -34,6 +34,40 @@
     <string name="genre_all">모든 장르</string>
     <string name="filter_by_genre">장르별 필터</string>
 
+    <!-- Genre Names -->
+    <string name="genre_alternative">Alternative</string>
+    <string name="genre_ambient">Ambient</string>
+    <string name="genre_blues">Blues</string>
+    <string name="genre_christian">Christian</string>
+    <string name="genre_classical">Classical</string>
+    <string name="genre_comedy">Comedy</string>
+    <string name="genre_country">Country</string>
+    <string name="genre_dance">Dance</string>
+    <string name="genre_edm">EDM</string>
+    <string name="genre_electronic">Electronic</string>
+    <string name="genre_folk">Folk</string>
+    <string name="genre_funk">Funk</string>
+    <string name="genre_gospel">Gospel</string>
+    <string name="genre_hip_hop">Hip Hop</string>
+    <string name="genre_indie">Indie</string>
+    <string name="genre_jazz">Jazz</string>
+    <string name="genre_k_pop">K-Pop</string>
+    <string name="genre_latin">Latin</string>
+    <string name="genre_lo_fi">Lo-Fi</string>
+    <string name="genre_metal">Metal</string>
+    <string name="genre_news">News</string>
+    <string name="genre_oldies">Oldies</string>
+    <string name="genre_pop">Pop</string>
+    <string name="genre_punk">Punk</string>
+    <string name="genre_r_and_b">R&amp;B</string>
+    <string name="genre_reggae">Reggae</string>
+    <string name="genre_rock">Rock</string>
+    <string name="genre_soul">Soul</string>
+    <string name="genre_sports">Sports</string>
+    <string name="genre_talk">Talk</string>
+    <string name="genre_world">World</string>
+    <string name="genre_other">Other</string>
+
      <!-- about -->
     <string name="about_description">deutsia radio는 클리어넷, Tor(.onion) 및 I2P 네트워크의 스트림을 통합하는 무료 오픈소스 멀티넷 라디오 플레이어입니다. Orbot 통합 및 구성 가능한 유출 방지 기능이 있는 Material You 인터페이스에서 좋아하는 방송국을 즐기세요</string>
 
@@ -118,6 +152,29 @@
     <string name="settings_color_scheme">색 구성표</string>
     <string name="settings_color_scheme_description">선호하는 색상 선택</string>
     <string name="settings_color_blue">파랑</string>
+    <string name="settings_language">Language</string>
+    <string name="settings_language_description">Choose your preferred language</string>
+
+    <!-- Language Names -->
+    <string name="language_choose">Choose Language</string>
+    <string name="language_system_default">System Default</string>
+    <string name="language_arabic">العربية</string>
+    <string name="language_german">Deutsch</string>
+    <string name="language_english">English</string>
+    <string name="language_spanish">Español</string>
+    <string name="language_farsi">فارسی</string>
+    <string name="language_french">Français</string>
+    <string name="language_hindi">हिन्दी</string>
+    <string name="language_italian">Italiano</string>
+    <string name="language_japanese">日本語</string>
+    <string name="language_korean">한국어</string>
+    <string name="language_burmese">မြန်မာ</string>
+    <string name="language_portuguese">Português</string>
+    <string name="language_russian">Русский</string>
+    <string name="language_turkish">Türkçe</string>
+    <string name="language_ukrainian">Українська</string>
+    <string name="language_vietnamese">Tiếng Việt</string>
+    <string name="language_chinese">中文</string>
 
     <!-- Settings - Tor Network -->
     <string name="settings_tor_network">Tor 네트워크</string>

--- a/app/src/main/res/values-my/strings.xml
+++ b/app/src/main/res/values-my/strings.xml
@@ -31,6 +31,40 @@
     <string name="genre_all">အမျိုးအစားအားလုံး</string>
     <string name="filter_by_genre">အမျိုးအစားအလိုက် စစ်ထုတ်ရန်</string>
 
+    <!-- Genre Names -->
+    <string name="genre_alternative">Alternative</string>
+    <string name="genre_ambient">Ambient</string>
+    <string name="genre_blues">Blues</string>
+    <string name="genre_christian">Christian</string>
+    <string name="genre_classical">Classical</string>
+    <string name="genre_comedy">Comedy</string>
+    <string name="genre_country">Country</string>
+    <string name="genre_dance">Dance</string>
+    <string name="genre_edm">EDM</string>
+    <string name="genre_electronic">Electronic</string>
+    <string name="genre_folk">Folk</string>
+    <string name="genre_funk">Funk</string>
+    <string name="genre_gospel">Gospel</string>
+    <string name="genre_hip_hop">Hip Hop</string>
+    <string name="genre_indie">Indie</string>
+    <string name="genre_jazz">Jazz</string>
+    <string name="genre_k_pop">K-Pop</string>
+    <string name="genre_latin">Latin</string>
+    <string name="genre_lo_fi">Lo-Fi</string>
+    <string name="genre_metal">Metal</string>
+    <string name="genre_news">News</string>
+    <string name="genre_oldies">Oldies</string>
+    <string name="genre_pop">Pop</string>
+    <string name="genre_punk">Punk</string>
+    <string name="genre_r_and_b">R&amp;B</string>
+    <string name="genre_reggae">Reggae</string>
+    <string name="genre_rock">Rock</string>
+    <string name="genre_soul">Soul</string>
+    <string name="genre_sports">Sports</string>
+    <string name="genre_talk">Talk</string>
+    <string name="genre_world">World</string>
+    <string name="genre_other">Other</string>
+
      <!-- about -->
     <string name="about_description">deutsia radio သည် clearnet၊ Tor (.onion) နှင့် I2P ကွန်ရက်များမှ ထုတ်လွှင့်မှုများကို ပေါင်းစည်းထားသော အခမဲ့ပွင့်လင်းအရင်းအမြစ် မာလ်တီနက် ရေဒီယိုပလေယာဖြစ်သည်။ Orbot ပေါင်းစည်းမှုနှင့် ပြင်ဆင်နိုင်သော leak ကာကွယ်မှုဖြင့် Material You အင်တာဖေ့စ်တွင် သင့်အကြိုက်ဆုံး စတေးရှင်းများကို ခံစားပါ</string>
 
@@ -115,6 +149,29 @@
     <string name="settings_color_scheme">အရောင်အစီအစဉ်</string>
     <string name="settings_color_scheme_description">သင့်အကြိုက် အရောင်ကို ရွေးချယ်ပါ</string>
     <string name="settings_color_blue">အပြာ</string>
+    <string name="settings_language">Language</string>
+    <string name="settings_language_description">Choose your preferred language</string>
+
+    <!-- Language Names -->
+    <string name="language_choose">Choose Language</string>
+    <string name="language_system_default">System Default</string>
+    <string name="language_arabic">العربية</string>
+    <string name="language_german">Deutsch</string>
+    <string name="language_english">English</string>
+    <string name="language_spanish">Español</string>
+    <string name="language_farsi">فارسی</string>
+    <string name="language_french">Français</string>
+    <string name="language_hindi">हिन्दी</string>
+    <string name="language_italian">Italiano</string>
+    <string name="language_japanese">日本語</string>
+    <string name="language_korean">한국어</string>
+    <string name="language_burmese">မြန်မာ</string>
+    <string name="language_portuguese">Português</string>
+    <string name="language_russian">Русский</string>
+    <string name="language_turkish">Türkçe</string>
+    <string name="language_ukrainian">Українська</string>
+    <string name="language_vietnamese">Tiếng Việt</string>
+    <string name="language_chinese">中文</string>
 
     <!-- Settings - Tor Network -->
     <string name="settings_tor_network">Tor ကွန်ရက်</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -34,6 +34,40 @@
     <string name="genre_all">Todos os gêneros</string>
     <string name="filter_by_genre">Filtrar por gênero</string>
 
+    <!-- Genre Names -->
+    <string name="genre_alternative">Alternative</string>
+    <string name="genre_ambient">Ambient</string>
+    <string name="genre_blues">Blues</string>
+    <string name="genre_christian">Christian</string>
+    <string name="genre_classical">Classical</string>
+    <string name="genre_comedy">Comedy</string>
+    <string name="genre_country">Country</string>
+    <string name="genre_dance">Dance</string>
+    <string name="genre_edm">EDM</string>
+    <string name="genre_electronic">Electronic</string>
+    <string name="genre_folk">Folk</string>
+    <string name="genre_funk">Funk</string>
+    <string name="genre_gospel">Gospel</string>
+    <string name="genre_hip_hop">Hip Hop</string>
+    <string name="genre_indie">Indie</string>
+    <string name="genre_jazz">Jazz</string>
+    <string name="genre_k_pop">K-Pop</string>
+    <string name="genre_latin">Latin</string>
+    <string name="genre_lo_fi">Lo-Fi</string>
+    <string name="genre_metal">Metal</string>
+    <string name="genre_news">News</string>
+    <string name="genre_oldies">Oldies</string>
+    <string name="genre_pop">Pop</string>
+    <string name="genre_punk">Punk</string>
+    <string name="genre_r_and_b">R&amp;B</string>
+    <string name="genre_reggae">Reggae</string>
+    <string name="genre_rock">Rock</string>
+    <string name="genre_soul">Soul</string>
+    <string name="genre_sports">Sports</string>
+    <string name="genre_talk">Talk</string>
+    <string name="genre_world">World</string>
+    <string name="genre_other">Other</string>
+
      <!-- about -->
     <string name="about_description">deutsia radio é um reprodutor de rádio multi-rede gratuito e de código aberto que reúne transmissões de clearnet, Tor (.onion) e redes I2P. Aproveite suas estações favoritas em uma interface Material You com integração Orbot e prevenção de vazamentos configurável</string>
 
@@ -118,6 +152,29 @@
     <string name="settings_color_scheme">Esquema de cores</string>
     <string name="settings_color_scheme_description">Escolha sua cor preferida</string>
     <string name="settings_color_blue">Azul</string>
+    <string name="settings_language">Language</string>
+    <string name="settings_language_description">Choose your preferred language</string>
+
+    <!-- Language Names -->
+    <string name="language_choose">Choose Language</string>
+    <string name="language_system_default">System Default</string>
+    <string name="language_arabic">العربية</string>
+    <string name="language_german">Deutsch</string>
+    <string name="language_english">English</string>
+    <string name="language_spanish">Español</string>
+    <string name="language_farsi">فارسی</string>
+    <string name="language_french">Français</string>
+    <string name="language_hindi">हिन्दी</string>
+    <string name="language_italian">Italiano</string>
+    <string name="language_japanese">日本語</string>
+    <string name="language_korean">한국어</string>
+    <string name="language_burmese">မြန်မာ</string>
+    <string name="language_portuguese">Português</string>
+    <string name="language_russian">Русский</string>
+    <string name="language_turkish">Türkçe</string>
+    <string name="language_ukrainian">Українська</string>
+    <string name="language_vietnamese">Tiếng Việt</string>
+    <string name="language_chinese">中文</string>
 
     <!-- Settings - Tor Network -->
     <string name="settings_tor_network">Rede Tor</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -34,6 +34,40 @@
     <string name="genre_all">Все жанры</string>
     <string name="filter_by_genre">Фильтр по жанру</string>
 
+    <!-- Genre Names -->
+    <string name="genre_alternative">Alternative</string>
+    <string name="genre_ambient">Ambient</string>
+    <string name="genre_blues">Blues</string>
+    <string name="genre_christian">Christian</string>
+    <string name="genre_classical">Classical</string>
+    <string name="genre_comedy">Comedy</string>
+    <string name="genre_country">Country</string>
+    <string name="genre_dance">Dance</string>
+    <string name="genre_edm">EDM</string>
+    <string name="genre_electronic">Electronic</string>
+    <string name="genre_folk">Folk</string>
+    <string name="genre_funk">Funk</string>
+    <string name="genre_gospel">Gospel</string>
+    <string name="genre_hip_hop">Hip Hop</string>
+    <string name="genre_indie">Indie</string>
+    <string name="genre_jazz">Jazz</string>
+    <string name="genre_k_pop">K-Pop</string>
+    <string name="genre_latin">Latin</string>
+    <string name="genre_lo_fi">Lo-Fi</string>
+    <string name="genre_metal">Metal</string>
+    <string name="genre_news">News</string>
+    <string name="genre_oldies">Oldies</string>
+    <string name="genre_pop">Pop</string>
+    <string name="genre_punk">Punk</string>
+    <string name="genre_r_and_b">R&amp;B</string>
+    <string name="genre_reggae">Reggae</string>
+    <string name="genre_rock">Rock</string>
+    <string name="genre_soul">Soul</string>
+    <string name="genre_sports">Sports</string>
+    <string name="genre_talk">Talk</string>
+    <string name="genre_world">World</string>
+    <string name="genre_other">Other</string>
+
      <!-- about -->
     <string name="about_description">deutsia radio — это бесплатный радиоплеер с открытым исходным кодом, объединяющий потоки из clearnet, Tor (.onion) и I2P сетей. Наслаждайтесь любимыми станциями в интерфейсе Material You с интеграцией Orbot и настраиваемой защитой от утечек</string>
 
@@ -118,6 +152,29 @@
     <string name="settings_color_scheme">Цветовая схема</string>
     <string name="settings_color_scheme_description">Выберите предпочитаемый цвет</string>
     <string name="settings_color_blue">Синий</string>
+    <string name="settings_language">Language</string>
+    <string name="settings_language_description">Choose your preferred language</string>
+
+    <!-- Language Names -->
+    <string name="language_choose">Choose Language</string>
+    <string name="language_system_default">System Default</string>
+    <string name="language_arabic">العربية</string>
+    <string name="language_german">Deutsch</string>
+    <string name="language_english">English</string>
+    <string name="language_spanish">Español</string>
+    <string name="language_farsi">فارسی</string>
+    <string name="language_french">Français</string>
+    <string name="language_hindi">हिन्दी</string>
+    <string name="language_italian">Italiano</string>
+    <string name="language_japanese">日本語</string>
+    <string name="language_korean">한국어</string>
+    <string name="language_burmese">မြန်မာ</string>
+    <string name="language_portuguese">Português</string>
+    <string name="language_russian">Русский</string>
+    <string name="language_turkish">Türkçe</string>
+    <string name="language_ukrainian">Українська</string>
+    <string name="language_vietnamese">Tiếng Việt</string>
+    <string name="language_chinese">中文</string>
 
     <!-- Settings - Tor Network -->
     <string name="settings_tor_network">Сеть Tor</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -34,6 +34,40 @@
     <string name="genre_all">Tüm Türler</string>
     <string name="filter_by_genre">Türe Göre Filtrele</string>
 
+    <!-- Genre Names -->
+    <string name="genre_alternative">Alternative</string>
+    <string name="genre_ambient">Ambient</string>
+    <string name="genre_blues">Blues</string>
+    <string name="genre_christian">Christian</string>
+    <string name="genre_classical">Classical</string>
+    <string name="genre_comedy">Comedy</string>
+    <string name="genre_country">Country</string>
+    <string name="genre_dance">Dance</string>
+    <string name="genre_edm">EDM</string>
+    <string name="genre_electronic">Electronic</string>
+    <string name="genre_folk">Folk</string>
+    <string name="genre_funk">Funk</string>
+    <string name="genre_gospel">Gospel</string>
+    <string name="genre_hip_hop">Hip Hop</string>
+    <string name="genre_indie">Indie</string>
+    <string name="genre_jazz">Jazz</string>
+    <string name="genre_k_pop">K-Pop</string>
+    <string name="genre_latin">Latin</string>
+    <string name="genre_lo_fi">Lo-Fi</string>
+    <string name="genre_metal">Metal</string>
+    <string name="genre_news">News</string>
+    <string name="genre_oldies">Oldies</string>
+    <string name="genre_pop">Pop</string>
+    <string name="genre_punk">Punk</string>
+    <string name="genre_r_and_b">R&amp;B</string>
+    <string name="genre_reggae">Reggae</string>
+    <string name="genre_rock">Rock</string>
+    <string name="genre_soul">Soul</string>
+    <string name="genre_sports">Sports</string>
+    <string name="genre_talk">Talk</string>
+    <string name="genre_world">World</string>
+    <string name="genre_other">Other</string>
+
      <!-- about -->
     <string name="about_description">deutsia radio, clearnet, Tor (.onion) ve I2P ağlarından yayınları bir araya getiren ücretsiz ve açık kaynaklı bir çoklu ağ radyo oynatıcısıdır. Orbot entegrasyonu ve yapılandırılabilir sızıntı önleme özellikli Material You arayüzünde favori istasyonlarınızın keyfini çıkarın</string>
 
@@ -118,6 +152,29 @@
     <string name="settings_color_scheme">Renk Şeması</string>
     <string name="settings_color_scheme_description">Tercih ettiğiniz rengi seçin</string>
     <string name="settings_color_blue">Mavi</string>
+    <string name="settings_language">Language</string>
+    <string name="settings_language_description">Choose your preferred language</string>
+
+    <!-- Language Names -->
+    <string name="language_choose">Choose Language</string>
+    <string name="language_system_default">System Default</string>
+    <string name="language_arabic">العربية</string>
+    <string name="language_german">Deutsch</string>
+    <string name="language_english">English</string>
+    <string name="language_spanish">Español</string>
+    <string name="language_farsi">فارسی</string>
+    <string name="language_french">Français</string>
+    <string name="language_hindi">हिन्दी</string>
+    <string name="language_italian">Italiano</string>
+    <string name="language_japanese">日本語</string>
+    <string name="language_korean">한국어</string>
+    <string name="language_burmese">မြန်မာ</string>
+    <string name="language_portuguese">Português</string>
+    <string name="language_russian">Русский</string>
+    <string name="language_turkish">Türkçe</string>
+    <string name="language_ukrainian">Українська</string>
+    <string name="language_vietnamese">Tiếng Việt</string>
+    <string name="language_chinese">中文</string>
 
     <!-- Settings - Tor Network -->
     <string name="settings_tor_network">Tor Ağı</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -34,6 +34,40 @@
     <string name="genre_all">Усі жанри</string>
     <string name="filter_by_genre">Фільтр за жанром</string>
 
+    <!-- Genre Names -->
+    <string name="genre_alternative">Alternative</string>
+    <string name="genre_ambient">Ambient</string>
+    <string name="genre_blues">Blues</string>
+    <string name="genre_christian">Christian</string>
+    <string name="genre_classical">Classical</string>
+    <string name="genre_comedy">Comedy</string>
+    <string name="genre_country">Country</string>
+    <string name="genre_dance">Dance</string>
+    <string name="genre_edm">EDM</string>
+    <string name="genre_electronic">Electronic</string>
+    <string name="genre_folk">Folk</string>
+    <string name="genre_funk">Funk</string>
+    <string name="genre_gospel">Gospel</string>
+    <string name="genre_hip_hop">Hip Hop</string>
+    <string name="genre_indie">Indie</string>
+    <string name="genre_jazz">Jazz</string>
+    <string name="genre_k_pop">K-Pop</string>
+    <string name="genre_latin">Latin</string>
+    <string name="genre_lo_fi">Lo-Fi</string>
+    <string name="genre_metal">Metal</string>
+    <string name="genre_news">News</string>
+    <string name="genre_oldies">Oldies</string>
+    <string name="genre_pop">Pop</string>
+    <string name="genre_punk">Punk</string>
+    <string name="genre_r_and_b">R&amp;B</string>
+    <string name="genre_reggae">Reggae</string>
+    <string name="genre_rock">Rock</string>
+    <string name="genre_soul">Soul</string>
+    <string name="genre_sports">Sports</string>
+    <string name="genre_talk">Talk</string>
+    <string name="genre_world">World</string>
+    <string name="genre_other">Other</string>
+
      <!-- about -->
     <string name="about_description">deutsia radio — це безплатний радіоплеєр з відкритим кодом, який об\'єднує потоки з clearnet, Tor (.onion) та I2P мереж. Насолоджуйтесь улюбленими станціями в Material You інтерфейсі з інтеграцією Orbot та налаштованим запобіганням витоків</string>
 
@@ -118,6 +152,29 @@
     <string name="settings_color_scheme">Колірна схема</string>
     <string name="settings_color_scheme_description">Виберіть бажаний колір</string>
     <string name="settings_color_blue">Синій</string>
+    <string name="settings_language">Language</string>
+    <string name="settings_language_description">Choose your preferred language</string>
+
+    <!-- Language Names -->
+    <string name="language_choose">Choose Language</string>
+    <string name="language_system_default">System Default</string>
+    <string name="language_arabic">العربية</string>
+    <string name="language_german">Deutsch</string>
+    <string name="language_english">English</string>
+    <string name="language_spanish">Español</string>
+    <string name="language_farsi">فارسی</string>
+    <string name="language_french">Français</string>
+    <string name="language_hindi">हिन्दी</string>
+    <string name="language_italian">Italiano</string>
+    <string name="language_japanese">日本語</string>
+    <string name="language_korean">한국어</string>
+    <string name="language_burmese">မြန်မာ</string>
+    <string name="language_portuguese">Português</string>
+    <string name="language_russian">Русский</string>
+    <string name="language_turkish">Türkçe</string>
+    <string name="language_ukrainian">Українська</string>
+    <string name="language_vietnamese">Tiếng Việt</string>
+    <string name="language_chinese">中文</string>
 
     <!-- Settings - Tor Network -->
     <string name="settings_tor_network">Мережа Tor</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -34,6 +34,40 @@
     <string name="genre_all">Tất cả thể loại</string>
     <string name="filter_by_genre">Lọc theo thể loại</string>
 
+    <!-- Genre Names -->
+    <string name="genre_alternative">Alternative</string>
+    <string name="genre_ambient">Ambient</string>
+    <string name="genre_blues">Blues</string>
+    <string name="genre_christian">Christian</string>
+    <string name="genre_classical">Classical</string>
+    <string name="genre_comedy">Comedy</string>
+    <string name="genre_country">Country</string>
+    <string name="genre_dance">Dance</string>
+    <string name="genre_edm">EDM</string>
+    <string name="genre_electronic">Electronic</string>
+    <string name="genre_folk">Folk</string>
+    <string name="genre_funk">Funk</string>
+    <string name="genre_gospel">Gospel</string>
+    <string name="genre_hip_hop">Hip Hop</string>
+    <string name="genre_indie">Indie</string>
+    <string name="genre_jazz">Jazz</string>
+    <string name="genre_k_pop">K-Pop</string>
+    <string name="genre_latin">Latin</string>
+    <string name="genre_lo_fi">Lo-Fi</string>
+    <string name="genre_metal">Metal</string>
+    <string name="genre_news">News</string>
+    <string name="genre_oldies">Oldies</string>
+    <string name="genre_pop">Pop</string>
+    <string name="genre_punk">Punk</string>
+    <string name="genre_r_and_b">R&amp;B</string>
+    <string name="genre_reggae">Reggae</string>
+    <string name="genre_rock">Rock</string>
+    <string name="genre_soul">Soul</string>
+    <string name="genre_sports">Sports</string>
+    <string name="genre_talk">Talk</string>
+    <string name="genre_world">World</string>
+    <string name="genre_other">Other</string>
+
      <!-- about -->
     <string name="about_description">deutsia radio là trình phát radio đa mạng miễn phí và mã nguồn mở, tập hợp các luồng từ mạng clearnet, Tor (.onion) và I2P. Tận hưởng các trạm yêu thích của bạn trong giao diện Material You với tích hợp Orbot và ngăn chặn rò rỉ có thể cấu hình</string>
 
@@ -118,6 +152,29 @@
     <string name="settings_color_scheme">Bảng màu</string>
     <string name="settings_color_scheme_description">Chọn màu ưa thích của bạn</string>
     <string name="settings_color_blue">Xanh dương</string>
+    <string name="settings_language">Language</string>
+    <string name="settings_language_description">Choose your preferred language</string>
+
+    <!-- Language Names -->
+    <string name="language_choose">Choose Language</string>
+    <string name="language_system_default">System Default</string>
+    <string name="language_arabic">العربية</string>
+    <string name="language_german">Deutsch</string>
+    <string name="language_english">English</string>
+    <string name="language_spanish">Español</string>
+    <string name="language_farsi">فارسی</string>
+    <string name="language_french">Français</string>
+    <string name="language_hindi">हिन्दी</string>
+    <string name="language_italian">Italiano</string>
+    <string name="language_japanese">日本語</string>
+    <string name="language_korean">한국어</string>
+    <string name="language_burmese">မြန်မာ</string>
+    <string name="language_portuguese">Português</string>
+    <string name="language_russian">Русский</string>
+    <string name="language_turkish">Türkçe</string>
+    <string name="language_ukrainian">Українська</string>
+    <string name="language_vietnamese">Tiếng Việt</string>
+    <string name="language_chinese">中文</string>
 
     <!-- Settings - Tor Network -->
     <string name="settings_tor_network">Mạng Tor</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -34,6 +34,40 @@
     <string name="genre_all">所有类型</string>
     <string name="filter_by_genre">按类型筛选</string>
 
+    <!-- Genre Names -->
+    <string name="genre_alternative">Alternative</string>
+    <string name="genre_ambient">Ambient</string>
+    <string name="genre_blues">Blues</string>
+    <string name="genre_christian">Christian</string>
+    <string name="genre_classical">Classical</string>
+    <string name="genre_comedy">Comedy</string>
+    <string name="genre_country">Country</string>
+    <string name="genre_dance">Dance</string>
+    <string name="genre_edm">EDM</string>
+    <string name="genre_electronic">Electronic</string>
+    <string name="genre_folk">Folk</string>
+    <string name="genre_funk">Funk</string>
+    <string name="genre_gospel">Gospel</string>
+    <string name="genre_hip_hop">Hip Hop</string>
+    <string name="genre_indie">Indie</string>
+    <string name="genre_jazz">Jazz</string>
+    <string name="genre_k_pop">K-Pop</string>
+    <string name="genre_latin">Latin</string>
+    <string name="genre_lo_fi">Lo-Fi</string>
+    <string name="genre_metal">Metal</string>
+    <string name="genre_news">News</string>
+    <string name="genre_oldies">Oldies</string>
+    <string name="genre_pop">Pop</string>
+    <string name="genre_punk">Punk</string>
+    <string name="genre_r_and_b">R&amp;B</string>
+    <string name="genre_reggae">Reggae</string>
+    <string name="genre_rock">Rock</string>
+    <string name="genre_soul">Soul</string>
+    <string name="genre_sports">Sports</string>
+    <string name="genre_talk">Talk</string>
+    <string name="genre_world">World</string>
+    <string name="genre_other">Other</string>
+
      <!-- about -->
     <string name="about_description">deutsia radio 是一款免费开源的多网络电台播放器，整合了来自明网、Tor（.onion）和 I2P 网络的流媒体。在具有 Orbot 集成和可配置泄漏防护的 Material You 界面中享受您喜爱的电台</string>
 
@@ -118,6 +152,29 @@
     <string name="settings_color_scheme">配色方案</string>
     <string name="settings_color_scheme_description">选择您喜欢的颜色</string>
     <string name="settings_color_blue">蓝色</string>
+    <string name="settings_language">Language</string>
+    <string name="settings_language_description">Choose your preferred language</string>
+
+    <!-- Language Names -->
+    <string name="language_choose">Choose Language</string>
+    <string name="language_system_default">System Default</string>
+    <string name="language_arabic">العربية</string>
+    <string name="language_german">Deutsch</string>
+    <string name="language_english">English</string>
+    <string name="language_spanish">Español</string>
+    <string name="language_farsi">فارسی</string>
+    <string name="language_french">Français</string>
+    <string name="language_hindi">हिन्दी</string>
+    <string name="language_italian">Italiano</string>
+    <string name="language_japanese">日本語</string>
+    <string name="language_korean">한국어</string>
+    <string name="language_burmese">မြန်မာ</string>
+    <string name="language_portuguese">Português</string>
+    <string name="language_russian">Русский</string>
+    <string name="language_turkish">Türkçe</string>
+    <string name="language_ukrainian">Українська</string>
+    <string name="language_vietnamese">Tiếng Việt</string>
+    <string name="language_chinese">中文</string>
 
     <!-- Settings - Tor Network -->
     <string name="settings_tor_network">Tor 网络</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -31,6 +31,40 @@
     <string name="genre_all">All Genres</string>
     <string name="filter_by_genre">Filter by Genre</string>
 
+    <!-- Genre Names -->
+    <string name="genre_alternative">Alternative</string>
+    <string name="genre_ambient">Ambient</string>
+    <string name="genre_blues">Blues</string>
+    <string name="genre_christian">Christian</string>
+    <string name="genre_classical">Classical</string>
+    <string name="genre_comedy">Comedy</string>
+    <string name="genre_country">Country</string>
+    <string name="genre_dance">Dance</string>
+    <string name="genre_edm">EDM</string>
+    <string name="genre_electronic">Electronic</string>
+    <string name="genre_folk">Folk</string>
+    <string name="genre_funk">Funk</string>
+    <string name="genre_gospel">Gospel</string>
+    <string name="genre_hip_hop">Hip Hop</string>
+    <string name="genre_indie">Indie</string>
+    <string name="genre_jazz">Jazz</string>
+    <string name="genre_k_pop">K-Pop</string>
+    <string name="genre_latin">Latin</string>
+    <string name="genre_lo_fi">Lo-Fi</string>
+    <string name="genre_metal">Metal</string>
+    <string name="genre_news">News</string>
+    <string name="genre_oldies">Oldies</string>
+    <string name="genre_pop">Pop</string>
+    <string name="genre_punk">Punk</string>
+    <string name="genre_r_and_b">R&amp;B</string>
+    <string name="genre_reggae">Reggae</string>
+    <string name="genre_rock">Rock</string>
+    <string name="genre_soul">Soul</string>
+    <string name="genre_sports">Sports</string>
+    <string name="genre_talk">Talk</string>
+    <string name="genre_world">World</string>
+    <string name="genre_other">Other</string>
+
      <!-- about -->
     <string name="about_description">deutsia radio is a free and open-source multinet radio player that brings together streams from the clearnet, Tor (.onion) and I2P networks. Enjoy your favorite stations in a Material You interface with Orbot integration and configurable leak prevention</string>
 
@@ -119,6 +153,7 @@
     <string name="settings_language_description">Choose your preferred language</string>
 
     <!-- Language Names -->
+    <string name="language_choose">Choose Language</string>
     <string name="language_system_default">System Default</string>
     <string name="language_arabic">العربية</string>
     <string name="language_german">Deutsch</string>


### PR DESCRIPTION
- Added string resources for all 32 genre names to support proper translation
- Updated LibraryFragment.kt to use getString() for genre names instead of hardcoded English strings
- Added language_choose string resource for language dialog title
- Updated SettingsFragment.kt to use getString() for "Choose Language" dialog title
- Added genre and language string resources to all 15 language translation files
- Genres and language switcher will now properly translate across all supported languages

This fixes two issues:
1. Genre list was hardcoded in English and didn't translate
2. Language switcher dialog title was hardcoded as "Choose Language"