### PR TITLE
Make hardcoded UI strings translatable

### DIFF
--- a/app/src/main/java/com/opensource/i2pradio/ui/SettingsFragment.kt
+++ b/app/src/main/java/com/opensource/i2pradio/ui/SettingsFragment.kt
@@ -522,13 +522,20 @@ class SettingsFragment : Fragment() {
     }
 
     private fun showSleepTimerDialog(button: MaterialButton) {
-        val options = arrayOf("Off", "15 minutes", "30 minutes", "45 minutes", "60 minutes", "90 minutes")
+        val options = arrayOf(
+            getString(R.string.settings_sleep_timer_off),
+            getString(R.string.settings_sleep_timer_15min),
+            getString(R.string.settings_sleep_timer_30min),
+            getString(R.string.settings_sleep_timer_45min),
+            getString(R.string.settings_sleep_timer_60min),
+            getString(R.string.settings_sleep_timer_90min)
+        )
         val values = intArrayOf(0, 15, 30, 45, 60, 90)
         val currentMinutes = PreferencesHelper.getSleepTimerMinutes(requireContext())
         val selectedIndex = values.indexOf(currentMinutes).coerceAtLeast(0)
 
         AlertDialog.Builder(requireContext())
-            .setTitle("Sleep Timer")
+            .setTitle(getString(R.string.settings_sleep_timer))
             .setSingleChoiceItems(options, selectedIndex) { dialog, which ->
                 val minutes = values[which]
                 PreferencesHelper.setSleepTimerMinutes(requireContext(), minutes)
@@ -970,14 +977,17 @@ class SettingsFragment : Fragment() {
     }
 
     private fun showRecordingDirectoryDialog() {
-        val options = mutableListOf("Default (Music/deutsia_radio)", "Choose custom folder...")
+        val options = mutableListOf(
+            getString(R.string.settings_recording_directory_default),
+            getString(R.string.settings_recording_directory_choose)
+        )
         val savedUri = PreferencesHelper.getRecordingDirectoryUri(requireContext())
         if (savedUri != null) {
-            options.add(1, "Clear custom folder")
+            options.add(1, getString(R.string.settings_recording_directory_clear))
         }
 
         AlertDialog.Builder(requireContext())
-            .setTitle("Recording Directory")
+            .setTitle(getString(R.string.settings_recording_directory))
             .setItems(options.toTypedArray()) { dialog, which ->
                 when {
                     which == 0 -> {
@@ -1005,14 +1015,18 @@ class SettingsFragment : Fragment() {
     private fun updateThemeButtonText(button: MaterialButton) {
         val currentMode = AppCompatDelegate.getDefaultNightMode()
         button.text = when (currentMode) {
-            AppCompatDelegate.MODE_NIGHT_NO -> "Light"
-            AppCompatDelegate.MODE_NIGHT_YES -> "Dark"
-            else -> "System Default"
+            AppCompatDelegate.MODE_NIGHT_NO -> getString(R.string.settings_theme_light)
+            AppCompatDelegate.MODE_NIGHT_YES -> getString(R.string.settings_theme_dark)
+            else -> getString(R.string.settings_theme_system_default)
         }
     }
 
     private fun showThemeDialog(themeButton: MaterialButton) {
-        val themes = arrayOf("System Default", "Light", "Dark")
+        val themes = arrayOf(
+            getString(R.string.settings_theme_system_default),
+            getString(R.string.settings_theme_light),
+            getString(R.string.settings_theme_dark)
+        )
         val currentMode = AppCompatDelegate.getDefaultNightMode()
         val selectedIndex = when (currentMode) {
             AppCompatDelegate.MODE_NIGHT_NO -> 1
@@ -1021,7 +1035,7 @@ class SettingsFragment : Fragment() {
         }
 
         AlertDialog.Builder(requireContext())
-            .setTitle("Choose Theme")
+            .setTitle(getString(R.string.settings_theme))
             .setSingleChoiceItems(themes, selectedIndex) { dialog, which ->
                 val newMode = when (which) {
                     0 -> AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM
@@ -1040,22 +1054,28 @@ class SettingsFragment : Fragment() {
     private fun updateColorSchemeButtonText(button: MaterialButton) {
         val currentScheme = PreferencesHelper.getColorScheme(requireContext())
         button.text = when (currentScheme) {
-            "peach" -> "Peach"
-            "green" -> "Green"
-            "purple" -> "Purple"
-            "orange" -> "Orange"
-            else -> "Blue"
+            "peach" -> getString(R.string.settings_color_peach)
+            "green" -> getString(R.string.settings_color_green)
+            "purple" -> getString(R.string.settings_color_purple)
+            "orange" -> getString(R.string.settings_color_orange)
+            else -> getString(R.string.settings_color_blue)
         }
     }
 
     private fun showColorSchemeDialog(colorSchemeButton: MaterialButton) {
-        val schemes = arrayOf("Blue (Default)", "Peach", "Green", "Purple", "Orange")
+        val schemes = arrayOf(
+            getString(R.string.settings_color_blue_default),
+            getString(R.string.settings_color_peach),
+            getString(R.string.settings_color_green),
+            getString(R.string.settings_color_purple),
+            getString(R.string.settings_color_orange)
+        )
         val schemeValues = arrayOf("default", "peach", "green", "purple", "orange")
         val currentScheme = PreferencesHelper.getColorScheme(requireContext())
         val selectedIndex = schemeValues.indexOf(currentScheme).coerceAtLeast(0)
 
         AlertDialog.Builder(requireContext())
-            .setTitle("Choose Color Scheme")
+            .setTitle(getString(R.string.settings_color_scheme))
             .setSingleChoiceItems(schemes, selectedIndex) { dialog, which ->
                 val newScheme = schemeValues[which]
                 PreferencesHelper.setColorScheme(requireContext(), newScheme)

--- a/app/src/main/java/com/opensource/i2pradio/ui/TorQuickControlBottomSheet.kt
+++ b/app/src/main/java/com/opensource/i2pradio/ui/TorQuickControlBottomSheet.kt
@@ -108,18 +108,18 @@ class TorQuickControlBottomSheet : BottomSheetDialogFragment() {
     private fun showStoppedState() {
         statusIcon.setImageResource(R.drawable.ic_tor_off)
         statusIcon.alpha = 0.6f
-        statusTitle.text = "Tor Disconnected"
-        statusSubtitle.text = "Tap Connect to browse anonymously via Tor"
+        statusTitle.text = getString(R.string.tor_control_title_stopped)
+        statusSubtitle.text = getString(R.string.tor_control_subtitle_stopped)
         connectionProgress.visibility = View.GONE
         connectionDetailsContainer.visibility = View.GONE
         orbotInfoCard.visibility = View.GONE
 
-        primaryActionButton.text = "Connect to Tor"
+        primaryActionButton.text = getString(R.string.tor_connect)
         primaryActionButton.setIconResource(R.drawable.ic_tor_on)
         primaryActionButton.isEnabled = true
         primaryActionButton.visibility = View.VISIBLE
 
-        secondaryActionButton.text = "Open Orbot"
+        secondaryActionButton.text = getString(R.string.tor_control_button_open_orbot)
         secondaryActionButton.visibility = View.VISIBLE
         secondaryActionButton.isEnabled = TorManager.isOrbotInstalled(requireContext())
     }
@@ -127,8 +127,8 @@ class TorQuickControlBottomSheet : BottomSheetDialogFragment() {
     private fun showConnectingState() {
         statusIcon.setImageResource(R.drawable.ic_tor_connecting)
         statusIcon.alpha = 1f
-        statusTitle.text = "Connecting to Tor..."
-        statusSubtitle.text = "Establishing secure connection via Orbot"
+        statusTitle.text = getString(R.string.tor_control_title_connecting)
+        statusSubtitle.text = getString(R.string.tor_control_subtitle_connecting)
         connectionProgress.visibility = View.VISIBLE
         connectionDetailsContainer.visibility = View.GONE
         orbotInfoCard.visibility = View.GONE
@@ -148,12 +148,12 @@ class TorQuickControlBottomSheet : BottomSheetDialogFragment() {
             }
             .start()
 
-        primaryActionButton.text = "Connecting..."
+        primaryActionButton.text = getString(R.string.tor_control_button_connecting)
         primaryActionButton.icon = null
         primaryActionButton.isEnabled = false
         primaryActionButton.visibility = View.VISIBLE
 
-        secondaryActionButton.text = "Cancel"
+        secondaryActionButton.text = getString(R.string.tor_control_button_cancel)
         secondaryActionButton.visibility = View.VISIBLE
         secondaryActionButton.isEnabled = true
     }
@@ -167,11 +167,11 @@ class TorQuickControlBottomSheet : BottomSheetDialogFragment() {
                                 PreferencesHelper.isForceTorExceptI2P(requireContext())
 
         if (isForceTorEnabled) {
-            statusTitle.text = "Connected to Tor (Force Mode)"
-            statusSubtitle.text = "Disconnect via Orbot or disable Force Tor in settings"
+            statusTitle.text = getString(R.string.tor_control_title_connected_force)
+            statusSubtitle.text = getString(R.string.tor_control_subtitle_connected_force)
         } else {
-            statusTitle.text = "Connected to Tor"
-            statusSubtitle.text = "Your connection is private and anonymous"
+            statusTitle.text = getString(R.string.tor_control_title_connected)
+            statusSubtitle.text = getString(R.string.tor_control_subtitle_connected)
         }
 
         connectionProgress.visibility = View.GONE
@@ -197,14 +197,14 @@ class TorQuickControlBottomSheet : BottomSheetDialogFragment() {
             }
             .start()
 
-        primaryActionButton.text = "Disconnect"
+        primaryActionButton.text = getString(R.string.tor_control_button_disconnect)
         primaryActionButton.setIconResource(R.drawable.ic_tor_off)
         // Disable disconnect button if force Tor mode is enabled
         primaryActionButton.isEnabled = !isForceTorEnabled
         primaryActionButton.alpha = if (isForceTorEnabled) 0.5f else 1.0f
         primaryActionButton.visibility = View.VISIBLE
 
-        secondaryActionButton.text = "Open Orbot"
+        secondaryActionButton.text = getString(R.string.tor_control_button_open_orbot)
         secondaryActionButton.visibility = View.VISIBLE
         secondaryActionButton.isEnabled = true
     }
@@ -212,8 +212,8 @@ class TorQuickControlBottomSheet : BottomSheetDialogFragment() {
     private fun showErrorState() {
         statusIcon.setImageResource(R.drawable.ic_tor_error)
         statusIcon.alpha = 1f
-        statusTitle.text = "Connection Failed"
-        statusSubtitle.text = TorManager.errorMessage ?: "Could not connect to Tor network"
+        statusTitle.text = getString(R.string.tor_control_title_error)
+        statusSubtitle.text = TorManager.errorMessage ?: getString(R.string.tor_control_subtitle_error)
         connectionProgress.visibility = View.GONE
         connectionDetailsContainer.visibility = View.GONE
         orbotInfoCard.visibility = View.GONE
@@ -236,12 +236,12 @@ class TorQuickControlBottomSheet : BottomSheetDialogFragment() {
             }
             .start()
 
-        primaryActionButton.text = "Retry Connection"
+        primaryActionButton.text = getString(R.string.tor_control_button_retry)
         primaryActionButton.setIconResource(R.drawable.ic_tor_on)
         primaryActionButton.isEnabled = true
         primaryActionButton.visibility = View.VISIBLE
 
-        secondaryActionButton.text = "Open Orbot"
+        secondaryActionButton.text = getString(R.string.tor_control_button_open_orbot)
         secondaryActionButton.visibility = View.VISIBLE
         secondaryActionButton.isEnabled = TorManager.isOrbotInstalled(requireContext())
     }
@@ -249,13 +249,13 @@ class TorQuickControlBottomSheet : BottomSheetDialogFragment() {
     private fun showOrbotNotInstalledState() {
         statusIcon.setImageResource(R.drawable.ic_orbot)
         statusIcon.alpha = 1f
-        statusTitle.text = "Orbot Required"
-        statusSubtitle.text = "Install Orbot to connect to the Tor network"
+        statusTitle.text = getString(R.string.tor_control_title_orbot_required)
+        statusSubtitle.text = getString(R.string.tor_control_subtitle_orbot_required)
         connectionProgress.visibility = View.GONE
         connectionDetailsContainer.visibility = View.GONE
         orbotInfoCard.visibility = View.VISIBLE
 
-        primaryActionButton.text = "Install Orbot"
+        primaryActionButton.text = getString(R.string.tor_control_button_install)
         primaryActionButton.setIconResource(R.drawable.ic_download)
         primaryActionButton.isEnabled = true
         primaryActionButton.visibility = View.VISIBLE

--- a/app/src/main/java/com/opensource/i2pradio/ui/TorStatusView.kt
+++ b/app/src/main/java/com/opensource/i2pradio/ui/TorStatusView.kt
@@ -85,7 +85,7 @@ class TorStatusView @JvmOverloads constructor(
                 } else {
                     statusIcon.setImageResource(R.drawable.ic_tor_off)
                     statusIcon.alpha = 0.5f
-                    statusText.text = "Tor Off"
+                    statusText.text = context.getString(R.string.tor_status_off)
                     statusText.setTextColor(context.getColor(R.color.tor_disconnected))
                     contentDescription = "Tor is disconnected. Tap to connect."
                 }
@@ -93,7 +93,7 @@ class TorStatusView @JvmOverloads constructor(
             TorManager.TorState.STARTING -> {
                 statusIcon.setImageResource(R.drawable.ic_tor_connecting)
                 statusIcon.alpha = 1f
-                statusText.text = "Connecting..."
+                statusText.text = context.getString(R.string.tor_status_connecting)
                 statusText.setTextColor(context.getColor(R.color.tor_connecting))
                 contentDescription = "Tor is connecting..."
                 startConnectingAnimation()
@@ -101,7 +101,7 @@ class TorStatusView @JvmOverloads constructor(
             TorManager.TorState.CONNECTED -> {
                 statusIcon.setImageResource(R.drawable.ic_tor_on)
                 statusIcon.alpha = 1f
-                statusText.text = "Tor Connected"
+                statusText.text = context.getString(R.string.tor_status_connected)
                 statusText.setTextColor(context.getColor(R.color.tor_connected))
                 contentDescription = "Tor is connected. Tap to view details."
                 showConnectedAnimation()
@@ -113,7 +113,7 @@ class TorStatusView @JvmOverloads constructor(
                 } else {
                     statusIcon.setImageResource(R.drawable.ic_tor_error)
                     statusIcon.alpha = 1f
-                    statusText.text = "Tor Error"
+                    statusText.text = context.getString(R.string.tor_status_error)
                     statusText.setTextColor(context.getColor(R.color.tor_error))
                     contentDescription = "Tor connection failed. Tap to retry."
                     showErrorAnimation()
@@ -129,7 +129,7 @@ class TorStatusView @JvmOverloads constructor(
                 } else {
                     statusIcon.setImageResource(R.drawable.ic_tor_off)
                     statusIcon.alpha = 0.5f
-                    statusText.text = "Install Orbot"
+                    statusText.text = context.getString(R.string.tor_status_install_orbot)
                     statusText.setTextColor(context.getColor(R.color.tor_disconnected))
                     contentDescription = "Orbot is not installed. Tap to install."
                 }
@@ -140,7 +140,7 @@ class TorStatusView @JvmOverloads constructor(
     private fun showConnectedStateForForceTor() {
         statusIcon.setImageResource(R.drawable.ic_tor_on)
         statusIcon.alpha = 1f
-        statusText.text = "Tor Connected"
+        statusText.text = context.getString(R.string.tor_status_connected)
         statusText.setTextColor(context.getColor(R.color.tor_connected))
         contentDescription = "Tor is connected (Force Mode). Tap to view details."
         showConnectedAnimation()
@@ -149,7 +149,7 @@ class TorStatusView @JvmOverloads constructor(
     private fun showForceTorWarning() {
         statusIcon.setImageResource(R.drawable.ic_tor_error)
         statusIcon.alpha = 1f
-        statusText.text = "Leak Warning"
+        statusText.text = context.getString(R.string.tor_status_leak_warning)
         statusText.setTextColor(context.getColor(R.color.tor_error))
         contentDescription = "Force Tor is enabled but not connected. Privacy may be compromised."
         showErrorAnimation()

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -144,11 +144,18 @@
     <string name="settings_theme">Theme</string>
     <string name="settings_theme_description">Choose light, dark, or system</string>
     <string name="settings_theme_system_default">System Default</string>
+    <string name="settings_theme_light">Light</string>
+    <string name="settings_theme_dark">Dark</string>
     <string name="settings_material_you">Material You</string>
     <string name="settings_material_you_description">Use wallpaper-based dynamic colors</string>
     <string name="settings_color_scheme">Color Scheme</string>
     <string name="settings_color_scheme_description">Choose your preferred color</string>
     <string name="settings_color_blue">Blue</string>
+    <string name="settings_color_blue_default">Blue (Default)</string>
+    <string name="settings_color_peach">Peach</string>
+    <string name="settings_color_green">Green</string>
+    <string name="settings_color_purple">Purple</string>
+    <string name="settings_color_orange">Orange</string>
     <string name="settings_language">Language</string>
     <string name="settings_language_description">Choose your preferred language</string>
 
@@ -207,9 +214,16 @@
     <string name="settings_sleep_timer">Sleep Timer</string>
     <string name="settings_sleep_timer_description">Auto-stop playback after set time</string>
     <string name="settings_sleep_timer_off">Off</string>
+    <string name="settings_sleep_timer_15min">15 minutes</string>
+    <string name="settings_sleep_timer_30min">30 minutes</string>
+    <string name="settings_sleep_timer_45min">45 minutes</string>
+    <string name="settings_sleep_timer_60min">60 minutes</string>
+    <string name="settings_sleep_timer_90min">90 minutes</string>
     <string name="settings_equalizer_description">Adjust audio frequency bands and effects</string>
     <string name="settings_recording_directory">Recording Directory</string>
     <string name="settings_recording_directory_default">Default (Music/deutsia_radio)</string>
+    <string name="settings_recording_directory_choose">Choose custom folder...</string>
+    <string name="settings_recording_directory_clear">Clear custom folder</string>
     <string name="settings_record_across_stations">Record Across Stations</string>
     <string name="settings_record_across_stations_description">Keep recording when switching stations</string>
     <string name="settings_record_all_stations">Record All Stations</string>
@@ -244,6 +258,35 @@
     <string name="tor_orbot_description">Orbot is the official Tor client for Android. It provides secure, encrypted access to the Tor network.</string>
     <string name="tor_connect">Connect to Tor</string>
     <string name="tor_open_orbot">Open Orbot</string>
+
+    <!-- Tor Status Messages -->
+    <string name="tor_status_connecting">Connecting...</string>
+    <string name="tor_status_connected">Tor Connected</string>
+    <string name="tor_status_disconnected">Tor Disconnected</string>
+    <string name="tor_status_off">Tor Off</string>
+    <string name="tor_status_error">Tor Error</string>
+    <string name="tor_status_leak_warning">Leak Warning</string>
+    <string name="tor_status_install_orbot">Install Orbot</string>
+    <string name="tor_status_connecting_message">Connecting to Tor...</string>
+    <string name="tor_status_connected_message">Connected via Tor</string>
+    <string name="tor_control_title_stopped">Tor Disconnected</string>
+    <string name="tor_control_subtitle_stopped">Tap Connect to browse anonymously via Tor</string>
+    <string name="tor_control_subtitle_connecting">Establishing secure connection via Orbot</string>
+    <string name="tor_control_title_connecting">Connecting to Tor...</string>
+    <string name="tor_control_title_connected">Connected to Tor</string>
+    <string name="tor_control_title_connected_force">Connected to Tor (Force Mode)</string>
+    <string name="tor_control_subtitle_connected">Your connection is private and anonymous</string>
+    <string name="tor_control_subtitle_connected_force">Disconnect via Orbot or disable Force Tor in settings</string>
+    <string name="tor_control_title_error">Connection Failed</string>
+    <string name="tor_control_subtitle_error">Could not connect to Tor network</string>
+    <string name="tor_control_title_orbot_required">Orbot Required</string>
+    <string name="tor_control_subtitle_orbot_required">Install Orbot to connect to the Tor network</string>
+    <string name="tor_control_button_connecting">Connecting...</string>
+    <string name="tor_control_button_disconnect">Disconnect</string>
+    <string name="tor_control_button_cancel">Cancel</string>
+    <string name="tor_control_button_retry">Retry Connection</string>
+    <string name="tor_control_button_install">Install Orbot</string>
+    <string name="tor_control_button_open_orbot">Open Orbot</string>
 
     <!-- Add/Edit Radio Dialog -->
     <string name="add_edit_tor_info">Using embedded Tor - no proxy config needed</string>


### PR DESCRIPTION
- Add translation strings for theme options (System Default, Light, Dark)
- Add translation strings for color scheme options (Blue, Peach, Green, Purple, Orange)
- Add translation strings for sleep timer options (Off, 15/30/45/60/90 minutes)
- Add translation strings for recording directory dialog options
- Add translation strings for Tor connection status and controls
- Update SettingsFragment.kt to use getString() for all dialogs
- Update TorStatusView.kt to use getString() for all status messages
- Update TorQuickControlBottomSheet.kt to use getString() for all UI text

This enables translation of previously hardcoded strings including:
- Theme selection (system default/light/dark)
- Color scheme selection
- Tor connection status messages
- Sleep timer options
- Recording directory options