### PR TITLE
Fix Android build errors in string resources

### DIFF
--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -116,7 +116,7 @@
 
     <!-- Recording Messages -->
     <string name="recording_failed">فشل التسجيل: %s</string>
-    <string name="recording_saved">تم حفظ التسجيل: %s (%dKB)</string>
+    <string name="recording_saved">تم حفظ التسجيل: %1$s (%2$dKB)</string>
     <string name="recording_stopping">جارٍ إيقاف التسجيل...</string>
     <string name="recording_starting">جارٍ بدء التسجيل...</string>
     <string name="recording_no_station">لا توجد محطة قيد التشغيل</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -116,7 +116,7 @@
 
     <!-- Recording Messages -->
     <string name="recording_failed">Aufnahme fehlgeschlagen: %s</string>
-    <string name="recording_saved">Aufnahme gespeichert: %s (%dKB)</string>
+    <string name="recording_saved">Aufnahme gespeichert: %1$s (%2$dKB)</string>
     <string name="recording_stopping">Aufnahme wird gestoppt...</string>
     <string name="recording_starting">Aufnahme wird gestartet...</string>
     <string name="recording_no_station">Kein Sender wird abgespielt</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -116,7 +116,7 @@
 
     <!-- Recording Messages -->
     <string name="recording_failed">Grabación fallida: %s</string>
-    <string name="recording_saved">Grabación guardada: %s (%dKB)</string>
+    <string name="recording_saved">Grabación guardada: %1$s (%2$dKB)</string>
     <string name="recording_stopping">Deteniendo grabación...</string>
     <string name="recording_starting">Iniciando grabación...</string>
     <string name="recording_no_station">No hay estación reproduciéndose</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -116,7 +116,7 @@
 
     <!-- Recording Messages -->
     <string name="recording_failed">ضبط ناموفق بود: %s</string>
-    <string name="recording_saved">ضبط ذخیره شد: %s (%dKB)</string>
+    <string name="recording_saved">ضبط ذخیره شد: %1$s (%2$dKB)</string>
     <string name="recording_stopping">در حال توقف ضبط...</string>
     <string name="recording_starting">در حال شروع ضبط...</string>
     <string name="recording_no_station">ایستگاهی در حال پخش نیست</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -123,7 +123,7 @@
 
     <!-- Recording Messages -->
     <string name="recording_failed">Échec de l\'enregistrement : %s</string>
-    <string name="recording_saved">Enregistrement sauvegardé : %s (%dKo)</string>
+    <string name="recording_saved">Enregistrement sauvegardé : %1$s (%2$dKo)</string>
     <string name="recording_stopping">Arrêt de l\'enregistrement...</string>
     <string name="recording_starting">Démarrage de l\'enregistrement...</string>
     <string name="recording_no_station">Aucune station en lecture</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -113,7 +113,7 @@
 
     <!-- Recording Messages -->
     <string name="recording_failed">रिकॉर्डिंग विफल: %s</string>
-    <string name="recording_saved">रिकॉर्डिंग सहेजी गई: %s (%dKB)</string>
+    <string name="recording_saved">रिकॉर्डिंग सहेजी गई: %1$s (%2$dKB)</string>
     <string name="recording_stopping">रिकॉर्डिंग बंद हो रही है...</string>
     <string name="recording_starting">रिकॉर्डिंग शुरू हो रही है...</string>
     <string name="recording_no_station">कोई स्टेशन नहीं चल रहा</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -123,7 +123,7 @@
 
     <!-- Recording Messages -->
     <string name="recording_failed">Registrazione fallita: %s</string>
-    <string name="recording_saved">Registrazione salvata: %s (%dKB)</string>
+    <string name="recording_saved">Registrazione salvata: %1$s (%2$dKB)</string>
     <string name="recording_stopping">Arresto registrazione...</string>
     <string name="recording_starting">Avvio registrazione...</string>
     <string name="recording_no_station">Nessuna stazione in riproduzione</string>
@@ -264,7 +264,7 @@
     <string name="tor_connection_details">Dettagli connessione</string>
     <string name="tor_proxy_host">Host proxy</string>
     <string name="tor_socks_port">Porta SOCKS</string>
-    <string name="tor_what_is_orbot">Cos'è Orbot?</string>
+    <string name="tor_what_is_orbot">Cos\'è Orbot?</string>
     <string name="tor_orbot_description">Orbot è il client Tor ufficiale per Android. Fornisce accesso sicuro e crittografato alla rete Tor.</string>
     <string name="tor_connect">Connetti a Tor</string>
     <string name="tor_open_orbot">Apri Orbot</string>
@@ -334,7 +334,7 @@
     <string name="now_playing_time_placeholder">00:00</string>
     <string name="now_playing_live">IN DIRETTA</string>
     <string name="now_playing_no_station">Nessuna stazione in riproduzione</string>
-    <string name="now_playing_no_station_subtitle">Seleziona una stazione dall'elenco</string>
+    <string name="now_playing_no_station_subtitle">Seleziona una stazione dall\'elenco</string>
     <string name="now_playing_volume_title">Volume radio</string>
     <string name="now_playing_volume_description">Regola solo lo stream radio</string>
 
@@ -357,7 +357,7 @@
     <string name="tor_channel_name">Connessione Tor</string>
     <string name="tor_channel_description">Mostra lo stato della connessione Tor</string>
     <string name="tor_notification_disconnected">Tor disconnesso</string>
-    <string name="tor_notification_tap_to_open">Tocca per aprire l'app</string>
+    <string name="tor_notification_tap_to_open">Tocca per aprire l\'app</string>
     <string name="tor_notification_connecting">Connessione tramite Orbot...</string>
     <string name="tor_notification_please_wait">Attendere prego</string>
     <string name="tor_notification_connected">Tor connesso</string>
@@ -389,20 +389,20 @@
     <!-- Security & Privacy -->
     <string name="settings_security_privacy">Sicurezza e privacy</string>
     <string name="settings_app_lock">Blocco app</string>
-    <string name="settings_app_lock_description">Richiedi password o biometria per sbloccare l'app</string>
+    <string name="settings_app_lock_description">Richiedi password o biometria per sbloccare l\'app</string>
     <string name="settings_biometric_auth">Autenticazione biometrica</string>
     <string name="settings_biometric_auth_description">Usa impronta digitale o sblocco col volto</string>
-    <string name="settings_require_auth_on_launch">Richiedi autenticazione all'avvio</string>
-    <string name="settings_require_auth_on_launch_description">Richiedi sempre l'autenticazione all'apertura dell'app</string>
+    <string name="settings_require_auth_on_launch">Richiedi autenticazione all\'avvio</string>
+    <string name="settings_require_auth_on_launch_description">Richiedi sempre l\'autenticazione all\'apertura dell\'app</string>
     <string name="settings_set_password">Imposta password</string>
     <string name="settings_change_password">Cambia password</string>
     <string name="settings_database_encryption">Crittografia database</string>
-    <string name="settings_database_encryption_description">Crittografa l'intero database con SQLCipher usando la password dell'app (richiede riavvio)</string>
+    <string name="settings_database_encryption_description">Crittografa l\'intero database con SQLCipher usando la password dell\'app (richiede riavvio)</string>
     <string name="settings_database_encryption_warning">Attenzione: Questa è una funzionalità sperimentale. Assicurati di avere un backup prima di abilitarla!</string>
     <string name="settings_database_encryption_enable_title">Abilitare crittografia database?</string>
-    <string name="settings_database_encryption_enable_message">Questo crittograferà l'intero database radio usando la password dell'app. L'app si riavvierà per applicare le modifiche.\n\nATTENZIONE: Questo è sperimentale. Assicurati di avere un backup!</string>
+    <string name="settings_database_encryption_enable_message">Questo crittograferà l\'intero database radio usando la password dell\'app. L\'app si riavvierà per applicare le modifiche.\n\nATTENZIONE: Questo è sperimentale. Assicurati di avere un backup!</string>
     <string name="settings_database_encryption_disable_title">Disabilitare crittografia database?</string>
-    <string name="settings_database_encryption_disable_message">Questo decrittograferà il database e rimuoverà la crittografia. L'app si riavvierà per applicare le modifiche.</string>
+    <string name="settings_database_encryption_disable_message">Questo decrittograferà il database e rimuoverà la crittografia. L\'app si riavvierà per applicare le modifiche.</string>
     <string name="settings_database_encryption_enabled">Crittografia database abilitata</string>
     <string name="settings_database_encryption_disabled">Crittografia database disabilitata</string>
     <string name="settings_database_encryption_error">Impossibile modificare impostazione crittografia</string>
@@ -425,8 +425,8 @@
     <string name="auth_password_changed">Password modificata con successo</string>
     <string name="auth_enter_password_to_encrypt">Verifica password app</string>
     <string name="auth_enter_password_to_decrypt">Verifica password app</string>
-    <string name="auth_password_for_encryption">Inserisci la password dell'app esistente per abilitare la crittografia del database.\n\nLa password dell'app verrà usata per derivare la chiave di crittografia. Nessuna password separata necessaria.</string>
-    <string name="auth_password_for_decryption">Inserisci la password dell'app per verificare e decrittografare il database prima di disabilitare la crittografia.</string>
+    <string name="auth_password_for_encryption">Inserisci la password dell\'app esistente per abilitare la crittografia del database.\n\nLa password dell\'app verrà usata per derivare la chiave di crittografia. Nessuna password separata necessaria.</string>
+    <string name="auth_password_for_decryption">Inserisci la password dell\'app per verificare e decrittografare il database prima di disabilitare la crittografia.</string>
     <string name="auth_encrypting_database">Crittografia database con password app…</string>
     <string name="auth_decrypting_database">Decrittografia database…</string>
     <string name="auth_rekeying_database">Aggiornamento crittografia database con nuova password…</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -116,7 +116,7 @@
 
     <!-- Recording Messages -->
     <string name="recording_failed">録音に失敗しました: %s</string>
-    <string name="recording_saved">録音を保存しました: %s (%dKB)</string>
+    <string name="recording_saved">録音を保存しました: %1$s (%2$dKB)</string>
     <string name="recording_stopping">録音を停止中...</string>
     <string name="recording_starting">録音を開始中...</string>
     <string name="recording_no_station">ステーションが再生されていません</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -116,7 +116,7 @@
 
     <!-- Recording Messages -->
     <string name="recording_failed">녹음 실패: %s</string>
-    <string name="recording_saved">녹음 저장됨: %s (%dKB)</string>
+    <string name="recording_saved">녹음 저장됨: %1$s (%2$dKB)</string>
     <string name="recording_stopping">녹음 중지 중...</string>
     <string name="recording_starting">녹음 시작 중...</string>
     <string name="recording_no_station">재생 중인 방송국 없음</string>

--- a/app/src/main/res/values-my/strings.xml
+++ b/app/src/main/res/values-my/strings.xml
@@ -113,7 +113,7 @@
 
     <!-- Recording Messages -->
     <string name="recording_failed">ရိုက်ကူးမှု မအောင်မြင်ပါ: %s</string>
-    <string name="recording_saved">ရိုက်ကူးမှုကို သိမ်းဆည်းပြီးပါပြီ: %s (%dKB)</string>
+    <string name="recording_saved">ရိုက်ကူးမှုကို သိမ်းဆည်းပြီးပါပြီ: %1$s (%2$dKB)</string>
     <string name="recording_stopping">ရိုက်ကူးမှုကို ရပ်နေသည်...</string>
     <string name="recording_starting">ရိုက်ကူးမှုကို စတင်နေသည်...</string>
     <string name="recording_no_station">စတေးရှင်း မဖွင့်ထားပါ</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -116,7 +116,7 @@
 
     <!-- Recording Messages -->
     <string name="recording_failed">Gravação falhou: %s</string>
-    <string name="recording_saved">Gravação salva: %s (%dKB)</string>
+    <string name="recording_saved">Gravação salva: %1$s (%2$dKB)</string>
     <string name="recording_stopping">Parando gravação...</string>
     <string name="recording_starting">Iniciando gravação...</string>
     <string name="recording_no_station">Nenhuma estação tocando</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -116,7 +116,7 @@
 
     <!-- Recording Messages -->
     <string name="recording_failed">Ошибка записи: %s</string>
-    <string name="recording_saved">Запись сохранена: %s (%dКБ)</string>
+    <string name="recording_saved">Запись сохранена: %1$s (%2$dКБ)</string>
     <string name="recording_stopping">Остановка записи...</string>
     <string name="recording_starting">Начало записи...</string>
     <string name="recording_no_station">Станция не воспроизводится</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -116,7 +116,7 @@
 
     <!-- Recording Messages -->
     <string name="recording_failed">Kayıt başarısız: %s</string>
-    <string name="recording_saved">Kayıt kaydedildi: %s (%dKB)</string>
+    <string name="recording_saved">Kayıt kaydedildi: %1$s (%2$dKB)</string>
     <string name="recording_stopping">Kayıt durduruluyor...</string>
     <string name="recording_starting">Kayıt başlatılıyor...</string>
     <string name="recording_no_station">Çalan istasyon yok</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -116,7 +116,7 @@
 
     <!-- Recording Messages -->
     <string name="recording_failed">Помилка запису: %s</string>
-    <string name="recording_saved">Запис збережено: %s (%dКБ)</string>
+    <string name="recording_saved">Запис збережено: %1$s (%2$dКБ)</string>
     <string name="recording_stopping">Зупинка запису...</string>
     <string name="recording_starting">Початок запису...</string>
     <string name="recording_no_station">Станція не відтворюється</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -116,7 +116,7 @@
 
     <!-- Recording Messages -->
     <string name="recording_failed">Ghi thất bại: %s</string>
-    <string name="recording_saved">Đã lưu bản ghi: %s (%dKB)</string>
+    <string name="recording_saved">Đã lưu bản ghi: %1$s (%2$dKB)</string>
     <string name="recording_stopping">Đang dừng ghi...</string>
     <string name="recording_starting">Đang bắt đầu ghi...</string>
     <string name="recording_no_station">Không có trạm đang phát</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -116,7 +116,7 @@
 
     <!-- Recording Messages -->
     <string name="recording_failed">录制失败：%s</string>
-    <string name="recording_saved">录制已保存：%s (%dKB)</string>
+    <string name="recording_saved">录制已保存：%1$s (%2$dKB)</string>
     <string name="recording_stopping">停止录制中...</string>
     <string name="recording_starting">开始录制中...</string>
     <string name="recording_no_station">无电台播放</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -113,7 +113,7 @@
 
     <!-- Recording Messages -->
     <string name="recording_failed">Recording failed: %s</string>
-    <string name="recording_saved">Recording saved: %s (%dKB)</string>
+    <string name="recording_saved">Recording saved: %1$s (%2$dKB)</string>
     <string name="recording_stopping">Stopping recording...</string>
     <string name="recording_starting">Starting recording...</string>
     <string name="recording_no_station">No station playing</string>


### PR DESCRIPTION
Fixed two types of Android resource compilation errors:

1. Multiple substitutions in non-positional format:
   - Updated recording_saved string in all languages to use positional arguments (%1$s and %2$d) instead of non-positional (%s and %d)
   - Affected all 17 language files

2. Invalid unicode escape sequences in Italian translations:
   - Escaped all apostrophes in Italian strings (changed ' to \')
   - Fixed 11 strings in values-it/strings.xml including:
     * tor_what_is_orbot
     * now_playing_no_station_subtitle * tor_notification_tap_to_open * settings_app_lock_description * settings_require_auth_on_launch and related strings * settings_database_encryption_description and related strings * auth_password_for_encryption and auth_password_for_decryption

All Android resource compilation errors are now resolved.