### PR TITLE
Fix background state loss: persist currently playing station

### DIFF
--- a/app/src/main/java/com/opensource/i2pradio/MainActivity.kt
+++ b/app/src/main/java/com/opensource/i2pradio/MainActivity.kt
@@ -125,6 +125,19 @@ class MainActivity : AppCompatActivity() {
             radioService?.let { service ->
                 viewModel.setPlaying(service.isPlaying())
                 viewModel.setBuffering(service.isBuffering())
+
+                // Restore currently playing station from persistent storage if ViewModel has no station
+                // This handles the case where MainActivity was destroyed while audio was playing in background
+                if (viewModel.getCurrentStation() == null) {
+                    val savedStation = PreferencesHelper.getCurrentStation(this@MainActivity)
+                    if (savedStation != null) {
+                        // Only restore if service is actually playing or buffering
+                        // This prevents showing stale station info when nothing is playing
+                        if (service.isPlaying() || service.isBuffering()) {
+                            viewModel.setCurrentStation(savedStation)
+                        }
+                    }
+                }
             }
         }
 

--- a/app/src/main/java/com/opensource/i2pradio/ui/RadioViewModel.kt
+++ b/app/src/main/java/com/opensource/i2pradio/ui/RadioViewModel.kt
@@ -52,6 +52,10 @@ class RadioViewModel(application: Application) : AndroidViewModel(application) {
         val previousStation = _currentStation.value
         _currentStation.value = station
 
+        // Persist the current station to SharedPreferences
+        // This ensures the UI can restore the station when MainActivity is recreated
+        PreferencesHelper.saveCurrentStation(getApplication(), station)
+
         // Stop recording if station is cleared
         if (station == null && _recordingState.value?.isRecording == true) {
             stopRecording()
@@ -122,7 +126,10 @@ class RadioViewModel(application: Application) : AndroidViewModel(application) {
     fun updateCurrentStationLikeState(isLiked: Boolean) {
         _currentStation.value?.let { station ->
             // Create a copy with updated like state
-            _currentStation.value = station.copy(isLiked = isLiked)
+            val updatedStation = station.copy(isLiked = isLiked)
+            _currentStation.value = updatedStation
+            // Persist the updated station
+            PreferencesHelper.saveCurrentStation(getApplication(), updatedStation)
         }
     }
 
@@ -134,7 +141,10 @@ class RadioViewModel(application: Application) : AndroidViewModel(application) {
         // Update the current station's cover art if it matches
         _currentStation.value?.let { station ->
             if (stationId == -1L || station.id == stationId) {
-                _currentStation.value = station.copy(coverArtUri = coverArtUri)
+                val updatedStation = station.copy(coverArtUri = coverArtUri)
+                _currentStation.value = updatedStation
+                // Persist the updated station
+                PreferencesHelper.saveCurrentStation(getApplication(), updatedStation)
             }
         }
         // Trigger cover art update event for all observers


### PR DESCRIPTION
Fixes the bug where the app forgets which station is playing after being in the background for a while and then returning to the app.

Changes:
1. Added PreferencesHelper.saveCurrentStation() and getCurrentStation() methods to persist RadioStation to SharedPreferences as JSON

2. Updated RadioViewModel to automatically persist the current station whenever it changes (setCurrentStation, updateCoverArt, updateCurrentStationLikeState)

3. Updated MainActivity.onServiceConnected() to restore the currently playing station from SharedPreferences when the activity is recreated and the service is still playing

This ensures that when MainActivity is destroyed (due to configuration changes, memory pressure, or backgrounding) and then recreated, the UI can restore the full station information even though the RadioService continues playing in the background.

The fix handles:
- Background art restoration
- Station name and metadata
- Like button state
- All proxy configuration
- Now Playing screen functionality