### PR TITLE
Fix nullable String type mismatch in LibraryFragment

### DIFF
--- a/app/src/main/java/com/opensource/i2pradio/ui/LibraryFragment.kt
+++ b/app/src/main/java/com/opensource/i2pradio/ui/LibraryFragment.kt
@@ -432,7 +432,7 @@ class LibraryFragment : Fragment() {
                 .setPositiveButton(android.R.string.ok) { _, _ ->
                     // Apply the selection when OK is clicked
                     // Store English genre name for language portability
-                    currentGenreFilter = if (tempSelectedGenre == allGenresText) {
+                    currentGenreFilter = if (tempSelectedGenre == allGenresText || tempSelectedGenre == null) {
                         null
                     } else {
                         getEnglishGenreName(tempSelectedGenre)


### PR DESCRIPTION
Added null check for tempSelectedGenre before passing to getEnglishGenreName() to prevent type mismatch error when nullable String? is passed to function expecting non-nullable String.