### PR TITLE
Hide Tor stop/start button in settings during force mode

### DIFF
--- a/app/src/main/java/com/opensource/i2pradio/ui/SettingsFragment.kt
+++ b/app/src/main/java/com/opensource/i2pradio/ui/SettingsFragment.kt
@@ -881,6 +881,9 @@ class SettingsFragment : Fragment() {
         val isForceTorEnabled = PreferencesHelper.isForceTorAll(requireContext()) ||
                                 PreferencesHelper.isForceTorExceptI2P(requireContext())
 
+        // Hide the action button during force mode - users shouldn't be able to stop Tor manually
+        torActionButton?.visibility = if (isForceTorEnabled) View.GONE else View.VISIBLE
+
         when (state) {
             TorManager.TorState.STOPPED -> {
                 // If force Tor is enabled and we have a proxy port, assume connected


### PR DESCRIPTION
During force mode (Force Tor All or Force Tor Except I2P), users should not be able to manually stop the Tor connection via the UI button. The button is now hidden when force mode is enabled.

Changes:
- Added visibility toggle in updateTorStatusUI() based on force mode
- Button is hidden (View.GONE) when force mode is active
- Button is visible (View.VISIBLE) when force mode is inactive