### PR TITLE
Add Classic theme matching app icon colors as new default

### DIFF
--- a/app/src/main/res/values-night/themes.xml
+++ b/app/src/main/res/values-night/themes.xml
@@ -1,40 +1,40 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <!-- Base Dark Theme -->
+    <!-- Base Dark Theme - Classic (Default) -->
     <style name="Base.Theme.I2PRadio" parent="Theme.Material3.Dark.NoActionBar">
-        <!-- Changed from Theme.Material3.Dark to Theme.Material3.Dark.NoActionBar -->
-        <item name="colorPrimary">@color/md_theme_dark_primary</item>
-        <item name="colorOnPrimary">@color/md_theme_dark_onPrimary</item>
-        <item name="colorPrimaryContainer">@color/md_theme_dark_primaryContainer</item>
-        <item name="colorOnPrimaryContainer">@color/md_theme_dark_onPrimaryContainer</item>
-        <item name="colorSecondary">@color/md_theme_dark_secondary</item>
-        <item name="colorOnSecondary">@color/md_theme_dark_onSecondary</item>
-        <item name="colorSecondaryContainer">@color/md_theme_dark_secondaryContainer</item>
-        <item name="colorOnSecondaryContainer">@color/md_theme_dark_onSecondaryContainer</item>
-        <item name="colorTertiary">@color/md_theme_dark_tertiary</item>
-        <item name="colorOnTertiary">@color/md_theme_dark_onTertiary</item>
-        <item name="colorTertiaryContainer">@color/md_theme_dark_tertiaryContainer</item>
-        <item name="colorOnTertiaryContainer">@color/md_theme_dark_onTertiaryContainer</item>
-        <item name="colorError">@color/md_theme_dark_error</item>
-        <item name="colorErrorContainer">@color/md_theme_dark_errorContainer</item>
-        <item name="colorOnError">@color/md_theme_dark_onError</item>
-        <item name="colorOnErrorContainer">@color/md_theme_dark_onErrorContainer</item>
-        <item name="android:colorBackground">@color/md_theme_dark_background</item>
-        <item name="colorOnBackground">@color/md_theme_dark_onBackground</item>
-        <item name="colorSurface">@color/md_theme_dark_surface</item>
-        <item name="colorOnSurface">@color/md_theme_dark_onSurface</item>
-        <item name="colorSurfaceVariant">@color/md_theme_dark_surfaceVariant</item>
-        <item name="colorOnSurfaceVariant">@color/md_theme_dark_onSurfaceVariant</item>
-        <item name="colorOutline">@color/md_theme_dark_outline</item>
-        <item name="colorOutlineVariant">@color/md_theme_dark_outlineVariant</item>
-        <item name="colorSurfaceInverse">@color/md_theme_dark_inverseSurface</item>
-        <item name="colorOnSurfaceInverse">@color/md_theme_dark_inverseOnSurface</item>
-        <item name="colorPrimaryInverse">@color/md_theme_dark_inversePrimary</item>
+        <!-- Classic dark theme matching app icon colors (#1d1d1d and #f5f0e6) -->
+        <item name="colorPrimary">@color/md_theme_classic_dark_primary</item>
+        <item name="colorOnPrimary">@color/md_theme_classic_dark_onPrimary</item>
+        <item name="colorPrimaryContainer">@color/md_theme_classic_dark_primaryContainer</item>
+        <item name="colorOnPrimaryContainer">@color/md_theme_classic_dark_onPrimaryContainer</item>
+        <item name="colorSecondary">@color/md_theme_classic_dark_secondary</item>
+        <item name="colorOnSecondary">@color/md_theme_classic_dark_onSecondary</item>
+        <item name="colorSecondaryContainer">@color/md_theme_classic_dark_secondaryContainer</item>
+        <item name="colorOnSecondaryContainer">@color/md_theme_classic_dark_onSecondaryContainer</item>
+        <item name="colorTertiary">@color/md_theme_classic_dark_tertiary</item>
+        <item name="colorOnTertiary">@color/md_theme_classic_dark_onTertiary</item>
+        <item name="colorTertiaryContainer">@color/md_theme_classic_dark_tertiaryContainer</item>
+        <item name="colorOnTertiaryContainer">@color/md_theme_classic_dark_onTertiaryContainer</item>
+        <item name="colorError">@color/md_theme_classic_dark_error</item>
+        <item name="colorErrorContainer">@color/md_theme_classic_dark_errorContainer</item>
+        <item name="colorOnError">@color/md_theme_classic_dark_onError</item>
+        <item name="colorOnErrorContainer">@color/md_theme_classic_dark_onErrorContainer</item>
+        <item name="android:colorBackground">@color/md_theme_classic_dark_background</item>
+        <item name="colorOnBackground">@color/md_theme_classic_dark_onBackground</item>
+        <item name="colorSurface">@color/md_theme_classic_dark_surface</item>
+        <item name="colorOnSurface">@color/md_theme_classic_dark_onSurface</item>
+        <item name="colorSurfaceVariant">@color/md_theme_classic_dark_surfaceVariant</item>
+        <item name="colorOnSurfaceVariant">@color/md_theme_classic_dark_onSurfaceVariant</item>
+        <item name="colorOutline">@color/md_theme_classic_dark_outline</item>
+        <item name="colorOutlineVariant">@color/md_theme_classic_dark_outlineVariant</item>
+        <item name="colorSurfaceInverse">@color/md_theme_classic_dark_inverseSurface</item>
+        <item name="colorOnSurfaceInverse">@color/md_theme_classic_dark_inverseOnSurface</item>
+        <item name="colorPrimaryInverse">@color/md_theme_classic_dark_inversePrimary</item>
         <!-- Surface Container Colors -->
-        <item name="colorSurfaceContainer">@color/md_theme_dark_surfaceContainer</item>
-        <item name="colorSurfaceContainerLow">@color/md_theme_dark_surfaceContainerLow</item>
-        <item name="colorSurfaceContainerHigh">@color/md_theme_dark_surfaceContainerHigh</item>
-        <item name="colorSurfaceContainerHighest">@color/md_theme_dark_surfaceContainerHighest</item>
+        <item name="colorSurfaceContainer">@color/md_theme_classic_dark_surfaceContainer</item>
+        <item name="colorSurfaceContainerLow">@color/md_theme_classic_dark_surfaceContainerLow</item>
+        <item name="colorSurfaceContainerHigh">@color/md_theme_classic_dark_surfaceContainerHigh</item>
+        <item name="colorSurfaceContainerHighest">@color/md_theme_classic_dark_surfaceContainerHighest</item>
     </style>
 
     <!-- Peach Color Scheme Theme - Dark -->
@@ -83,5 +83,17 @@
         <item name="colorOnSecondary">@color/md_theme_orange_dark_onSecondary</item>
         <item name="colorSecondaryContainer">@color/md_theme_orange_dark_secondaryContainer</item>
         <item name="colorOnSecondaryContainer">@color/md_theme_orange_dark_onSecondaryContainer</item>
+    </style>
+
+    <!-- Blue Color Scheme Theme - Dark -->
+    <style name="Theme.I2PRadio.Blue" parent="Base.Theme.I2PRadio">
+        <item name="colorPrimary">@color/md_theme_blue_dark_primary</item>
+        <item name="colorOnPrimary">@color/md_theme_blue_dark_onPrimary</item>
+        <item name="colorPrimaryContainer">@color/md_theme_blue_dark_primaryContainer</item>
+        <item name="colorOnPrimaryContainer">@color/md_theme_blue_dark_onPrimaryContainer</item>
+        <item name="colorSecondary">@color/md_theme_blue_dark_secondary</item>
+        <item name="colorOnSecondary">@color/md_theme_blue_dark_onSecondary</item>
+        <item name="colorSecondaryContainer">@color/md_theme_blue_dark_secondaryContainer</item>
+        <item name="colorOnSecondaryContainer">@color/md_theme_blue_dark_onSecondaryContainer</item>
     </style>
 </resources>

--- a/app/src/main/res/values/colors_blue.xml
+++ b/app/src/main/res/values/colors_blue.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Blue Theme - Original Default Colors -->
+
+    <!-- Light Theme Colors -->
+    <color name="md_theme_blue_light_primary">#0061A4</color>
+    <color name="md_theme_blue_light_onPrimary">#FFFFFF</color>
+    <color name="md_theme_blue_light_primaryContainer">#D1E4FF</color>
+    <color name="md_theme_blue_light_onPrimaryContainer">#001D36</color>
+    <color name="md_theme_blue_light_secondary">#535F70</color>
+    <color name="md_theme_blue_light_onSecondary">#FFFFFF</color>
+    <color name="md_theme_blue_light_secondaryContainer">#D7E3F7</color>
+    <color name="md_theme_blue_light_onSecondaryContainer">#101C2B</color>
+
+    <!-- Dark Theme Colors -->
+    <color name="md_theme_blue_dark_primary">#9ECAFF</color>
+    <color name="md_theme_blue_dark_onPrimary">#003258</color>
+    <color name="md_theme_blue_dark_primaryContainer">#00497D</color>
+    <color name="md_theme_blue_dark_onPrimaryContainer">#D1E4FF</color>
+    <color name="md_theme_blue_dark_secondary">#BBC7DB</color>
+    <color name="md_theme_blue_dark_onSecondary">#253140</color>
+    <color name="md_theme_blue_dark_secondaryContainer">#3B4858</color>
+    <color name="md_theme_blue_dark_onSecondaryContainer">#D7E3F7</color>
+</resources>

--- a/app/src/main/res/values/colors_classic.xml
+++ b/app/src/main/res/values/colors_classic.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Classic Theme - Matching App Icon Colors (#1d1d1d and #f5f0e6) -->
+
+    <!-- Light Theme Colors -->
+    <color name="md_theme_classic_light_primary">#5C5C5C</color>
+    <color name="md_theme_classic_light_onPrimary">#FFFFFF</color>
+    <color name="md_theme_classic_light_primaryContainer">#E0E0E0</color>
+    <color name="md_theme_classic_light_onPrimaryContainer">#1d1d1d</color>
+    <color name="md_theme_classic_light_secondary">#625B57</color>
+    <color name="md_theme_classic_light_onSecondary">#FFFFFF</color>
+    <color name="md_theme_classic_light_secondaryContainer">#E8E1DC</color>
+    <color name="md_theme_classic_light_onSecondaryContainer">#1F1B18</color>
+    <color name="md_theme_classic_light_tertiary">#635B4E</color>
+    <color name="md_theme_classic_light_onTertiary">#FFFFFF</color>
+    <color name="md_theme_classic_light_tertiaryContainer">#EBE2D4</color>
+    <color name="md_theme_classic_light_onTertiaryContainer">#1F1B10</color>
+    <color name="md_theme_classic_light_error">#BA1A1A</color>
+    <color name="md_theme_classic_light_errorContainer">#FFDAD6</color>
+    <color name="md_theme_classic_light_onError">#FFFFFF</color>
+    <color name="md_theme_classic_light_onErrorContainer">#410002</color>
+    <color name="md_theme_classic_light_background">#f5f0e6</color>
+    <color name="md_theme_classic_light_onBackground">#1d1d1d</color>
+    <color name="md_theme_classic_light_surface">#f5f0e6</color>
+    <color name="md_theme_classic_light_onSurface">#1d1d1d</color>
+    <color name="md_theme_classic_light_surfaceVariant">#E7E2D9</color>
+    <color name="md_theme_classic_light_onSurfaceVariant">#4A4541</color>
+    <color name="md_theme_classic_light_outline">#7B7571</color>
+    <color name="md_theme_classic_light_inverseOnSurface">#f5f0e6</color>
+    <color name="md_theme_classic_light_inverseSurface">#323031</color>
+    <color name="md_theme_classic_light_inversePrimary">#C4C4C4</color>
+    <color name="md_theme_classic_light_shadow">#000000</color>
+    <color name="md_theme_classic_light_surfaceTint">#5C5C5C</color>
+    <color name="md_theme_classic_light_outlineVariant">#CBC6BD</color>
+    <color name="md_theme_classic_light_scrim">#000000</color>
+    <!-- Surface Container Colors (Material 3) -->
+    <color name="md_theme_classic_light_surfaceContainer">#EEEADF</color>
+    <color name="md_theme_classic_light_surfaceContainerLow">#F3EEE4</color>
+    <color name="md_theme_classic_light_surfaceContainerHigh">#E8E4DA</color>
+    <color name="md_theme_classic_light_surfaceContainerHighest">#E2DED4</color>
+
+    <!-- Dark Theme Colors -->
+    <color name="md_theme_classic_dark_primary">#C4C4C4</color>
+    <color name="md_theme_classic_dark_onPrimary">#2E2E2E</color>
+    <color name="md_theme_classic_dark_primaryContainer">#454545</color>
+    <color name="md_theme_classic_dark_onPrimaryContainer">#E0E0E0</color>
+    <color name="md_theme_classic_dark_secondary">#CCC5C0</color>
+    <color name="md_theme_classic_dark_onSecondary">#33302D</color>
+    <color name="md_theme_classic_dark_secondaryContainer">#4A4643</color>
+    <color name="md_theme_classic_dark_onSecondaryContainer">#E8E1DC</color>
+    <color name="md_theme_classic_dark_tertiary">#CFC6B8</color>
+    <color name="md_theme_classic_dark_onTertiary">#353026</color>
+    <color name="md_theme_classic_dark_tertiaryContainer">#4C463A</color>
+    <color name="md_theme_classic_dark_onTertiaryContainer">#EBE2D4</color>
+    <color name="md_theme_classic_dark_error">#FFB4AB</color>
+    <color name="md_theme_classic_dark_errorContainer">#93000A</color>
+    <color name="md_theme_classic_dark_onError">#690005</color>
+    <color name="md_theme_classic_dark_onErrorContainer">#FFDAD6</color>
+    <color name="md_theme_classic_dark_background">#1d1d1d</color>
+    <color name="md_theme_classic_dark_onBackground">#E6E1D8</color>
+    <color name="md_theme_classic_dark_surface">#1d1d1d</color>
+    <color name="md_theme_classic_dark_onSurface">#E6E1D8</color>
+    <color name="md_theme_classic_dark_surfaceVariant">#4A4541</color>
+    <color name="md_theme_classic_dark_onSurfaceVariant">#CBC6BD</color>
+    <color name="md_theme_classic_dark_outline">#95908B</color>
+    <color name="md_theme_classic_dark_inverseOnSurface">#1d1d1d</color>
+    <color name="md_theme_classic_dark_inverseSurface">#E6E1D8</color>
+    <color name="md_theme_classic_dark_inversePrimary">#5C5C5C</color>
+    <color name="md_theme_classic_dark_shadow">#000000</color>
+    <color name="md_theme_classic_dark_surfaceTint">#C4C4C4</color>
+    <color name="md_theme_classic_dark_outlineVariant">#4A4541</color>
+    <color name="md_theme_classic_dark_scrim">#000000</color>
+    <!-- Surface Container Colors (Material 3) -->
+    <color name="md_theme_classic_dark_surfaceContainer">#252423</color>
+    <color name="md_theme_classic_dark_surfaceContainerLow">#1d1d1d</color>
+    <color name="md_theme_classic_dark_surfaceContainerHigh">#2F2E2D</color>
+    <color name="md_theme_classic_dark_surfaceContainerHighest">#3A3938</color>
+</resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,40 +1,40 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <!-- Base Light Theme -->
+    <!-- Base Light Theme - Classic (Default) -->
     <style name="Base.Theme.I2PRadio" parent="Theme.Material3.Light.NoActionBar">
-        <!-- Changed from Theme.Material3.Light to Theme.Material3.Light.NoActionBar -->
-        <item name="colorPrimary">@color/md_theme_light_primary</item>
-        <item name="colorOnPrimary">@color/md_theme_light_onPrimary</item>
-        <item name="colorPrimaryContainer">@color/md_theme_light_primaryContainer</item>
-        <item name="colorOnPrimaryContainer">@color/md_theme_light_onPrimaryContainer</item>
-        <item name="colorSecondary">@color/md_theme_light_secondary</item>
-        <item name="colorOnSecondary">@color/md_theme_light_onSecondary</item>
-        <item name="colorSecondaryContainer">@color/md_theme_light_secondaryContainer</item>
-        <item name="colorOnSecondaryContainer">@color/md_theme_light_onSecondaryContainer</item>
-        <item name="colorTertiary">@color/md_theme_light_tertiary</item>
-        <item name="colorOnTertiary">@color/md_theme_light_onTertiary</item>
-        <item name="colorTertiaryContainer">@color/md_theme_light_tertiaryContainer</item>
-        <item name="colorOnTertiaryContainer">@color/md_theme_light_onTertiaryContainer</item>
-        <item name="colorError">@color/md_theme_light_error</item>
-        <item name="colorErrorContainer">@color/md_theme_light_errorContainer</item>
-        <item name="colorOnError">@color/md_theme_light_onError</item>
-        <item name="colorOnErrorContainer">@color/md_theme_light_onErrorContainer</item>
-        <item name="android:colorBackground">@color/md_theme_light_background</item>
-        <item name="colorOnBackground">@color/md_theme_light_onBackground</item>
-        <item name="colorSurface">@color/md_theme_light_surface</item>
-        <item name="colorOnSurface">@color/md_theme_light_onSurface</item>
-        <item name="colorSurfaceVariant">@color/md_theme_light_surfaceVariant</item>
-        <item name="colorOnSurfaceVariant">@color/md_theme_light_onSurfaceVariant</item>
-        <item name="colorOutline">@color/md_theme_light_outline</item>
-        <item name="colorOutlineVariant">@color/md_theme_light_outlineVariant</item>
-        <item name="colorSurfaceInverse">@color/md_theme_light_inverseSurface</item>
-        <item name="colorOnSurfaceInverse">@color/md_theme_light_inverseOnSurface</item>
-        <item name="colorPrimaryInverse">@color/md_theme_light_inversePrimary</item>
+        <!-- Classic theme matching app icon colors (#1d1d1d and #f5f0e6) -->
+        <item name="colorPrimary">@color/md_theme_classic_light_primary</item>
+        <item name="colorOnPrimary">@color/md_theme_classic_light_onPrimary</item>
+        <item name="colorPrimaryContainer">@color/md_theme_classic_light_primaryContainer</item>
+        <item name="colorOnPrimaryContainer">@color/md_theme_classic_light_onPrimaryContainer</item>
+        <item name="colorSecondary">@color/md_theme_classic_light_secondary</item>
+        <item name="colorOnSecondary">@color/md_theme_classic_light_onSecondary</item>
+        <item name="colorSecondaryContainer">@color/md_theme_classic_light_secondaryContainer</item>
+        <item name="colorOnSecondaryContainer">@color/md_theme_classic_light_onSecondaryContainer</item>
+        <item name="colorTertiary">@color/md_theme_classic_light_tertiary</item>
+        <item name="colorOnTertiary">@color/md_theme_classic_light_onTertiary</item>
+        <item name="colorTertiaryContainer">@color/md_theme_classic_light_tertiaryContainer</item>
+        <item name="colorOnTertiaryContainer">@color/md_theme_classic_light_onTertiaryContainer</item>
+        <item name="colorError">@color/md_theme_classic_light_error</item>
+        <item name="colorErrorContainer">@color/md_theme_classic_light_errorContainer</item>
+        <item name="colorOnError">@color/md_theme_classic_light_onError</item>
+        <item name="colorOnErrorContainer">@color/md_theme_classic_light_onErrorContainer</item>
+        <item name="android:colorBackground">@color/md_theme_classic_light_background</item>
+        <item name="colorOnBackground">@color/md_theme_classic_light_onBackground</item>
+        <item name="colorSurface">@color/md_theme_classic_light_surface</item>
+        <item name="colorOnSurface">@color/md_theme_classic_light_onSurface</item>
+        <item name="colorSurfaceVariant">@color/md_theme_classic_light_surfaceVariant</item>
+        <item name="colorOnSurfaceVariant">@color/md_theme_classic_light_onSurfaceVariant</item>
+        <item name="colorOutline">@color/md_theme_classic_light_outline</item>
+        <item name="colorOutlineVariant">@color/md_theme_classic_light_outlineVariant</item>
+        <item name="colorSurfaceInverse">@color/md_theme_classic_light_inverseSurface</item>
+        <item name="colorOnSurfaceInverse">@color/md_theme_classic_light_inverseOnSurface</item>
+        <item name="colorPrimaryInverse">@color/md_theme_classic_light_inversePrimary</item>
         <!-- Surface Container Colors -->
-        <item name="colorSurfaceContainer">@color/md_theme_light_surfaceContainer</item>
-        <item name="colorSurfaceContainerLow">@color/md_theme_light_surfaceContainerLow</item>
-        <item name="colorSurfaceContainerHigh">@color/md_theme_light_surfaceContainerHigh</item>
-        <item name="colorSurfaceContainerHighest">@color/md_theme_light_surfaceContainerHighest</item>
+        <item name="colorSurfaceContainer">@color/md_theme_classic_light_surfaceContainer</item>
+        <item name="colorSurfaceContainerLow">@color/md_theme_classic_light_surfaceContainerLow</item>
+        <item name="colorSurfaceContainerHigh">@color/md_theme_classic_light_surfaceContainerHigh</item>
+        <item name="colorSurfaceContainerHighest">@color/md_theme_classic_light_surfaceContainerHighest</item>
     </style>
 
     <style name="Theme.I2PRadio" parent="Base.Theme.I2PRadio" />
@@ -85,6 +85,18 @@
         <item name="colorOnSecondary">@color/md_theme_orange_light_onSecondary</item>
         <item name="colorSecondaryContainer">@color/md_theme_orange_light_secondaryContainer</item>
         <item name="colorOnSecondaryContainer">@color/md_theme_orange_light_onSecondaryContainer</item>
+    </style>
+
+    <!-- Blue Color Scheme Theme -->
+    <style name="Theme.I2PRadio.Blue" parent="Base.Theme.I2PRadio">
+        <item name="colorPrimary">@color/md_theme_blue_light_primary</item>
+        <item name="colorOnPrimary">@color/md_theme_blue_light_onPrimary</item>
+        <item name="colorPrimaryContainer">@color/md_theme_blue_light_primaryContainer</item>
+        <item name="colorOnPrimaryContainer">@color/md_theme_blue_light_onPrimaryContainer</item>
+        <item name="colorSecondary">@color/md_theme_blue_light_secondary</item>
+        <item name="colorOnSecondary">@color/md_theme_blue_light_onSecondary</item>
+        <item name="colorSecondaryContainer">@color/md_theme_blue_light_secondaryContainer</item>
+        <item name="colorOnSecondaryContainer">@color/md_theme_blue_light_onSecondaryContainer</item>
     </style>
 
     <!-- Mini Player rounded top corners -->


### PR DESCRIPTION
- Create Classic theme using app icon colors (#1d1d1d and #f5f0e6)
- Make Classic the default theme for better visual consistency
- Preserve original blue theme as Theme.I2PRadio.Blue variant
- Update both light and dark theme configurations
- Maintain all existing color scheme options (Peach, Green, Purple, Orange)

The Classic theme provides a neutral, professional appearance that matches the app icon, creating a more cohesive user experience.