### PR TITLE
Translate genre names in library filter for all languages

### DIFF
--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -40,9 +40,9 @@
     <string name="genre_blues">Blues</string>
     <string name="genre_christian">Christlich</string>
     <string name="genre_classical">Klassik</string>
-    <string name="genre_comedy">Comedy</string>
+    <string name="genre_comedy">Komödie</string>
     <string name="genre_country">Country</string>
-    <string name="genre_dance">Dance</string>
+    <string name="genre_dance">Tanz</string>
     <string name="genre_edm">EDM</string>
     <string name="genre_electronic">Elektronisch</string>
     <string name="genre_folk">Folk</string>
@@ -64,7 +64,7 @@
     <string name="genre_rock">Rock</string>
     <string name="genre_soul">Soul</string>
     <string name="genre_sports">Sport</string>
-    <string name="genre_talk">Talk</string>
+    <string name="genre_talk">Gespräch</string>
     <string name="genre_world">Weltmusik</string>
     <string name="genre_other">Sonstige</string>
 

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -42,7 +42,7 @@
     <string name="genre_classical">Clásica</string>
     <string name="genre_comedy">Comedia</string>
     <string name="genre_country">Country</string>
-    <string name="genre_dance">Dance</string>
+    <string name="genre_dance">Baile</string>
     <string name="genre_edm">EDM</string>
     <string name="genre_electronic">Electrónica</string>
     <string name="genre_folk">Folk</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -45,11 +45,11 @@
     <string name="genre_alternative">Alternative</string>
     <string name="genre_ambient">Ambient</string>
     <string name="genre_blues">Blues</string>
-    <string name="genre_christian">Christian</string>
+    <string name="genre_christian">Chrétien</string>
     <string name="genre_classical">Classique</string>
     <string name="genre_comedy">Comédie</string>
     <string name="genre_country">Country</string>
-    <string name="genre_dance">Dance</string>
+    <string name="genre_dance">Danse</string>
     <string name="genre_edm">EDM</string>
     <string name="genre_electronic">Électronique</string>
     <string name="genre_folk">Folk</string>
@@ -63,16 +63,16 @@
     <string name="genre_lo_fi">Lo-Fi</string>
     <string name="genre_metal">Metal</string>
     <string name="genre_news">Actualités</string>
-    <string name="genre_oldies">Oldies</string>
+    <string name="genre_oldies">Classiques</string>
     <string name="genre_pop">Pop</string>
     <string name="genre_punk">Punk</string>
     <string name="genre_r_and_b">R&amp;B</string>
     <string name="genre_reggae">Reggae</string>
     <string name="genre_rock">Rock</string>
     <string name="genre_soul">Soul</string>
-    <string name="genre_sports">Sports</string>
-    <string name="genre_talk">Talk</string>
-    <string name="genre_world">World</string>
+    <string name="genre_sports">Sport</string>
+    <string name="genre_talk">Discussion</string>
+    <string name="genre_world">Monde</string>
     <string name="genre_other">Autre</string>
 
      <!-- about -->

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -45,11 +45,11 @@
     <string name="genre_alternative">Alternative</string>
     <string name="genre_ambient">Ambient</string>
     <string name="genre_blues">Blues</string>
-    <string name="genre_christian">Christian</string>
+    <string name="genre_christian">Cristiana</string>
     <string name="genre_classical">Classica</string>
     <string name="genre_comedy">Commedia</string>
     <string name="genre_country">Country</string>
-    <string name="genre_dance">Dance</string>
+    <string name="genre_dance">Danza</string>
     <string name="genre_edm">EDM</string>
     <string name="genre_electronic">Elettronica</string>
     <string name="genre_folk">Folk</string>
@@ -71,8 +71,8 @@
     <string name="genre_rock">Rock</string>
     <string name="genre_soul">Soul</string>
     <string name="genre_sports">Sport</string>
-    <string name="genre_talk">Talk</string>
-    <string name="genre_world">World</string>
+    <string name="genre_talk">Conversazione</string>
+    <string name="genre_world">Mondo</string>
     <string name="genre_other">Altro</string>
 
      <!-- about -->

--- a/app/src/main/res/values-my/strings.xml
+++ b/app/src/main/res/values-my/strings.xml
@@ -39,7 +39,7 @@
     <string name="genre_classical">ဂန္ထဝင်</string>
     <string name="genre_comedy">ဟာသ</string>
     <string name="genre_country">Country</string>
-    <string name="genre_dance">Dance</string>
+    <string name="genre_dance">အက</string>
     <string name="genre_edm">EDM</string>
     <string name="genre_electronic">အီလက်ထရွန်နစ်</string>
     <string name="genre_folk">Folk</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -42,7 +42,7 @@
     <string name="genre_classical">Clássica</string>
     <string name="genre_comedy">Comédia</string>
     <string name="genre_country">Country</string>
-    <string name="genre_dance">Dance</string>
+    <string name="genre_dance">Dança</string>
     <string name="genre_edm">EDM</string>
     <string name="genre_electronic">Eletrônica</string>
     <string name="genre_folk">Folk</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -42,7 +42,7 @@
     <string name="genre_classical">Cổ điển</string>
     <string name="genre_comedy">Hài kịch</string>
     <string name="genre_country">Country</string>
-    <string name="genre_dance">Dance</string>
+    <string name="genre_dance">Khiêu vũ</string>
     <string name="genre_edm">EDM</string>
     <string name="genre_electronic">Điện tử</string>
     <string name="genre_folk">Dân ca</string>


### PR DESCRIPTION
This commit completes the localization of music genre names in the genre filter dialog. While the LibraryFragment code was already set up to use string resources, many translation files still had genre names in English.

Updated translations for the following languages:
- French (fr): Dance->Danse, Christian->Chrétien, Sports->Sport, Talk->Discussion, World->Monde, Oldies->Classiques
- Spanish (es): Dance->Baile
- German (de): Dance->Tanz, Comedy->Komödie, Talk->Gespräch
- Italian (it): Dance->Danza, Christian->Cristiana, Talk->Conversazione, World->Mondo
- Portuguese (pt): Dance->Dança
- Vietnamese (vi): Dance->Khiêu vũ
- Burmese (my): Dance->အက

Other languages (Russian, Turkish, Ukrainian, Chinese, Japanese, Korean, Arabic, Persian, Hindi) already had proper translations.

Note: Many music genre names (Jazz, Blues, Rock, Funk, etc.) remain in their English/international form as they are universally recognized and commonly used across languages.

Fixes issue where genre names appeared in English regardless of app language setting.