### PR TITLE
Translate Tor status strings to German, Spanish, and Portuguese

### DIFF
--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -263,13 +263,13 @@
     <string name="tor_open_orbot">Orbot öffnen</string>
 
     <!-- Tor Status Messages -->
-    <string name="tor_status_connecting">Connecting...</string>
-    <string name="tor_status_connected">Tor Connected</string>
-    <string name="tor_status_disconnected">Tor Disconnected</string>
-    <string name="tor_status_off">Tor Off</string>
-    <string name="tor_status_error">Tor Error</string>
-    <string name="tor_status_leak_warning">Leak Warning</string>
-    <string name="tor_status_install_orbot">Install Orbot</string>
+    <string name="tor_status_connecting">Verbinden...</string>
+    <string name="tor_status_connected">Tor verbunden</string>
+    <string name="tor_status_disconnected">Tor getrennt</string>
+    <string name="tor_status_off">Tor aus</string>
+    <string name="tor_status_error">Tor-Fehler</string>
+    <string name="tor_status_leak_warning">Leak-Warnung</string>
+    <string name="tor_status_install_orbot">Orbot installieren</string>
 
     <!-- Tor Status ContentDescriptions (for accessibility) -->
     <string name="tor_status_off_description">Tor ist getrennt. Tippen zum Verbinden.</string>
@@ -280,26 +280,26 @@
     <string name="tor_status_install_orbot_description">Orbot ist nicht installiert. Tippen zum Installieren.</string>
     <string name="tor_status_leak_warning_description">Tor-Zwangsmodus ist aktiviert, aber nicht verbunden. Privatsphäre könnte gefährdet sein.</string>
 
-    <string name="tor_status_connecting_message">Connecting to Tor...</string>
-    <string name="tor_status_connected_message">Connected via Tor</string>
-    <string name="tor_control_title_stopped">Tor Disconnected</string>
-    <string name="tor_control_subtitle_stopped">Tap Connect to browse anonymously via Tor</string>
-    <string name="tor_control_subtitle_connecting">Establishing secure connection via Orbot</string>
-    <string name="tor_control_title_connecting">Connecting to Tor...</string>
-    <string name="tor_control_title_connected">Connected to Tor</string>
-    <string name="tor_control_title_connected_force">Connected to Tor (Force Mode)</string>
-    <string name="tor_control_subtitle_connected">Your connection is private and anonymous</string>
-    <string name="tor_control_subtitle_connected_force">Disconnect via Orbot or disable Force Tor in settings</string>
-    <string name="tor_control_title_error">Connection Failed</string>
-    <string name="tor_control_subtitle_error">Could not connect to Tor network</string>
-    <string name="tor_control_title_orbot_required">Orbot Required</string>
-    <string name="tor_control_subtitle_orbot_required">Install Orbot to connect to the Tor network</string>
-    <string name="tor_control_button_connecting">Connecting...</string>
-    <string name="tor_control_button_disconnect">Disconnect</string>
-    <string name="tor_control_button_cancel">Cancel</string>
-    <string name="tor_control_button_retry">Retry Connection</string>
-    <string name="tor_control_button_install">Install Orbot</string>
-    <string name="tor_control_button_open_orbot">Open Orbot</string>
+    <string name="tor_status_connecting_message">Verbinde mit Tor...</string>
+    <string name="tor_status_connected_message">Über Tor verbunden</string>
+    <string name="tor_control_title_stopped">Tor getrennt</string>
+    <string name="tor_control_subtitle_stopped">Tippen Sie auf Verbinden, um anonym über Tor zu surfen</string>
+    <string name="tor_control_subtitle_connecting">Stelle sichere Verbindung über Orbot her</string>
+    <string name="tor_control_title_connecting">Verbinde mit Tor...</string>
+    <string name="tor_control_title_connected">Mit Tor verbunden</string>
+    <string name="tor_control_title_connected_force">Mit Tor verbunden (Zwangsmodus)</string>
+    <string name="tor_control_subtitle_connected">Ihre Verbindung ist privat und anonym</string>
+    <string name="tor_control_subtitle_connected_force">Über Orbot trennen oder Tor-Zwang in Einstellungen deaktivieren</string>
+    <string name="tor_control_title_error">Verbindung fehlgeschlagen</string>
+    <string name="tor_control_subtitle_error">Konnte nicht mit Tor-Netzwerk verbinden</string>
+    <string name="tor_control_title_orbot_required">Orbot erforderlich</string>
+    <string name="tor_control_subtitle_orbot_required">Orbot installieren, um mit dem Tor-Netzwerk zu verbinden</string>
+    <string name="tor_control_button_connecting">Verbinden...</string>
+    <string name="tor_control_button_disconnect">Trennen</string>
+    <string name="tor_control_button_cancel">Abbrechen</string>
+    <string name="tor_control_button_retry">Verbindung wiederholen</string>
+    <string name="tor_control_button_install">Orbot installieren</string>
+    <string name="tor_control_button_open_orbot">Orbot öffnen</string>
 
 
     <!-- Add/Edit Radio Dialog -->

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -263,13 +263,13 @@
     <string name="tor_open_orbot">Abrir Orbot</string>
 
     <!-- Tor Status Messages -->
-    <string name="tor_status_connecting">Connecting...</string>
-    <string name="tor_status_connected">Tor Connected</string>
-    <string name="tor_status_disconnected">Tor Disconnected</string>
-    <string name="tor_status_off">Tor Off</string>
-    <string name="tor_status_error">Tor Error</string>
-    <string name="tor_status_leak_warning">Leak Warning</string>
-    <string name="tor_status_install_orbot">Install Orbot</string>
+    <string name="tor_status_connecting">Conectando...</string>
+    <string name="tor_status_connected">Tor conectado</string>
+    <string name="tor_status_disconnected">Tor desconectado</string>
+    <string name="tor_status_off">Tor apagado</string>
+    <string name="tor_status_error">Error de Tor</string>
+    <string name="tor_status_leak_warning">Advertencia de fuga</string>
+    <string name="tor_status_install_orbot">Instalar Orbot</string>
 
     <!-- Tor Status ContentDescriptions (for accessibility) -->
     <string name="tor_status_off_description">Tor está desconectado. Toca para conectar.</string>
@@ -280,26 +280,26 @@
     <string name="tor_status_install_orbot_description">Orbot no está instalado. Toca para instalar.</string>
     <string name="tor_status_leak_warning_description">Modo Tor forzado está activado pero no conectado. La privacidad puede estar comprometida.</string>
 
-    <string name="tor_status_connecting_message">Connecting to Tor...</string>
-    <string name="tor_status_connected_message">Connected via Tor</string>
-    <string name="tor_control_title_stopped">Tor Disconnected</string>
-    <string name="tor_control_subtitle_stopped">Tap Connect to browse anonymously via Tor</string>
-    <string name="tor_control_subtitle_connecting">Establishing secure connection via Orbot</string>
-    <string name="tor_control_title_connecting">Connecting to Tor...</string>
-    <string name="tor_control_title_connected">Connected to Tor</string>
-    <string name="tor_control_title_connected_force">Connected to Tor (Force Mode)</string>
-    <string name="tor_control_subtitle_connected">Your connection is private and anonymous</string>
-    <string name="tor_control_subtitle_connected_force">Disconnect via Orbot or disable Force Tor in settings</string>
-    <string name="tor_control_title_error">Connection Failed</string>
-    <string name="tor_control_subtitle_error">Could not connect to Tor network</string>
-    <string name="tor_control_title_orbot_required">Orbot Required</string>
-    <string name="tor_control_subtitle_orbot_required">Install Orbot to connect to the Tor network</string>
-    <string name="tor_control_button_connecting">Connecting...</string>
-    <string name="tor_control_button_disconnect">Disconnect</string>
-    <string name="tor_control_button_cancel">Cancel</string>
-    <string name="tor_control_button_retry">Retry Connection</string>
-    <string name="tor_control_button_install">Install Orbot</string>
-    <string name="tor_control_button_open_orbot">Open Orbot</string>
+    <string name="tor_status_connecting_message">Conectando a Tor...</string>
+    <string name="tor_status_connected_message">Conectado vía Tor</string>
+    <string name="tor_control_title_stopped">Tor desconectado</string>
+    <string name="tor_control_subtitle_stopped">Toca Conectar para navegar de forma anónima vía Tor</string>
+    <string name="tor_control_subtitle_connecting">Estableciendo conexión segura vía Orbot</string>
+    <string name="tor_control_title_connecting">Conectando a Tor...</string>
+    <string name="tor_control_title_connected">Conectado a Tor</string>
+    <string name="tor_control_title_connected_force">Conectado a Tor (Modo forzado)</string>
+    <string name="tor_control_subtitle_connected">Tu conexión es privada y anónima</string>
+    <string name="tor_control_subtitle_connected_force">Desconecta vía Orbot o desactiva Forzar Tor en ajustes</string>
+    <string name="tor_control_title_error">Conexión fallida</string>
+    <string name="tor_control_subtitle_error">No se pudo conectar a la red Tor</string>
+    <string name="tor_control_title_orbot_required">Orbot requerido</string>
+    <string name="tor_control_subtitle_orbot_required">Instala Orbot para conectarte a la red Tor</string>
+    <string name="tor_control_button_connecting">Conectando...</string>
+    <string name="tor_control_button_disconnect">Desconectar</string>
+    <string name="tor_control_button_cancel">Cancelar</string>
+    <string name="tor_control_button_retry">Reintentar conexión</string>
+    <string name="tor_control_button_install">Instalar Orbot</string>
+    <string name="tor_control_button_open_orbot">Abrir Orbot</string>
 
 
     <!-- Add/Edit Radio Dialog -->

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -263,13 +263,13 @@
     <string name="tor_open_orbot">Abrir Orbot</string>
 
     <!-- Tor Status Messages -->
-    <string name="tor_status_connecting">Connecting...</string>
-    <string name="tor_status_connected">Tor Connected</string>
-    <string name="tor_status_disconnected">Tor Disconnected</string>
-    <string name="tor_status_off">Tor Off</string>
-    <string name="tor_status_error">Tor Error</string>
-    <string name="tor_status_leak_warning">Leak Warning</string>
-    <string name="tor_status_install_orbot">Install Orbot</string>
+    <string name="tor_status_connecting">Conectando...</string>
+    <string name="tor_status_connected">Tor conectado</string>
+    <string name="tor_status_disconnected">Tor desconectado</string>
+    <string name="tor_status_off">Tor desligado</string>
+    <string name="tor_status_error">Erro do Tor</string>
+    <string name="tor_status_leak_warning">Aviso de vazamento</string>
+    <string name="tor_status_install_orbot">Instalar Orbot</string>
 
     <!-- Tor Status ContentDescriptions (for accessibility) -->
     <string name="tor_status_off_description">Tor está desconectado. Toque para conectar.</string>
@@ -280,26 +280,26 @@
     <string name="tor_status_install_orbot_description">Orbot não está instalado. Toque para instalar.</string>
     <string name="tor_status_leak_warning_description">Modo Tor forçado está ativado mas não conectado. A privacidade pode estar comprometida.</string>
 
-    <string name="tor_status_connecting_message">Connecting to Tor...</string>
-    <string name="tor_status_connected_message">Connected via Tor</string>
-    <string name="tor_control_title_stopped">Tor Disconnected</string>
-    <string name="tor_control_subtitle_stopped">Tap Connect to browse anonymously via Tor</string>
-    <string name="tor_control_subtitle_connecting">Establishing secure connection via Orbot</string>
-    <string name="tor_control_title_connecting">Connecting to Tor...</string>
-    <string name="tor_control_title_connected">Connected to Tor</string>
-    <string name="tor_control_title_connected_force">Connected to Tor (Force Mode)</string>
-    <string name="tor_control_subtitle_connected">Your connection is private and anonymous</string>
-    <string name="tor_control_subtitle_connected_force">Disconnect via Orbot or disable Force Tor in settings</string>
-    <string name="tor_control_title_error">Connection Failed</string>
-    <string name="tor_control_subtitle_error">Could not connect to Tor network</string>
-    <string name="tor_control_title_orbot_required">Orbot Required</string>
-    <string name="tor_control_subtitle_orbot_required">Install Orbot to connect to the Tor network</string>
-    <string name="tor_control_button_connecting">Connecting...</string>
-    <string name="tor_control_button_disconnect">Disconnect</string>
-    <string name="tor_control_button_cancel">Cancel</string>
-    <string name="tor_control_button_retry">Retry Connection</string>
-    <string name="tor_control_button_install">Install Orbot</string>
-    <string name="tor_control_button_open_orbot">Open Orbot</string>
+    <string name="tor_status_connecting_message">Conectando ao Tor...</string>
+    <string name="tor_status_connected_message">Conectado via Tor</string>
+    <string name="tor_control_title_stopped">Tor desconectado</string>
+    <string name="tor_control_subtitle_stopped">Toque em Conectar para navegar anonimamente via Tor</string>
+    <string name="tor_control_subtitle_connecting">Estabelecendo conexão segura via Orbot</string>
+    <string name="tor_control_title_connecting">Conectando ao Tor...</string>
+    <string name="tor_control_title_connected">Conectado ao Tor</string>
+    <string name="tor_control_title_connected_force">Conectado ao Tor (Modo Forçado)</string>
+    <string name="tor_control_subtitle_connected">Sua conexão é privada e anônima</string>
+    <string name="tor_control_subtitle_connected_force">Desconecte via Orbot ou desative Forçar Tor nas configurações</string>
+    <string name="tor_control_title_error">Conexão falhou</string>
+    <string name="tor_control_subtitle_error">Não foi possível conectar à rede Tor</string>
+    <string name="tor_control_title_orbot_required">Orbot necessário</string>
+    <string name="tor_control_subtitle_orbot_required">Instale o Orbot para conectar à rede Tor</string>
+    <string name="tor_control_button_connecting">Conectando...</string>
+    <string name="tor_control_button_disconnect">Desconectar</string>
+    <string name="tor_control_button_cancel">Cancelar</string>
+    <string name="tor_control_button_retry">Tentar novamente</string>
+    <string name="tor_control_button_install">Instalar Orbot</string>
+    <string name="tor_control_button_open_orbot">Abrir Orbot</string>
 
 
     <!-- Add/Edit Radio Dialog -->


### PR DESCRIPTION
- Translate all Tor status messages and UI strings in values-de/strings.xml
- Translate all Tor status messages and UI strings in values-es/strings.xml
- Translate all Tor status messages and UI strings in values-pt/strings.xml
- Makes the "Tor connected" status indicator and bottom sheet translatable in all languages