### PR TITLE
Fix Tor icon display and improve Force Tor mode UX

### DIFF
--- a/app/src/main/java/com/opensource/i2pradio/MainActivity.kt
+++ b/app/src/main/java/com/opensource/i2pradio/MainActivity.kt
@@ -276,12 +276,9 @@ class MainActivity : AppCompatActivity() {
             val protocol = PreferencesHelper.getCustomProxyProtocol(this)
             val port = PreferencesHelper.getCustomProxyPort(this)
             customProxyStatusView.updateStateFromConfig(true, proxyHost, protocol, port)
-        } else if (isForceTorAll || isForceTorExceptI2P) {
-            // Hide both status views when Tor is in force mode
-            torStatusView.visibility = View.GONE
-            customProxyStatusView.visibility = View.GONE
         } else {
-            // Show Tor status, hide custom proxy status
+            // Show Tor status (always visible when Tor is enabled, including force mode)
+            // Hide custom proxy status
             torStatusView.visibility = View.VISIBLE
             customProxyStatusView.visibility = View.GONE
 

--- a/app/src/main/java/com/opensource/i2pradio/ui/SettingsFragment.kt
+++ b/app/src/main/java/com/opensource/i2pradio/ui/SettingsFragment.kt
@@ -881,8 +881,12 @@ class SettingsFragment : Fragment() {
         val isForceTorEnabled = PreferencesHelper.isForceTorAll(requireContext()) ||
                                 PreferencesHelper.isForceTorExceptI2P(requireContext())
 
-        // Hide the action button during force mode - users shouldn't be able to stop Tor manually
-        torActionButton?.visibility = if (isForceTorEnabled) View.GONE else View.VISIBLE
+        // Grey out the action button during force mode - users shouldn't be able to stop Tor manually
+        // Keep it visible but disabled to provide better UX feedback
+        torActionButton?.apply {
+            isEnabled = !isForceTorEnabled
+            alpha = if (isForceTorEnabled) 0.5f else 1.0f
+        }
 
         when (state) {
             TorManager.TorState.STOPPED -> {
@@ -949,7 +953,9 @@ class SettingsFragment : Fragment() {
         torStatusText?.text = "Connected"
         torStatusDetail?.text = "SOCKS port: ${TorManager.socksPort}"
         torActionButton?.text = "Stop"
-        torActionButton?.isEnabled = true
+        // Keep button disabled and greyed out in force mode (handled by updateTorStatusUI)
+        torActionButton?.isEnabled = false
+        torActionButton?.alpha = 0.5f
     }
 
     private fun showForceTorWarning() {
@@ -957,7 +963,9 @@ class SettingsFragment : Fragment() {
         torStatusText?.text = "Connection Failed"
         torStatusDetail?.text = "Force Tor is enabled but not connected"
         torActionButton?.text = "Retry"
-        torActionButton?.isEnabled = true
+        // Keep button disabled and greyed out in force mode (handled by updateTorStatusUI)
+        torActionButton?.isEnabled = false
+        torActionButton?.alpha = 0.5f
     }
 
     private fun updateRecordingDirectoryDisplay() {


### PR DESCRIPTION
- Fix bug where Tor icon in toolbar was hidden when Force Tor mode was enabled
  - The icon now remains visible to show connection status
  - Users can see Tor connection state even in Force mode

- Change Stop button behavior in settings when Force Tor mode is on
  - Button is now disabled and greyed out (50% opacity) instead of hidden
  - Provides better UX feedback that Tor cannot be stopped in Force mode
  - Prevents accidental Force Tor mode turn-offs

These changes address the "abhorrent" bug where the Tor icon wouldn't show most of the time, and improve user experience by making the Force Tor mode restrictions more clear.