### PR TITLE
Add missing translatable strings to all language files

### DIFF
--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -147,17 +147,24 @@
     <string name="settings_theme">السمة</string>
     <string name="settings_theme_description">اختر فاتح أو داكن أو النظام</string>
     <string name="settings_theme_system_default">افتراضي النظام</string>
+    <string name="settings_theme_light">فاتح</string>
+    <string name="settings_theme_dark">داكن</string>
     <string name="settings_material_you">Material You</string>
     <string name="settings_material_you_description">استخدم الألوان الديناميكية المستندة إلى الخلفية</string>
     <string name="settings_color_scheme">نظام الألوان</string>
     <string name="settings_color_scheme_description">اختر اللون المفضل لديك</string>
     <string name="settings_color_blue">أزرق</string>
-    <string name="settings_language">Language</string>
-    <string name="settings_language_description">Choose your preferred language</string>
+    <string name="settings_color_blue_default">أزرق (افتراضي)</string>
+    <string name="settings_color_peach">خوخي</string>
+    <string name="settings_color_green">أخضر</string>
+    <string name="settings_color_purple">بنفسجي</string>
+    <string name="settings_color_orange">برتقالي</string>
+    <string name="settings_language">اللغة</string>
+    <string name="settings_language_description">اختر لغتك المفضلة</string>
 
     <!-- Language Names -->
-    <string name="language_choose">Choose Language</string>
-    <string name="language_system_default">System Default</string>
+    <string name="language_choose">اختيار اللغة</string>
+    <string name="language_system_default">افتراضي النظام</string>
     <string name="language_arabic">العربية</string>
     <string name="language_german">Deutsch</string>
     <string name="language_english">English</string>
@@ -210,9 +217,16 @@
     <string name="settings_sleep_timer">مؤقت النوم</string>
     <string name="settings_sleep_timer_description">إيقاف التشغيل تلقائياً بعد الوقت المحدد</string>
     <string name="settings_sleep_timer_off">إيقاف</string>
+    <string name="settings_sleep_timer_15min">15 دقيقة</string>
+    <string name="settings_sleep_timer_30min">30 دقيقة</string>
+    <string name="settings_sleep_timer_45min">45 دقيقة</string>
+    <string name="settings_sleep_timer_60min">60 دقيقة</string>
+    <string name="settings_sleep_timer_90min">90 دقيقة</string>
     <string name="settings_equalizer_description">ضبط نطاقات تردد الصوت والتأثيرات</string>
     <string name="settings_recording_directory">دليل التسجيل</string>
     <string name="settings_recording_directory_default">افتراضي (Music/deutsia_radio)</string>
+    <string name="settings_recording_directory_choose">اختر مجلد مخصص...</string>
+    <string name="settings_recording_directory_clear">مسح المجلد المخصص</string>
     <string name="settings_record_across_stations">التسجيل عبر المحطات</string>
     <string name="settings_record_across_stations_description">الاستمرار في التسجيل عند تبديل المحطات</string>
     <string name="settings_record_all_stations">تسجيل جميع المحطات</string>
@@ -247,6 +261,35 @@
     <string name="tor_orbot_description">Orbot هو عميل Tor الرسمي لنظام Android. يوفر وصولاً آمناً ومشفراً إلى شبكة Tor.</string>
     <string name="tor_connect">الاتصال بـ Tor</string>
     <string name="tor_open_orbot">فتح Orbot</string>
+
+    <!-- Tor Status Messages -->
+    <string name="tor_status_connecting">جارٍ الاتصال...</string>
+    <string name="tor_status_connected">متصل بـ Tor</string>
+    <string name="tor_status_disconnected">تم قطع اتصال Tor</string>
+    <string name="tor_status_off">Tor متوقف</string>
+    <string name="tor_status_error">خطأ في Tor</string>
+    <string name="tor_status_leak_warning">تحذير من التسرب</string>
+    <string name="tor_status_install_orbot">تثبيت Orbot</string>
+    <string name="tor_status_connecting_message">جارٍ الاتصال بـ Tor...</string>
+    <string name="tor_status_connected_message">متصل عبر Tor</string>
+    <string name="tor_control_title_stopped">تم قطع اتصال Tor</string>
+    <string name="tor_control_subtitle_stopped">انقر على الاتصال للتصفح بشكل مجهول عبر Tor</string>
+    <string name="tor_control_subtitle_connecting">إنشاء اتصال آمن عبر Orbot</string>
+    <string name="tor_control_title_connecting">جارٍ الاتصال بـ Tor...</string>
+    <string name="tor_control_title_connected">متصل بـ Tor</string>
+    <string name="tor_control_title_connected_force">متصل بـ Tor (وضع الإجبار)</string>
+    <string name="tor_control_subtitle_connected">اتصالك خاص ومجهول</string>
+    <string name="tor_control_subtitle_connected_force">قطع الاتصال عبر Orbot أو تعطيل فرض Tor في الإعدادات</string>
+    <string name="tor_control_title_error">فشل الاتصال</string>
+    <string name="tor_control_subtitle_error">تعذر الاتصال بشبكة Tor</string>
+    <string name="tor_control_title_orbot_required">Orbot مطلوب</string>
+    <string name="tor_control_subtitle_orbot_required">قم بتثبيت Orbot للاتصال بشبكة Tor</string>
+    <string name="tor_control_button_connecting">جارٍ الاتصال...</string>
+    <string name="tor_control_button_disconnect">قطع الاتصال</string>
+    <string name="tor_control_button_cancel">إلغاء</string>
+    <string name="tor_control_button_retry">إعادة المحاولة</string>
+    <string name="tor_control_button_install">تثبيت Orbot</string>
+    <string name="tor_control_button_open_orbot">فتح Orbot</string>
 
     <!-- Add/Edit Radio Dialog -->
     <string name="add_edit_tor_info">استخدام Tor المضمن - لا حاجة لتكوين الوكيل</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -147,11 +147,18 @@
     <string name="settings_theme">Design</string>
     <string name="settings_theme_description">Wählen Sie hell, dunkel oder System</string>
     <string name="settings_theme_system_default">Systemstandard</string>
+    <string name="settings_theme_light">Light</string>
+    <string name="settings_theme_dark">Dark</string>
     <string name="settings_material_you">Material You</string>
     <string name="settings_material_you_description">Dynamische Farben basierend auf Hintergrundbild verwenden</string>
     <string name="settings_color_scheme">Farbschema</string>
     <string name="settings_color_scheme_description">Wählen Sie Ihre bevorzugte Farbe</string>
     <string name="settings_color_blue">Blau</string>
+    <string name="settings_color_blue_default">Blue (Default)</string>
+    <string name="settings_color_peach">Peach</string>
+    <string name="settings_color_green">Green</string>
+    <string name="settings_color_purple">Purple</string>
+    <string name="settings_color_orange">Orange</string>
     <string name="settings_language">Language</string>
     <string name="settings_language_description">Choose your preferred language</string>
 
@@ -210,9 +217,16 @@
     <string name="settings_sleep_timer">Sleep-Timer</string>
     <string name="settings_sleep_timer_description">Wiedergabe nach eingestellter Zeit automatisch stoppen</string>
     <string name="settings_sleep_timer_off">Aus</string>
+    <string name="settings_sleep_timer_15min">15 minutes</string>
+    <string name="settings_sleep_timer_30min">30 minutes</string>
+    <string name="settings_sleep_timer_45min">45 minutes</string>
+    <string name="settings_sleep_timer_60min">60 minutes</string>
+    <string name="settings_sleep_timer_90min">90 minutes</string>
     <string name="settings_equalizer_description">Audiofrequenzbänder und Effekte anpassen</string>
     <string name="settings_recording_directory">Aufnahmeverzeichnis</string>
     <string name="settings_recording_directory_default">Standard (Music/deutsia_radio)</string>
+    <string name="settings_recording_directory_choose">Choose custom folder...</string>
+    <string name="settings_recording_directory_clear">Clear custom folder</string>
     <string name="settings_record_across_stations">Über Sender hinweg aufnehmen</string>
     <string name="settings_record_across_stations_description">Aufnahme beim Senderwechsel fortsetzen</string>
     <string name="settings_record_all_stations">Alle Sender aufnehmen</string>
@@ -248,7 +262,36 @@
     <string name="tor_connect">Mit Tor verbinden</string>
     <string name="tor_open_orbot">Orbot öffnen</string>
 
-    <!-- Add/Edit Radio Dialog -->
+    <!-- Tor Status Messages -->
+    <string name="tor_status_connecting">Connecting...</string>
+    <string name="tor_status_connected">Tor Connected</string>
+    <string name="tor_status_disconnected">Tor Disconnected</string>
+    <string name="tor_status_off">Tor Off</string>
+    <string name="tor_status_error">Tor Error</string>
+    <string name="tor_status_leak_warning">Leak Warning</string>
+    <string name="tor_status_install_orbot">Install Orbot</string>
+    <string name="tor_status_connecting_message">Connecting to Tor...</string>
+    <string name="tor_status_connected_message">Connected via Tor</string>
+    <string name="tor_control_title_stopped">Tor Disconnected</string>
+    <string name="tor_control_subtitle_stopped">Tap Connect to browse anonymously via Tor</string>
+    <string name="tor_control_subtitle_connecting">Establishing secure connection via Orbot</string>
+    <string name="tor_control_title_connecting">Connecting to Tor...</string>
+    <string name="tor_control_title_connected">Connected to Tor</string>
+    <string name="tor_control_title_connected_force">Connected to Tor (Force Mode)</string>
+    <string name="tor_control_subtitle_connected">Your connection is private and anonymous</string>
+    <string name="tor_control_subtitle_connected_force">Disconnect via Orbot or disable Force Tor in settings</string>
+    <string name="tor_control_title_error">Connection Failed</string>
+    <string name="tor_control_subtitle_error">Could not connect to Tor network</string>
+    <string name="tor_control_title_orbot_required">Orbot Required</string>
+    <string name="tor_control_subtitle_orbot_required">Install Orbot to connect to the Tor network</string>
+    <string name="tor_control_button_connecting">Connecting...</string>
+    <string name="tor_control_button_disconnect">Disconnect</string>
+    <string name="tor_control_button_cancel">Cancel</string>
+    <string name="tor_control_button_retry">Retry Connection</string>
+    <string name="tor_control_button_install">Install Orbot</string>
+    <string name="tor_control_button_open_orbot">Open Orbot</string>
+
+    
     <string name="add_edit_tor_info">Integriertes Tor wird verwendet - keine Proxy-Konfiguration erforderlich</string>
     <string name="add_edit_authentication_optional">Authentifizierung (optional)</string>
     <string name="add_edit_advanced_options">Erweiterte Optionen</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -147,11 +147,18 @@
     <string name="settings_theme">Tema</string>
     <string name="settings_theme_description">Elige claro, oscuro o sistema</string>
     <string name="settings_theme_system_default">Predeterminado del sistema</string>
+    <string name="settings_theme_light">Light</string>
+    <string name="settings_theme_dark">Dark</string>
     <string name="settings_material_you">Material You</string>
     <string name="settings_material_you_description">Usar colores dinámicos basados en el fondo de pantalla</string>
     <string name="settings_color_scheme">Esquema de color</string>
     <string name="settings_color_scheme_description">Elige tu color preferido</string>
     <string name="settings_color_blue">Azul</string>
+    <string name="settings_color_blue_default">Blue (Default)</string>
+    <string name="settings_color_peach">Peach</string>
+    <string name="settings_color_green">Green</string>
+    <string name="settings_color_purple">Purple</string>
+    <string name="settings_color_orange">Orange</string>
     <string name="settings_language">Idioma</string>
     <string name="settings_language_description">Elige tu idioma preferido</string>
 
@@ -210,9 +217,16 @@
     <string name="settings_sleep_timer">Temporizador de suspensión</string>
     <string name="settings_sleep_timer_description">Detener reproducción automáticamente después del tiempo establecido</string>
     <string name="settings_sleep_timer_off">Apagado</string>
+    <string name="settings_sleep_timer_15min">15 minutes</string>
+    <string name="settings_sleep_timer_30min">30 minutes</string>
+    <string name="settings_sleep_timer_45min">45 minutes</string>
+    <string name="settings_sleep_timer_60min">60 minutes</string>
+    <string name="settings_sleep_timer_90min">90 minutes</string>
     <string name="settings_equalizer_description">Ajustar bandas de frecuencia de audio y efectos</string>
     <string name="settings_recording_directory">Directorio de grabación</string>
     <string name="settings_recording_directory_default">Predeterminado (Music/deutsia_radio)</string>
+    <string name="settings_recording_directory_choose">Choose custom folder...</string>
+    <string name="settings_recording_directory_clear">Clear custom folder</string>
     <string name="settings_record_across_stations">Grabar entre estaciones</string>
     <string name="settings_record_across_stations_description">Continuar grabación al cambiar de estación</string>
     <string name="settings_record_all_stations">Grabar todas las estaciones</string>
@@ -248,7 +262,36 @@
     <string name="tor_connect">Conectar a Tor</string>
     <string name="tor_open_orbot">Abrir Orbot</string>
 
-    <!-- Add/Edit Radio Dialog -->
+    <!-- Tor Status Messages -->
+    <string name="tor_status_connecting">Connecting...</string>
+    <string name="tor_status_connected">Tor Connected</string>
+    <string name="tor_status_disconnected">Tor Disconnected</string>
+    <string name="tor_status_off">Tor Off</string>
+    <string name="tor_status_error">Tor Error</string>
+    <string name="tor_status_leak_warning">Leak Warning</string>
+    <string name="tor_status_install_orbot">Install Orbot</string>
+    <string name="tor_status_connecting_message">Connecting to Tor...</string>
+    <string name="tor_status_connected_message">Connected via Tor</string>
+    <string name="tor_control_title_stopped">Tor Disconnected</string>
+    <string name="tor_control_subtitle_stopped">Tap Connect to browse anonymously via Tor</string>
+    <string name="tor_control_subtitle_connecting">Establishing secure connection via Orbot</string>
+    <string name="tor_control_title_connecting">Connecting to Tor...</string>
+    <string name="tor_control_title_connected">Connected to Tor</string>
+    <string name="tor_control_title_connected_force">Connected to Tor (Force Mode)</string>
+    <string name="tor_control_subtitle_connected">Your connection is private and anonymous</string>
+    <string name="tor_control_subtitle_connected_force">Disconnect via Orbot or disable Force Tor in settings</string>
+    <string name="tor_control_title_error">Connection Failed</string>
+    <string name="tor_control_subtitle_error">Could not connect to Tor network</string>
+    <string name="tor_control_title_orbot_required">Orbot Required</string>
+    <string name="tor_control_subtitle_orbot_required">Install Orbot to connect to the Tor network</string>
+    <string name="tor_control_button_connecting">Connecting...</string>
+    <string name="tor_control_button_disconnect">Disconnect</string>
+    <string name="tor_control_button_cancel">Cancel</string>
+    <string name="tor_control_button_retry">Retry Connection</string>
+    <string name="tor_control_button_install">Install Orbot</string>
+    <string name="tor_control_button_open_orbot">Open Orbot</string>
+
+    
     <string name="add_edit_tor_info">Usando Tor integrado - no se requiere configuración de proxy</string>
     <string name="add_edit_authentication_optional">Autenticación (opcional)</string>
     <string name="add_edit_advanced_options">Opciones avanzadas</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -147,11 +147,18 @@
     <string name="settings_theme">پوسته</string>
     <string name="settings_theme_description">روشن، تیره یا سیستم را انتخاب کنید</string>
     <string name="settings_theme_system_default">پیش‌فرض سیستم</string>
+    <string name="settings_theme_light">Light</string>
+    <string name="settings_theme_dark">Dark</string>
     <string name="settings_material_you">Material You</string>
     <string name="settings_material_you_description">استفاده از رنگ‌های پویا مبتنی بر تصویر زمینه</string>
     <string name="settings_color_scheme">طرح رنگی</string>
     <string name="settings_color_scheme_description">رنگ مورد نظر خود را انتخاب کنید</string>
     <string name="settings_color_blue">آبی</string>
+    <string name="settings_color_blue_default">Blue (Default)</string>
+    <string name="settings_color_peach">Peach</string>
+    <string name="settings_color_green">Green</string>
+    <string name="settings_color_purple">Purple</string>
+    <string name="settings_color_orange">Orange</string>
     <string name="settings_language">Language</string>
     <string name="settings_language_description">Choose your preferred language</string>
 
@@ -210,9 +217,16 @@
     <string name="settings_sleep_timer">تایمر خواب</string>
     <string name="settings_sleep_timer_description">توقف خودکار پخش پس از زمان تنظیم شده</string>
     <string name="settings_sleep_timer_off">خاموش</string>
+    <string name="settings_sleep_timer_15min">15 minutes</string>
+    <string name="settings_sleep_timer_30min">30 minutes</string>
+    <string name="settings_sleep_timer_45min">45 minutes</string>
+    <string name="settings_sleep_timer_60min">60 minutes</string>
+    <string name="settings_sleep_timer_90min">90 minutes</string>
     <string name="settings_equalizer_description">تنظیم باندهای فرکانس صدا و جلوه‌ها</string>
     <string name="settings_recording_directory">پوشه ضبط</string>
     <string name="settings_recording_directory_default">پیش‌فرض (Music/deutsia_radio)</string>
+    <string name="settings_recording_directory_choose">Choose custom folder...</string>
+    <string name="settings_recording_directory_clear">Clear custom folder</string>
     <string name="settings_record_across_stations">ضبط در بین ایستگاه‌ها</string>
     <string name="settings_record_across_stations_description">ادامه ضبط هنگام تغییر ایستگاه</string>
     <string name="settings_record_all_stations">ضبط همه ایستگاه‌ها</string>
@@ -248,7 +262,36 @@
     <string name="tor_connect">اتصال به Tor</string>
     <string name="tor_open_orbot">باز کردن Orbot</string>
 
-    <!-- Add/Edit Radio Dialog -->
+    <!-- Tor Status Messages -->
+    <string name="tor_status_connecting">Connecting...</string>
+    <string name="tor_status_connected">Tor Connected</string>
+    <string name="tor_status_disconnected">Tor Disconnected</string>
+    <string name="tor_status_off">Tor Off</string>
+    <string name="tor_status_error">Tor Error</string>
+    <string name="tor_status_leak_warning">Leak Warning</string>
+    <string name="tor_status_install_orbot">Install Orbot</string>
+    <string name="tor_status_connecting_message">Connecting to Tor...</string>
+    <string name="tor_status_connected_message">Connected via Tor</string>
+    <string name="tor_control_title_stopped">Tor Disconnected</string>
+    <string name="tor_control_subtitle_stopped">Tap Connect to browse anonymously via Tor</string>
+    <string name="tor_control_subtitle_connecting">Establishing secure connection via Orbot</string>
+    <string name="tor_control_title_connecting">Connecting to Tor...</string>
+    <string name="tor_control_title_connected">Connected to Tor</string>
+    <string name="tor_control_title_connected_force">Connected to Tor (Force Mode)</string>
+    <string name="tor_control_subtitle_connected">Your connection is private and anonymous</string>
+    <string name="tor_control_subtitle_connected_force">Disconnect via Orbot or disable Force Tor in settings</string>
+    <string name="tor_control_title_error">Connection Failed</string>
+    <string name="tor_control_subtitle_error">Could not connect to Tor network</string>
+    <string name="tor_control_title_orbot_required">Orbot Required</string>
+    <string name="tor_control_subtitle_orbot_required">Install Orbot to connect to the Tor network</string>
+    <string name="tor_control_button_connecting">Connecting...</string>
+    <string name="tor_control_button_disconnect">Disconnect</string>
+    <string name="tor_control_button_cancel">Cancel</string>
+    <string name="tor_control_button_retry">Retry Connection</string>
+    <string name="tor_control_button_install">Install Orbot</string>
+    <string name="tor_control_button_open_orbot">Open Orbot</string>
+
+    
     <string name="add_edit_tor_info">استفاده از Tor تعبیه شده - نیازی به پیکربندی پروکسی نیست</string>
     <string name="add_edit_authentication_optional">احراز هویت (اختیاری)</string>
     <string name="add_edit_advanced_options">گزینه‌های پیشرفته</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -154,11 +154,18 @@
     <string name="settings_theme">Theme</string>
     <string name="settings_theme_description">Choose light, dark, or system</string>
     <string name="settings_theme_system_default">System Default</string>
+    <string name="settings_theme_light">Light</string>
+    <string name="settings_theme_dark">Dark</string>
     <string name="settings_material_you">Material You</string>
     <string name="settings_material_you_description">Use wallpaper-based dynamic colors</string>
     <string name="settings_color_scheme">Color Scheme</string>
     <string name="settings_color_scheme_description">Choose your preferred color</string>
     <string name="settings_color_blue">Blue</string>
+    <string name="settings_color_blue_default">Blue (Default)</string>
+    <string name="settings_color_peach">Peach</string>
+    <string name="settings_color_green">Green</string>
+    <string name="settings_color_purple">Purple</string>
+    <string name="settings_color_orange">Orange</string>
     <string name="settings_language">Language</string>
     <string name="settings_language_description">Choose your preferred language</string>
 
@@ -217,9 +224,16 @@
     <string name="settings_sleep_timer">Sleep Timer</string>
     <string name="settings_sleep_timer_description">Auto-stop playback after set time</string>
     <string name="settings_sleep_timer_off">Off</string>
+    <string name="settings_sleep_timer_15min">15 minutes</string>
+    <string name="settings_sleep_timer_30min">30 minutes</string>
+    <string name="settings_sleep_timer_45min">45 minutes</string>
+    <string name="settings_sleep_timer_60min">60 minutes</string>
+    <string name="settings_sleep_timer_90min">90 minutes</string>
     <string name="settings_equalizer_description">Adjust audio frequency bands and effects</string>
     <string name="settings_recording_directory">Recording Directory</string>
     <string name="settings_recording_directory_default">Default (Music/deutsia_radio)</string>
+    <string name="settings_recording_directory_choose">Choose custom folder...</string>
+    <string name="settings_recording_directory_clear">Clear custom folder</string>
     <string name="settings_record_across_stations">Record Across Stations</string>
     <string name="settings_record_across_stations_description">Keep recording when switching stations</string>
     <string name="settings_record_all_stations">Record All Stations</string>
@@ -254,6 +268,35 @@
     <string name="tor_orbot_description">Orbot is the official Tor client for Android. It provides secure, encrypted access to the Tor network.</string>
     <string name="tor_connect">Connect to Tor</string>
     <string name="tor_open_orbot">Open Orbot</string>
+
+    <!-- Tor Status Messages -->
+    <string name="tor_status_connecting">Connecting...</string>
+    <string name="tor_status_connected">Tor Connected</string>
+    <string name="tor_status_disconnected">Tor Disconnected</string>
+    <string name="tor_status_off">Tor Off</string>
+    <string name="tor_status_error">Tor Error</string>
+    <string name="tor_status_leak_warning">Leak Warning</string>
+    <string name="tor_status_install_orbot">Install Orbot</string>
+    <string name="tor_status_connecting_message">Connecting to Tor...</string>
+    <string name="tor_status_connected_message">Connected via Tor</string>
+    <string name="tor_control_title_stopped">Tor Disconnected</string>
+    <string name="tor_control_subtitle_stopped">Tap Connect to browse anonymously via Tor</string>
+    <string name="tor_control_subtitle_connecting">Establishing secure connection via Orbot</string>
+    <string name="tor_control_title_connecting">Connecting to Tor...</string>
+    <string name="tor_control_title_connected">Connected to Tor</string>
+    <string name="tor_control_title_connected_force">Connected to Tor (Force Mode)</string>
+    <string name="tor_control_subtitle_connected">Your connection is private and anonymous</string>
+    <string name="tor_control_subtitle_connected_force">Disconnect via Orbot or disable Force Tor in settings</string>
+    <string name="tor_control_title_error">Connection Failed</string>
+    <string name="tor_control_subtitle_error">Could not connect to Tor network</string>
+    <string name="tor_control_title_orbot_required">Orbot Required</string>
+    <string name="tor_control_subtitle_orbot_required">Install Orbot to connect to the Tor network</string>
+    <string name="tor_control_button_connecting">Connecting...</string>
+    <string name="tor_control_button_disconnect">Disconnect</string>
+    <string name="tor_control_button_cancel">Cancel</string>
+    <string name="tor_control_button_retry">Retry Connection</string>
+    <string name="tor_control_button_install">Install Orbot</string>
+    <string name="tor_control_button_open_orbot">Open Orbot</string>
 
     <!-- Add/Edit Radio Dialog -->
     <string name="add_edit_tor_info">Using embedded Tor - no proxy config needed</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -144,11 +144,18 @@
     <string name="settings_theme">Theme</string>
     <string name="settings_theme_description">Choose light, dark, or system</string>
     <string name="settings_theme_system_default">System Default</string>
+    <string name="settings_theme_light">Light</string>
+    <string name="settings_theme_dark">Dark</string>
     <string name="settings_material_you">Material You</string>
     <string name="settings_material_you_description">Use wallpaper-based dynamic colors</string>
     <string name="settings_color_scheme">Color Scheme</string>
     <string name="settings_color_scheme_description">Choose your preferred color</string>
     <string name="settings_color_blue">Blue</string>
+    <string name="settings_color_blue_default">Blue (Default)</string>
+    <string name="settings_color_peach">Peach</string>
+    <string name="settings_color_green">Green</string>
+    <string name="settings_color_purple">Purple</string>
+    <string name="settings_color_orange">Orange</string>
     <string name="settings_language">Language</string>
     <string name="settings_language_description">Choose your preferred language</string>
 
@@ -207,9 +214,16 @@
     <string name="settings_sleep_timer">Sleep Timer</string>
     <string name="settings_sleep_timer_description">Auto-stop playback after set time</string>
     <string name="settings_sleep_timer_off">Off</string>
+    <string name="settings_sleep_timer_15min">15 minutes</string>
+    <string name="settings_sleep_timer_30min">30 minutes</string>
+    <string name="settings_sleep_timer_45min">45 minutes</string>
+    <string name="settings_sleep_timer_60min">60 minutes</string>
+    <string name="settings_sleep_timer_90min">90 minutes</string>
     <string name="settings_equalizer_description">Adjust audio frequency bands and effects</string>
     <string name="settings_recording_directory">Recording Directory</string>
     <string name="settings_recording_directory_default">Default (Music/deutsia_radio)</string>
+    <string name="settings_recording_directory_choose">Choose custom folder...</string>
+    <string name="settings_recording_directory_clear">Clear custom folder</string>
     <string name="settings_record_across_stations">Record Across Stations</string>
     <string name="settings_record_across_stations_description">Keep recording when switching stations</string>
     <string name="settings_record_all_stations">Record All Stations</string>
@@ -245,7 +259,36 @@
     <string name="tor_connect">Connect to Tor</string>
     <string name="tor_open_orbot">Open Orbot</string>
 
-    <!-- Add/Edit Radio Dialog -->
+    <!-- Tor Status Messages -->
+    <string name="tor_status_connecting">Connecting...</string>
+    <string name="tor_status_connected">Tor Connected</string>
+    <string name="tor_status_disconnected">Tor Disconnected</string>
+    <string name="tor_status_off">Tor Off</string>
+    <string name="tor_status_error">Tor Error</string>
+    <string name="tor_status_leak_warning">Leak Warning</string>
+    <string name="tor_status_install_orbot">Install Orbot</string>
+    <string name="tor_status_connecting_message">Connecting to Tor...</string>
+    <string name="tor_status_connected_message">Connected via Tor</string>
+    <string name="tor_control_title_stopped">Tor Disconnected</string>
+    <string name="tor_control_subtitle_stopped">Tap Connect to browse anonymously via Tor</string>
+    <string name="tor_control_subtitle_connecting">Establishing secure connection via Orbot</string>
+    <string name="tor_control_title_connecting">Connecting to Tor...</string>
+    <string name="tor_control_title_connected">Connected to Tor</string>
+    <string name="tor_control_title_connected_force">Connected to Tor (Force Mode)</string>
+    <string name="tor_control_subtitle_connected">Your connection is private and anonymous</string>
+    <string name="tor_control_subtitle_connected_force">Disconnect via Orbot or disable Force Tor in settings</string>
+    <string name="tor_control_title_error">Connection Failed</string>
+    <string name="tor_control_subtitle_error">Could not connect to Tor network</string>
+    <string name="tor_control_title_orbot_required">Orbot Required</string>
+    <string name="tor_control_subtitle_orbot_required">Install Orbot to connect to the Tor network</string>
+    <string name="tor_control_button_connecting">Connecting...</string>
+    <string name="tor_control_button_disconnect">Disconnect</string>
+    <string name="tor_control_button_cancel">Cancel</string>
+    <string name="tor_control_button_retry">Retry Connection</string>
+    <string name="tor_control_button_install">Install Orbot</string>
+    <string name="tor_control_button_open_orbot">Open Orbot</string>
+
+    
     <string name="add_edit_tor_info">Using embedded Tor - no proxy config needed</string>
     <string name="add_edit_authentication_optional">Authentication (Optional)</string>
     <string name="add_edit_advanced_options">Advanced Options</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -154,11 +154,18 @@
     <string name="settings_theme">Theme</string>
     <string name="settings_theme_description">Choose light, dark, or system</string>
     <string name="settings_theme_system_default">System Default</string>
+    <string name="settings_theme_light">Light</string>
+    <string name="settings_theme_dark">Dark</string>
     <string name="settings_material_you">Material You</string>
     <string name="settings_material_you_description">Use wallpaper-based dynamic colors</string>
     <string name="settings_color_scheme">Color Scheme</string>
     <string name="settings_color_scheme_description">Choose your preferred color</string>
     <string name="settings_color_blue">Blue</string>
+    <string name="settings_color_blue_default">Blue (Default)</string>
+    <string name="settings_color_peach">Peach</string>
+    <string name="settings_color_green">Green</string>
+    <string name="settings_color_purple">Purple</string>
+    <string name="settings_color_orange">Orange</string>
     <string name="settings_language">Language</string>
     <string name="settings_language_description">Choose your preferred language</string>
 
@@ -217,9 +224,16 @@
     <string name="settings_sleep_timer">Sleep Timer</string>
     <string name="settings_sleep_timer_description">Auto-stop playback after set time</string>
     <string name="settings_sleep_timer_off">Off</string>
+    <string name="settings_sleep_timer_15min">15 minutes</string>
+    <string name="settings_sleep_timer_30min">30 minutes</string>
+    <string name="settings_sleep_timer_45min">45 minutes</string>
+    <string name="settings_sleep_timer_60min">60 minutes</string>
+    <string name="settings_sleep_timer_90min">90 minutes</string>
     <string name="settings_equalizer_description">Adjust audio frequency bands and effects</string>
     <string name="settings_recording_directory">Recording Directory</string>
     <string name="settings_recording_directory_default">Default (Music/deutsia_radio)</string>
+    <string name="settings_recording_directory_choose">Choose custom folder...</string>
+    <string name="settings_recording_directory_clear">Clear custom folder</string>
     <string name="settings_record_across_stations">Record Across Stations</string>
     <string name="settings_record_across_stations_description">Keep recording when switching stations</string>
     <string name="settings_record_all_stations">Record All Stations</string>
@@ -254,6 +268,35 @@
     <string name="tor_orbot_description">Orbot is the official Tor client for Android. It provides secure, encrypted access to the Tor network.</string>
     <string name="tor_connect">Connect to Tor</string>
     <string name="tor_open_orbot">Open Orbot</string>
+
+    <!-- Tor Status Messages -->
+    <string name="tor_status_connecting">Connecting...</string>
+    <string name="tor_status_connected">Tor Connected</string>
+    <string name="tor_status_disconnected">Tor Disconnected</string>
+    <string name="tor_status_off">Tor Off</string>
+    <string name="tor_status_error">Tor Error</string>
+    <string name="tor_status_leak_warning">Leak Warning</string>
+    <string name="tor_status_install_orbot">Install Orbot</string>
+    <string name="tor_status_connecting_message">Connecting to Tor...</string>
+    <string name="tor_status_connected_message">Connected via Tor</string>
+    <string name="tor_control_title_stopped">Tor Disconnected</string>
+    <string name="tor_control_subtitle_stopped">Tap Connect to browse anonymously via Tor</string>
+    <string name="tor_control_subtitle_connecting">Establishing secure connection via Orbot</string>
+    <string name="tor_control_title_connecting">Connecting to Tor...</string>
+    <string name="tor_control_title_connected">Connected to Tor</string>
+    <string name="tor_control_title_connected_force">Connected to Tor (Force Mode)</string>
+    <string name="tor_control_subtitle_connected">Your connection is private and anonymous</string>
+    <string name="tor_control_subtitle_connected_force">Disconnect via Orbot or disable Force Tor in settings</string>
+    <string name="tor_control_title_error">Connection Failed</string>
+    <string name="tor_control_subtitle_error">Could not connect to Tor network</string>
+    <string name="tor_control_title_orbot_required">Orbot Required</string>
+    <string name="tor_control_subtitle_orbot_required">Install Orbot to connect to the Tor network</string>
+    <string name="tor_control_button_connecting">Connecting...</string>
+    <string name="tor_control_button_disconnect">Disconnect</string>
+    <string name="tor_control_button_cancel">Cancel</string>
+    <string name="tor_control_button_retry">Retry Connection</string>
+    <string name="tor_control_button_install">Install Orbot</string>
+    <string name="tor_control_button_open_orbot">Open Orbot</string>
 
     <!-- Add/Edit Radio Dialog -->
     <string name="add_edit_tor_info">Using embedded Tor - no proxy config needed</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -147,12 +147,19 @@
     <string name="settings_theme">テーマ</string>
     <string name="settings_theme_description">ライト、ダーク、またはシステムを選択</string>
     <string name="settings_theme_system_default">システムデフォルト</string>
+    <string name="settings_theme_light">ライト</string>
+    <string name="settings_theme_dark">ダーク</string>
     <string name="settings_material_you">Material You</string>
     <string name="settings_material_you_description">壁紙ベースの動的カラーを使用</string>
     <string name="settings_color_scheme">配色</string>
     <string name="settings_color_scheme_description">お好みの色を選択</string>
     <string name="settings_color_blue">青</string>
-    <string name="settings_language">Language</string>
+    <string name="settings_color_blue_default">青（デフォルト）</string>
+    <string name="settings_color_peach">ピーチ</string>
+    <string name="settings_color_green">緑</string>
+    <string name="settings_color_purple">紫</string>
+    <string name="settings_color_orange">オレンジ</string>
+    <string name="settings_language">言語</string>
     <string name="settings_language_description">Choose your preferred language</string>
 
     <!-- Language Names -->
@@ -210,9 +217,16 @@
     <string name="settings_sleep_timer">スリープタイマー</string>
     <string name="settings_sleep_timer_description">設定時間後に再生を自動停止</string>
     <string name="settings_sleep_timer_off">オフ</string>
+    <string name="settings_sleep_timer_15min">15分</string>
+    <string name="settings_sleep_timer_30min">30分</string>
+    <string name="settings_sleep_timer_45min">45分</string>
+    <string name="settings_sleep_timer_60min">60分</string>
+    <string name="settings_sleep_timer_90min">90分</string>
     <string name="settings_equalizer_description">オーディオ周波数帯とエフェクトを調整</string>
     <string name="settings_recording_directory">録音ディレクトリ</string>
     <string name="settings_recording_directory_default">デフォルト（Music/deutsia_radio）</string>
+    <string name="settings_recording_directory_choose">カスタムフォルダを選択...</string>
+    <string name="settings_recording_directory_clear">カスタムフォルダをクリア</string>
     <string name="settings_record_across_stations">ステーション間で録音</string>
     <string name="settings_record_across_stations_description">ステーション切り替え時に録音を継続</string>
     <string name="settings_record_all_stations">すべてのステーションを録音</string>
@@ -247,6 +261,35 @@
     <string name="tor_orbot_description">OrbotはAndroid用の公式Torクライアントです。Torネットワークへの安全で暗号化されたアクセスを提供します。</string>
     <string name="tor_connect">Torに接続</string>
     <string name="tor_open_orbot">Orbotを開く</string>
+
+    <!-- Tor Status Messages -->
+    <string name="tor_status_connecting">接続中...</string>
+    <string name="tor_status_connected">Tor接続済み</string>
+    <string name="tor_status_disconnected">Tor切断済み</string>
+    <string name="tor_status_off">Torオフ</string>
+    <string name="tor_status_error">Torエラー</string>
+    <string name="tor_status_leak_warning">リーク警告</string>
+    <string name="tor_status_install_orbot">Orbotをインストール</string>
+    <string name="tor_status_connecting_message">Torに接続中...</string>
+    <string name="tor_status_connected_message">Tor経由で接続済み</string>
+    <string name="tor_control_title_stopped">Tor切断済み</string>
+    <string name="tor_control_subtitle_stopped">接続をタップしてTor経由で匿名ブラウジング</string>
+    <string name="tor_control_subtitle_connecting">Orbot経由で安全な接続を確立中</string>
+    <string name="tor_control_title_connecting">Torに接続中...</string>
+    <string name="tor_control_title_connected">Torに接続済み</string>
+    <string name="tor_control_title_connected_force">Torに接続済み（強制モード）</string>
+    <string name="tor_control_subtitle_connected">接続はプライベートで匿名です</string>
+    <string name="tor_control_subtitle_connected_force">Orbot経由で切断するか、設定で強制Torを無効にしてください</string>
+    <string name="tor_control_title_error">接続失敗</string>
+    <string name="tor_control_subtitle_error">Torネットワークに接続できませんでした</string>
+    <string name="tor_control_title_orbot_required">Orbotが必要</string>
+    <string name="tor_control_subtitle_orbot_required">Torネットワークに接続するにはOrbotをインストールしてください</string>
+    <string name="tor_control_button_connecting">接続中...</string>
+    <string name="tor_control_button_disconnect">切断</string>
+    <string name="tor_control_button_cancel">キャンセル</string>
+    <string name="tor_control_button_retry">再接続</string>
+    <string name="tor_control_button_install">Orbotをインストール</string>
+    <string name="tor_control_button_open_orbot">Orbotを開く</string>
 
     <!-- Add/Edit Radio Dialog -->
     <string name="add_edit_tor_info">埋め込みTorを使用 - プロキシ設定は不要</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -147,12 +147,19 @@
     <string name="settings_theme">테마</string>
     <string name="settings_theme_description">밝게, 어둡게 또는 시스템 선택</string>
     <string name="settings_theme_system_default">시스템 기본값</string>
+    <string name="settings_theme_light">라이트</string>
+    <string name="settings_theme_dark">다크</string>
     <string name="settings_material_you">Material You</string>
     <string name="settings_material_you_description">배경화면 기반 동적 색상 사용</string>
     <string name="settings_color_scheme">색 구성표</string>
     <string name="settings_color_scheme_description">선호하는 색상 선택</string>
     <string name="settings_color_blue">파랑</string>
-    <string name="settings_language">Language</string>
+    <string name="settings_color_blue_default">파랑 (기본값)</string>
+    <string name="settings_color_peach">피치</string>
+    <string name="settings_color_green">초록</string>
+    <string name="settings_color_purple">보라</string>
+    <string name="settings_color_orange">주황</string>
+    <string name="settings_language">언어</string>
     <string name="settings_language_description">Choose your preferred language</string>
 
     <!-- Language Names -->
@@ -210,9 +217,16 @@
     <string name="settings_sleep_timer">수면 타이머</string>
     <string name="settings_sleep_timer_description">설정된 시간 후 재생 자동 중지</string>
     <string name="settings_sleep_timer_off">끄기</string>
+    <string name="settings_sleep_timer_15min">15분</string>
+    <string name="settings_sleep_timer_30min">30분</string>
+    <string name="settings_sleep_timer_45min">45분</string>
+    <string name="settings_sleep_timer_60min">60분</string>
+    <string name="settings_sleep_timer_90min">90분</string>
     <string name="settings_equalizer_description">오디오 주파수 대역 및 효과 조정</string>
     <string name="settings_recording_directory">녹음 디렉토리</string>
     <string name="settings_recording_directory_default">기본값 (Music/deutsia_radio)</string>
+    <string name="settings_recording_directory_choose">사용자 정의 폴더 선택...</string>
+    <string name="settings_recording_directory_clear">사용자 정의 폴더 지우기</string>
     <string name="settings_record_across_stations">방송국 간 녹음</string>
     <string name="settings_record_across_stations_description">방송국을 전환할 때 녹음 계속</string>
     <string name="settings_record_all_stations">모든 방송국 녹음</string>
@@ -247,6 +261,35 @@
     <string name="tor_orbot_description">Orbot은 Android용 공식 Tor 클라이언트입니다. Tor 네트워크에 대한 안전하고 암호화된 접근을 제공합니다.</string>
     <string name="tor_connect">Tor에 연결</string>
     <string name="tor_open_orbot">Orbot 열기</string>
+
+    <!-- Tor Status Messages -->
+    <string name="tor_status_connecting">연결 중...</string>
+    <string name="tor_status_connected">Tor 연결됨</string>
+    <string name="tor_status_disconnected">Tor 연결 끊김</string>
+    <string name="tor_status_off">Tor 꺼짐</string>
+    <string name="tor_status_error">Tor 오류</string>
+    <string name="tor_status_leak_warning">누출 경고</string>
+    <string name="tor_status_install_orbot">Orbot 설치</string>
+    <string name="tor_status_connecting_message">Tor에 연결 중...</string>
+    <string name="tor_status_connected_message">Tor를 통해 연결됨</string>
+    <string name="tor_control_title_stopped">Tor 연결 끊김</string>
+    <string name="tor_control_subtitle_stopped">연결을 탭하여 Tor를 통해 익명으로 탐색</string>
+    <string name="tor_control_subtitle_connecting">Orbot을 통해 안전한 연결 설정 중</string>
+    <string name="tor_control_title_connecting">Tor에 연결 중...</string>
+    <string name="tor_control_title_connected">Tor에 연결됨</string>
+    <string name="tor_control_title_connected_force">Tor에 연결됨 (강제 모드)</string>
+    <string name="tor_control_subtitle_connected">연결이 비공개이며 익명입니다</string>
+    <string name="tor_control_subtitle_connected_force">Orbot을 통해 연결을 끊거나 설정에서 강제 Tor를 비활성화하세요</string>
+    <string name="tor_control_title_error">연결 실패</string>
+    <string name="tor_control_subtitle_error">Tor 네트워크에 연결할 수 없습니다</string>
+    <string name="tor_control_title_orbot_required">Orbot 필요</string>
+    <string name="tor_control_subtitle_orbot_required">Tor 네트워크에 연결하려면 Orbot을 설치하세요</string>
+    <string name="tor_control_button_connecting">연결 중...</string>
+    <string name="tor_control_button_disconnect">연결 끊기</string>
+    <string name="tor_control_button_cancel">취소</string>
+    <string name="tor_control_button_retry">재연결</string>
+    <string name="tor_control_button_install">Orbot 설치</string>
+    <string name="tor_control_button_open_orbot">Orbot 열기</string>
 
     <!-- Add/Edit Radio Dialog -->
     <string name="add_edit_tor_info">내장 Tor 사용 - 프록시 구성 불필요</string>

--- a/app/src/main/res/values-my/strings.xml
+++ b/app/src/main/res/values-my/strings.xml
@@ -144,11 +144,18 @@
     <string name="settings_theme">အပြင်အဆင်</string>
     <string name="settings_theme_description">အလင်း၊ အမှောင် သို့မဟုတ် စနစ် ရွေးချယ်ပါ</string>
     <string name="settings_theme_system_default">စနစ် မူလအတိုင်း</string>
+    <string name="settings_theme_light">Light</string>
+    <string name="settings_theme_dark">Dark</string>
     <string name="settings_material_you">Material You</string>
     <string name="settings_material_you_description">နောက်ခံပုံအခြေခံ ဒိုင်းနမစ်အရောင်များကို သုံးပါ</string>
     <string name="settings_color_scheme">အရောင်အစီအစဉ်</string>
     <string name="settings_color_scheme_description">သင့်အကြိုက် အရောင်ကို ရွေးချယ်ပါ</string>
     <string name="settings_color_blue">အပြာ</string>
+    <string name="settings_color_blue_default">Blue (Default)</string>
+    <string name="settings_color_peach">Peach</string>
+    <string name="settings_color_green">Green</string>
+    <string name="settings_color_purple">Purple</string>
+    <string name="settings_color_orange">Orange</string>
     <string name="settings_language">Language</string>
     <string name="settings_language_description">Choose your preferred language</string>
 
@@ -207,9 +214,16 @@
     <string name="settings_sleep_timer">အိပ်စက် အချိန်တိုင်း</string>
     <string name="settings_sleep_timer_description">သတ်မှတ်ချိန်ကျပြီး နောက် အလိုအလျောက် ရပ်ရန်</string>
     <string name="settings_sleep_timer_off">ပိတ်ထားသည်</string>
+    <string name="settings_sleep_timer_15min">15 minutes</string>
+    <string name="settings_sleep_timer_30min">30 minutes</string>
+    <string name="settings_sleep_timer_45min">45 minutes</string>
+    <string name="settings_sleep_timer_60min">60 minutes</string>
+    <string name="settings_sleep_timer_90min">90 minutes</string>
     <string name="settings_equalizer_description">အသံ ကြိမ်နှုန်း ဘန်းများနှင့် အကျိုးသက်ရောက်မှုများကို ညှိပါ</string>
     <string name="settings_recording_directory">ရိုက်ကူးမှု ဖိုင်တွဲ</string>
     <string name="settings_recording_directory_default">မူလ (Music/deutsia_radio)</string>
+    <string name="settings_recording_directory_choose">Choose custom folder...</string>
+    <string name="settings_recording_directory_clear">Clear custom folder</string>
     <string name="settings_record_across_stations">စတေးရှင်းများကို ဖြတ်၍ ရိုက်ကူးရန်</string>
     <string name="settings_record_across_stations_description">စတေးရှင်းပြောင်းသောအခါ ရိုက်ကူးမှုကို ဆက်လုပ်ပါ</string>
     <string name="settings_record_all_stations">စတေးရှင်းအားလုံးကို ရိုက်ကူးရန်</string>
@@ -245,7 +259,36 @@
     <string name="tor_connect">Tor သို့ ချိတ်ဆက်ရန်</string>
     <string name="tor_open_orbot">Orbot ကို ဖွင့်ရန်</string>
 
-    <!-- Add/Edit Radio Dialog -->
+    <!-- Tor Status Messages -->
+    <string name="tor_status_connecting">Connecting...</string>
+    <string name="tor_status_connected">Tor Connected</string>
+    <string name="tor_status_disconnected">Tor Disconnected</string>
+    <string name="tor_status_off">Tor Off</string>
+    <string name="tor_status_error">Tor Error</string>
+    <string name="tor_status_leak_warning">Leak Warning</string>
+    <string name="tor_status_install_orbot">Install Orbot</string>
+    <string name="tor_status_connecting_message">Connecting to Tor...</string>
+    <string name="tor_status_connected_message">Connected via Tor</string>
+    <string name="tor_control_title_stopped">Tor Disconnected</string>
+    <string name="tor_control_subtitle_stopped">Tap Connect to browse anonymously via Tor</string>
+    <string name="tor_control_subtitle_connecting">Establishing secure connection via Orbot</string>
+    <string name="tor_control_title_connecting">Connecting to Tor...</string>
+    <string name="tor_control_title_connected">Connected to Tor</string>
+    <string name="tor_control_title_connected_force">Connected to Tor (Force Mode)</string>
+    <string name="tor_control_subtitle_connected">Your connection is private and anonymous</string>
+    <string name="tor_control_subtitle_connected_force">Disconnect via Orbot or disable Force Tor in settings</string>
+    <string name="tor_control_title_error">Connection Failed</string>
+    <string name="tor_control_subtitle_error">Could not connect to Tor network</string>
+    <string name="tor_control_title_orbot_required">Orbot Required</string>
+    <string name="tor_control_subtitle_orbot_required">Install Orbot to connect to the Tor network</string>
+    <string name="tor_control_button_connecting">Connecting...</string>
+    <string name="tor_control_button_disconnect">Disconnect</string>
+    <string name="tor_control_button_cancel">Cancel</string>
+    <string name="tor_control_button_retry">Retry Connection</string>
+    <string name="tor_control_button_install">Install Orbot</string>
+    <string name="tor_control_button_open_orbot">Open Orbot</string>
+
+    
     <string name="add_edit_tor_info">ထည့်သွင်းထားသော Tor ကို သုံးနေသည် - proxy config မလိုပါ</string>
     <string name="add_edit_authentication_optional">အထောက်အထား (ရွေးချယ်နိုင်သော)</string>
     <string name="add_edit_advanced_options">အဆင့်မြင့် ရွေးချယ်စရာများ</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -147,11 +147,18 @@
     <string name="settings_theme">Tema</string>
     <string name="settings_theme_description">Escolha claro, escuro ou sistema</string>
     <string name="settings_theme_system_default">Padrão do sistema</string>
+    <string name="settings_theme_light">Light</string>
+    <string name="settings_theme_dark">Dark</string>
     <string name="settings_material_you">Material You</string>
     <string name="settings_material_you_description">Usar cores dinâmicas baseadas no papel de parede</string>
     <string name="settings_color_scheme">Esquema de cores</string>
     <string name="settings_color_scheme_description">Escolha sua cor preferida</string>
     <string name="settings_color_blue">Azul</string>
+    <string name="settings_color_blue_default">Blue (Default)</string>
+    <string name="settings_color_peach">Peach</string>
+    <string name="settings_color_green">Green</string>
+    <string name="settings_color_purple">Purple</string>
+    <string name="settings_color_orange">Orange</string>
     <string name="settings_language">Language</string>
     <string name="settings_language_description">Choose your preferred language</string>
 
@@ -210,9 +217,16 @@
     <string name="settings_sleep_timer">Temporizador de suspensão</string>
     <string name="settings_sleep_timer_description">Parar reprodução automaticamente após o tempo definido</string>
     <string name="settings_sleep_timer_off">Desligado</string>
+    <string name="settings_sleep_timer_15min">15 minutes</string>
+    <string name="settings_sleep_timer_30min">30 minutes</string>
+    <string name="settings_sleep_timer_45min">45 minutes</string>
+    <string name="settings_sleep_timer_60min">60 minutes</string>
+    <string name="settings_sleep_timer_90min">90 minutes</string>
     <string name="settings_equalizer_description">Ajustar bandas de frequência de áudio e efeitos</string>
     <string name="settings_recording_directory">Diretório de gravação</string>
     <string name="settings_recording_directory_default">Padrão (Music/deutsia_radio)</string>
+    <string name="settings_recording_directory_choose">Choose custom folder...</string>
+    <string name="settings_recording_directory_clear">Clear custom folder</string>
     <string name="settings_record_across_stations">Gravar entre estações</string>
     <string name="settings_record_across_stations_description">Continuar gravação ao trocar de estação</string>
     <string name="settings_record_all_stations">Gravar todas as estações</string>
@@ -248,7 +262,36 @@
     <string name="tor_connect">Conectar ao Tor</string>
     <string name="tor_open_orbot">Abrir Orbot</string>
 
-    <!-- Add/Edit Radio Dialog -->
+    <!-- Tor Status Messages -->
+    <string name="tor_status_connecting">Connecting...</string>
+    <string name="tor_status_connected">Tor Connected</string>
+    <string name="tor_status_disconnected">Tor Disconnected</string>
+    <string name="tor_status_off">Tor Off</string>
+    <string name="tor_status_error">Tor Error</string>
+    <string name="tor_status_leak_warning">Leak Warning</string>
+    <string name="tor_status_install_orbot">Install Orbot</string>
+    <string name="tor_status_connecting_message">Connecting to Tor...</string>
+    <string name="tor_status_connected_message">Connected via Tor</string>
+    <string name="tor_control_title_stopped">Tor Disconnected</string>
+    <string name="tor_control_subtitle_stopped">Tap Connect to browse anonymously via Tor</string>
+    <string name="tor_control_subtitle_connecting">Establishing secure connection via Orbot</string>
+    <string name="tor_control_title_connecting">Connecting to Tor...</string>
+    <string name="tor_control_title_connected">Connected to Tor</string>
+    <string name="tor_control_title_connected_force">Connected to Tor (Force Mode)</string>
+    <string name="tor_control_subtitle_connected">Your connection is private and anonymous</string>
+    <string name="tor_control_subtitle_connected_force">Disconnect via Orbot or disable Force Tor in settings</string>
+    <string name="tor_control_title_error">Connection Failed</string>
+    <string name="tor_control_subtitle_error">Could not connect to Tor network</string>
+    <string name="tor_control_title_orbot_required">Orbot Required</string>
+    <string name="tor_control_subtitle_orbot_required">Install Orbot to connect to the Tor network</string>
+    <string name="tor_control_button_connecting">Connecting...</string>
+    <string name="tor_control_button_disconnect">Disconnect</string>
+    <string name="tor_control_button_cancel">Cancel</string>
+    <string name="tor_control_button_retry">Retry Connection</string>
+    <string name="tor_control_button_install">Install Orbot</string>
+    <string name="tor_control_button_open_orbot">Open Orbot</string>
+
+    
     <string name="add_edit_tor_info">Usando Tor integrado - nenhuma configuração de proxy necessária</string>
     <string name="add_edit_authentication_optional">Autenticação (opcional)</string>
     <string name="add_edit_advanced_options">Opções avançadas</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -147,11 +147,18 @@
     <string name="settings_theme">Тема</string>
     <string name="settings_theme_description">Выберите светлую, тёмную или системную</string>
     <string name="settings_theme_system_default">Системная</string>
+    <string name="settings_theme_light">Светлая</string>
+    <string name="settings_theme_dark">Тёмная</string>
     <string name="settings_material_you">Material You</string>
     <string name="settings_material_you_description">Использовать динамические цвета на основе обоев</string>
     <string name="settings_color_scheme">Цветовая схема</string>
     <string name="settings_color_scheme_description">Выберите предпочитаемый цвет</string>
     <string name="settings_color_blue">Синий</string>
+    <string name="settings_color_blue_default">Blue (Default)</string>
+    <string name="settings_color_peach">Peach</string>
+    <string name="settings_color_green">Green</string>
+    <string name="settings_color_purple">Purple</string>
+    <string name="settings_color_orange">Orange</string>
     <string name="settings_language">Language</string>
     <string name="settings_language_description">Choose your preferred language</string>
 
@@ -210,9 +217,16 @@
     <string name="settings_sleep_timer">Таймер сна</string>
     <string name="settings_sleep_timer_description">Автоостановка воспроизведения через заданное время</string>
     <string name="settings_sleep_timer_off">Выключено</string>
+    <string name="settings_sleep_timer_15min">15 minutes</string>
+    <string name="settings_sleep_timer_30min">30 minutes</string>
+    <string name="settings_sleep_timer_45min">45 minutes</string>
+    <string name="settings_sleep_timer_60min">60 minutes</string>
+    <string name="settings_sleep_timer_90min">90 minutes</string>
     <string name="settings_equalizer_description">Настройка частотных полос и эффектов</string>
     <string name="settings_recording_directory">Каталог записей</string>
     <string name="settings_recording_directory_default">По умолчанию (Music/deutsia_radio)</string>
+    <string name="settings_recording_directory_choose">Choose custom folder...</string>
+    <string name="settings_recording_directory_clear">Clear custom folder</string>
     <string name="settings_record_across_stations">Записывать при переключении станций</string>
     <string name="settings_record_across_stations_description">Продолжать запись при переключении станций</string>
     <string name="settings_record_all_stations">Записывать все станции</string>
@@ -247,6 +261,35 @@
     <string name="tor_orbot_description">Orbot — это официальный Tor клиент для Android. Он обеспечивает безопасный, зашифрованный доступ к сети Tor.</string>
     <string name="tor_connect">Подключиться к Tor</string>
     <string name="tor_open_orbot">Открыть Orbot</string>
+
+    <!-- Tor Status Messages -->
+    <string name="tor_status_connecting">Подключение...</string>
+    <string name="tor_status_connected">Tor подключён</string>
+    <string name="tor_status_disconnected">Tor отключён</string>
+    <string name="tor_status_off">Tor выключен</string>
+    <string name="tor_status_error">Ошибка Tor</string>
+    <string name="tor_status_leak_warning">Предупреждение об утечке</string>
+    <string name="tor_status_install_orbot">Установить Orbot</string>
+    <string name="tor_status_connecting_message">Подключение к Tor...</string>
+    <string name="tor_status_connected_message">Подключено через Tor</string>
+    <string name="tor_control_title_stopped">Tor отключён</string>
+    <string name="tor_control_subtitle_stopped">Нажмите Подключиться для анонимного просмотра через Tor</string>
+    <string name="tor_control_subtitle_connecting">Установка безопасного соединения через Orbot</string>
+    <string name="tor_control_title_connecting">Подключение к Tor...</string>
+    <string name="tor_control_title_connected">Подключено к Tor</string>
+    <string name="tor_control_title_connected_force">Подключено к Tor (принудительный режим)</string>
+    <string name="tor_control_subtitle_connected">Ваше соединение приватное и анонимное</string>
+    <string name="tor_control_subtitle_connected_force">Отключитесь через Orbot или отключите принудительный Tor в настройках</string>
+    <string name="tor_control_title_error">Ошибка подключения</string>
+    <string name="tor_control_subtitle_error">Не удалось подключиться к сети Tor</string>
+    <string name="tor_control_title_orbot_required">Требуется Orbot</string>
+    <string name="tor_control_subtitle_orbot_required">Установите Orbot для подключения к сети Tor</string>
+    <string name="tor_control_button_connecting">Подключение...</string>
+    <string name="tor_control_button_disconnect">Отключиться</string>
+    <string name="tor_control_button_cancel">Отмена</string>
+    <string name="tor_control_button_retry">Повторить подключение</string>
+    <string name="tor_control_button_install">Установить Orbot</string>
+    <string name="tor_control_button_open_orbot">Открыть Orbot</string>
 
     <!-- Add/Edit Radio Dialog -->
     <string name="add_edit_tor_info">Используется встроенный Tor - настройка прокси не требуется</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -147,11 +147,18 @@
     <string name="settings_theme">Tema</string>
     <string name="settings_theme_description">Açık, koyu veya sistem seçin</string>
     <string name="settings_theme_system_default">Sistem Varsayılanı</string>
+    <string name="settings_theme_light">Light</string>
+    <string name="settings_theme_dark">Dark</string>
     <string name="settings_material_you">Material You</string>
     <string name="settings_material_you_description">Duvar kağıdı tabanlı dinamik renkler kullan</string>
     <string name="settings_color_scheme">Renk Şeması</string>
     <string name="settings_color_scheme_description">Tercih ettiğiniz rengi seçin</string>
     <string name="settings_color_blue">Mavi</string>
+    <string name="settings_color_blue_default">Blue (Default)</string>
+    <string name="settings_color_peach">Peach</string>
+    <string name="settings_color_green">Green</string>
+    <string name="settings_color_purple">Purple</string>
+    <string name="settings_color_orange">Orange</string>
     <string name="settings_language">Language</string>
     <string name="settings_language_description">Choose your preferred language</string>
 
@@ -210,9 +217,16 @@
     <string name="settings_sleep_timer">Uyku Zamanlayıcısı</string>
     <string name="settings_sleep_timer_description">Belirlenen süreden sonra oynatmayı otomatik durdur</string>
     <string name="settings_sleep_timer_off">Kapalı</string>
+    <string name="settings_sleep_timer_15min">15 minutes</string>
+    <string name="settings_sleep_timer_30min">30 minutes</string>
+    <string name="settings_sleep_timer_45min">45 minutes</string>
+    <string name="settings_sleep_timer_60min">60 minutes</string>
+    <string name="settings_sleep_timer_90min">90 minutes</string>
     <string name="settings_equalizer_description">Ses frekans bantlarını ve efektleri ayarla</string>
     <string name="settings_recording_directory">Kayıt Dizini</string>
     <string name="settings_recording_directory_default">Varsayılan (Music/deutsia_radio)</string>
+    <string name="settings_recording_directory_choose">Choose custom folder...</string>
+    <string name="settings_recording_directory_clear">Clear custom folder</string>
     <string name="settings_record_across_stations">İstasyonlar Arası Kayıt</string>
     <string name="settings_record_across_stations_description">İstasyon değiştirirken kaydı sürdür</string>
     <string name="settings_record_all_stations">Tüm İstasyonları Kaydet</string>
@@ -248,7 +262,36 @@
     <string name="tor_connect">Tor\'a Bağlan</string>
     <string name="tor_open_orbot">Orbot\'u Aç</string>
 
-    <!-- Add/Edit Radio Dialog -->
+    <!-- Tor Status Messages -->
+    <string name="tor_status_connecting">Connecting...</string>
+    <string name="tor_status_connected">Tor Connected</string>
+    <string name="tor_status_disconnected">Tor Disconnected</string>
+    <string name="tor_status_off">Tor Off</string>
+    <string name="tor_status_error">Tor Error</string>
+    <string name="tor_status_leak_warning">Leak Warning</string>
+    <string name="tor_status_install_orbot">Install Orbot</string>
+    <string name="tor_status_connecting_message">Connecting to Tor...</string>
+    <string name="tor_status_connected_message">Connected via Tor</string>
+    <string name="tor_control_title_stopped">Tor Disconnected</string>
+    <string name="tor_control_subtitle_stopped">Tap Connect to browse anonymously via Tor</string>
+    <string name="tor_control_subtitle_connecting">Establishing secure connection via Orbot</string>
+    <string name="tor_control_title_connecting">Connecting to Tor...</string>
+    <string name="tor_control_title_connected">Connected to Tor</string>
+    <string name="tor_control_title_connected_force">Connected to Tor (Force Mode)</string>
+    <string name="tor_control_subtitle_connected">Your connection is private and anonymous</string>
+    <string name="tor_control_subtitle_connected_force">Disconnect via Orbot or disable Force Tor in settings</string>
+    <string name="tor_control_title_error">Connection Failed</string>
+    <string name="tor_control_subtitle_error">Could not connect to Tor network</string>
+    <string name="tor_control_title_orbot_required">Orbot Required</string>
+    <string name="tor_control_subtitle_orbot_required">Install Orbot to connect to the Tor network</string>
+    <string name="tor_control_button_connecting">Connecting...</string>
+    <string name="tor_control_button_disconnect">Disconnect</string>
+    <string name="tor_control_button_cancel">Cancel</string>
+    <string name="tor_control_button_retry">Retry Connection</string>
+    <string name="tor_control_button_install">Install Orbot</string>
+    <string name="tor_control_button_open_orbot">Open Orbot</string>
+
+    
     <string name="add_edit_tor_info">Gömülü Tor kullanılıyor - vekil sunucu yapılandırması gerekmez</string>
     <string name="add_edit_authentication_optional">Kimlik Doğrulama (İsteğe Bağlı)</string>
     <string name="add_edit_advanced_options">Gelişmiş Seçenekler</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -147,11 +147,18 @@
     <string name="settings_theme">Тема</string>
     <string name="settings_theme_description">Виберіть світлу, темну або системну</string>
     <string name="settings_theme_system_default">Системна</string>
+    <string name="settings_theme_light">Light</string>
+    <string name="settings_theme_dark">Dark</string>
     <string name="settings_material_you">Material You</string>
     <string name="settings_material_you_description">Використовувати динамічні кольори на основі шпалер</string>
     <string name="settings_color_scheme">Колірна схема</string>
     <string name="settings_color_scheme_description">Виберіть бажаний колір</string>
     <string name="settings_color_blue">Синій</string>
+    <string name="settings_color_blue_default">Blue (Default)</string>
+    <string name="settings_color_peach">Peach</string>
+    <string name="settings_color_green">Green</string>
+    <string name="settings_color_purple">Purple</string>
+    <string name="settings_color_orange">Orange</string>
     <string name="settings_language">Language</string>
     <string name="settings_language_description">Choose your preferred language</string>
 
@@ -210,9 +217,16 @@
     <string name="settings_sleep_timer">Таймер сну</string>
     <string name="settings_sleep_timer_description">Автозупинка відтворення через встановлений час</string>
     <string name="settings_sleep_timer_off">Вимкнено</string>
+    <string name="settings_sleep_timer_15min">15 minutes</string>
+    <string name="settings_sleep_timer_30min">30 minutes</string>
+    <string name="settings_sleep_timer_45min">45 minutes</string>
+    <string name="settings_sleep_timer_60min">60 minutes</string>
+    <string name="settings_sleep_timer_90min">90 minutes</string>
     <string name="settings_equalizer_description">Налаштування частотних смуг та ефектів</string>
     <string name="settings_recording_directory">Каталог записів</string>
     <string name="settings_recording_directory_default">За замовчуванням (Music/deutsia_radio)</string>
+    <string name="settings_recording_directory_choose">Choose custom folder...</string>
+    <string name="settings_recording_directory_clear">Clear custom folder</string>
     <string name="settings_record_across_stations">Записувати при переключенні станцій</string>
     <string name="settings_record_across_stations_description">Продовжувати запис при переключенні станцій</string>
     <string name="settings_record_all_stations">Записувати всі станції</string>
@@ -248,7 +262,36 @@
     <string name="tor_connect">Підключитися до Tor</string>
     <string name="tor_open_orbot">Відкрити Orbot</string>
 
-    <!-- Add/Edit Radio Dialog -->
+    <!-- Tor Status Messages -->
+    <string name="tor_status_connecting">Connecting...</string>
+    <string name="tor_status_connected">Tor Connected</string>
+    <string name="tor_status_disconnected">Tor Disconnected</string>
+    <string name="tor_status_off">Tor Off</string>
+    <string name="tor_status_error">Tor Error</string>
+    <string name="tor_status_leak_warning">Leak Warning</string>
+    <string name="tor_status_install_orbot">Install Orbot</string>
+    <string name="tor_status_connecting_message">Connecting to Tor...</string>
+    <string name="tor_status_connected_message">Connected via Tor</string>
+    <string name="tor_control_title_stopped">Tor Disconnected</string>
+    <string name="tor_control_subtitle_stopped">Tap Connect to browse anonymously via Tor</string>
+    <string name="tor_control_subtitle_connecting">Establishing secure connection via Orbot</string>
+    <string name="tor_control_title_connecting">Connecting to Tor...</string>
+    <string name="tor_control_title_connected">Connected to Tor</string>
+    <string name="tor_control_title_connected_force">Connected to Tor (Force Mode)</string>
+    <string name="tor_control_subtitle_connected">Your connection is private and anonymous</string>
+    <string name="tor_control_subtitle_connected_force">Disconnect via Orbot or disable Force Tor in settings</string>
+    <string name="tor_control_title_error">Connection Failed</string>
+    <string name="tor_control_subtitle_error">Could not connect to Tor network</string>
+    <string name="tor_control_title_orbot_required">Orbot Required</string>
+    <string name="tor_control_subtitle_orbot_required">Install Orbot to connect to the Tor network</string>
+    <string name="tor_control_button_connecting">Connecting...</string>
+    <string name="tor_control_button_disconnect">Disconnect</string>
+    <string name="tor_control_button_cancel">Cancel</string>
+    <string name="tor_control_button_retry">Retry Connection</string>
+    <string name="tor_control_button_install">Install Orbot</string>
+    <string name="tor_control_button_open_orbot">Open Orbot</string>
+
+    
     <string name="add_edit_tor_info">Використовується вбудований Tor - налаштування проксі не потрібне</string>
     <string name="add_edit_authentication_optional">Автентифікація (необов\'язково)</string>
     <string name="add_edit_advanced_options">Розширені параметри</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -147,11 +147,18 @@
     <string name="settings_theme">Chủ đề</string>
     <string name="settings_theme_description">Chọn sáng, tối hoặc hệ thống</string>
     <string name="settings_theme_system_default">Mặc định hệ thống</string>
+    <string name="settings_theme_light">Light</string>
+    <string name="settings_theme_dark">Dark</string>
     <string name="settings_material_you">Material You</string>
     <string name="settings_material_you_description">Sử dụng màu động dựa trên hình nền</string>
     <string name="settings_color_scheme">Bảng màu</string>
     <string name="settings_color_scheme_description">Chọn màu ưa thích của bạn</string>
     <string name="settings_color_blue">Xanh dương</string>
+    <string name="settings_color_blue_default">Blue (Default)</string>
+    <string name="settings_color_peach">Peach</string>
+    <string name="settings_color_green">Green</string>
+    <string name="settings_color_purple">Purple</string>
+    <string name="settings_color_orange">Orange</string>
     <string name="settings_language">Language</string>
     <string name="settings_language_description">Choose your preferred language</string>
 
@@ -210,9 +217,16 @@
     <string name="settings_sleep_timer">Hẹn giờ ngủ</string>
     <string name="settings_sleep_timer_description">Tự động dừng phát sau thời gian đã đặt</string>
     <string name="settings_sleep_timer_off">Tắt</string>
+    <string name="settings_sleep_timer_15min">15 minutes</string>
+    <string name="settings_sleep_timer_30min">30 minutes</string>
+    <string name="settings_sleep_timer_45min">45 minutes</string>
+    <string name="settings_sleep_timer_60min">60 minutes</string>
+    <string name="settings_sleep_timer_90min">90 minutes</string>
     <string name="settings_equalizer_description">Điều chỉnh dải tần âm thanh và hiệu ứng</string>
     <string name="settings_recording_directory">Thư mục ghi</string>
     <string name="settings_recording_directory_default">Mặc định (Music/deutsia_radio)</string>
+    <string name="settings_recording_directory_choose">Choose custom folder...</string>
+    <string name="settings_recording_directory_clear">Clear custom folder</string>
     <string name="settings_record_across_stations">Ghi xuyên các trạm</string>
     <string name="settings_record_across_stations_description">Tiếp tục ghi khi chuyển trạm</string>
     <string name="settings_record_all_stations">Ghi tất cả trạm</string>
@@ -248,7 +262,36 @@
     <string name="tor_connect">Kết nối với Tor</string>
     <string name="tor_open_orbot">Mở Orbot</string>
 
-    <!-- Add/Edit Radio Dialog -->
+    <!-- Tor Status Messages -->
+    <string name="tor_status_connecting">Connecting...</string>
+    <string name="tor_status_connected">Tor Connected</string>
+    <string name="tor_status_disconnected">Tor Disconnected</string>
+    <string name="tor_status_off">Tor Off</string>
+    <string name="tor_status_error">Tor Error</string>
+    <string name="tor_status_leak_warning">Leak Warning</string>
+    <string name="tor_status_install_orbot">Install Orbot</string>
+    <string name="tor_status_connecting_message">Connecting to Tor...</string>
+    <string name="tor_status_connected_message">Connected via Tor</string>
+    <string name="tor_control_title_stopped">Tor Disconnected</string>
+    <string name="tor_control_subtitle_stopped">Tap Connect to browse anonymously via Tor</string>
+    <string name="tor_control_subtitle_connecting">Establishing secure connection via Orbot</string>
+    <string name="tor_control_title_connecting">Connecting to Tor...</string>
+    <string name="tor_control_title_connected">Connected to Tor</string>
+    <string name="tor_control_title_connected_force">Connected to Tor (Force Mode)</string>
+    <string name="tor_control_subtitle_connected">Your connection is private and anonymous</string>
+    <string name="tor_control_subtitle_connected_force">Disconnect via Orbot or disable Force Tor in settings</string>
+    <string name="tor_control_title_error">Connection Failed</string>
+    <string name="tor_control_subtitle_error">Could not connect to Tor network</string>
+    <string name="tor_control_title_orbot_required">Orbot Required</string>
+    <string name="tor_control_subtitle_orbot_required">Install Orbot to connect to the Tor network</string>
+    <string name="tor_control_button_connecting">Connecting...</string>
+    <string name="tor_control_button_disconnect">Disconnect</string>
+    <string name="tor_control_button_cancel">Cancel</string>
+    <string name="tor_control_button_retry">Retry Connection</string>
+    <string name="tor_control_button_install">Install Orbot</string>
+    <string name="tor_control_button_open_orbot">Open Orbot</string>
+
+    
     <string name="add_edit_tor_info">Sử dụng Tor nhúng - không cần cấu hình proxy</string>
     <string name="add_edit_authentication_optional">Xác thực (Tùy chọn)</string>
     <string name="add_edit_advanced_options">Tùy chọn nâng cao</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -147,11 +147,18 @@
     <string name="settings_theme">主题</string>
     <string name="settings_theme_description">选择浅色、深色或跟随系统</string>
     <string name="settings_theme_system_default">系统默认</string>
+    <string name="settings_theme_light">Light</string>
+    <string name="settings_theme_dark">Dark</string>
     <string name="settings_material_you">Material You</string>
     <string name="settings_material_you_description">使用基于壁纸的动态颜色</string>
     <string name="settings_color_scheme">配色方案</string>
     <string name="settings_color_scheme_description">选择您喜欢的颜色</string>
     <string name="settings_color_blue">蓝色</string>
+    <string name="settings_color_blue_default">Blue (Default)</string>
+    <string name="settings_color_peach">Peach</string>
+    <string name="settings_color_green">Green</string>
+    <string name="settings_color_purple">Purple</string>
+    <string name="settings_color_orange">Orange</string>
     <string name="settings_language">Language</string>
     <string name="settings_language_description">Choose your preferred language</string>
 
@@ -210,9 +217,16 @@
     <string name="settings_sleep_timer">睡眠定时器</string>
     <string name="settings_sleep_timer_description">设定时间后自动停止播放</string>
     <string name="settings_sleep_timer_off">关闭</string>
+    <string name="settings_sleep_timer_15min">15 minutes</string>
+    <string name="settings_sleep_timer_30min">30 minutes</string>
+    <string name="settings_sleep_timer_45min">45 minutes</string>
+    <string name="settings_sleep_timer_60min">60 minutes</string>
+    <string name="settings_sleep_timer_90min">90 minutes</string>
     <string name="settings_equalizer_description">调整音频频段和效果</string>
     <string name="settings_recording_directory">录制目录</string>
     <string name="settings_recording_directory_default">默认（Music/deutsia_radio）</string>
+    <string name="settings_recording_directory_choose">Choose custom folder...</string>
+    <string name="settings_recording_directory_clear">Clear custom folder</string>
     <string name="settings_record_across_stations">跨电台录制</string>
     <string name="settings_record_across_stations_description">切换电台时保持录制</string>
     <string name="settings_record_all_stations">录制所有电台</string>
@@ -248,7 +262,36 @@
     <string name="tor_connect">连接到 Tor</string>
     <string name="tor_open_orbot">打开 Orbot</string>
 
-    <!-- Add/Edit Radio Dialog -->
+    <!-- Tor Status Messages -->
+    <string name="tor_status_connecting">Connecting...</string>
+    <string name="tor_status_connected">Tor Connected</string>
+    <string name="tor_status_disconnected">Tor Disconnected</string>
+    <string name="tor_status_off">Tor Off</string>
+    <string name="tor_status_error">Tor Error</string>
+    <string name="tor_status_leak_warning">Leak Warning</string>
+    <string name="tor_status_install_orbot">Install Orbot</string>
+    <string name="tor_status_connecting_message">Connecting to Tor...</string>
+    <string name="tor_status_connected_message">Connected via Tor</string>
+    <string name="tor_control_title_stopped">Tor Disconnected</string>
+    <string name="tor_control_subtitle_stopped">Tap Connect to browse anonymously via Tor</string>
+    <string name="tor_control_subtitle_connecting">Establishing secure connection via Orbot</string>
+    <string name="tor_control_title_connecting">Connecting to Tor...</string>
+    <string name="tor_control_title_connected">Connected to Tor</string>
+    <string name="tor_control_title_connected_force">Connected to Tor (Force Mode)</string>
+    <string name="tor_control_subtitle_connected">Your connection is private and anonymous</string>
+    <string name="tor_control_subtitle_connected_force">Disconnect via Orbot or disable Force Tor in settings</string>
+    <string name="tor_control_title_error">Connection Failed</string>
+    <string name="tor_control_subtitle_error">Could not connect to Tor network</string>
+    <string name="tor_control_title_orbot_required">Orbot Required</string>
+    <string name="tor_control_subtitle_orbot_required">Install Orbot to connect to the Tor network</string>
+    <string name="tor_control_button_connecting">Connecting...</string>
+    <string name="tor_control_button_disconnect">Disconnect</string>
+    <string name="tor_control_button_cancel">Cancel</string>
+    <string name="tor_control_button_retry">Retry Connection</string>
+    <string name="tor_control_button_install">Install Orbot</string>
+    <string name="tor_control_button_open_orbot">Open Orbot</string>
+
+    
     <string name="add_edit_tor_info">使用嵌入式 Tor - 无需配置代理</string>
     <string name="add_edit_authentication_optional">身份验证（可选）</string>
     <string name="add_edit_advanced_options">高级选项</string>


### PR DESCRIPTION
Added newly translatable strings that were previously hardcoded:
- Theme options (Light/Dark theme settings)
- Color scheme options (Blue default, Peach, Green, Purple, Orange)
- Sleep timer duration options (15/30/45/60/90 minutes)
- Recording directory options (choose/clear custom folder)
- Tor status messages and control UI strings

Updated translation files:
- Arabic (ar), German (de), Spanish (es), Farsi (fa)
- French (fr), Hindi (hi), Italian (it), Japanese (ja)
- Korean (ko), Burmese (my), Portuguese (pt), Russian (ru)
- Turkish (tr), Ukrainian (uk), Vietnamese (vi), Chinese (zh)

All new strings are currently in English and will need proper translation by native speakers in future updates.