### PR TITLE
Optimize app lock performance: skip SQLCipher overhead when encryptio…

### DIFF
--- a/app/src/main/java/com/opensource/i2pradio/AuthenticationActivity.kt
+++ b/app/src/main/java/com/opensource/i2pradio/AuthenticationActivity.kt
@@ -85,12 +85,14 @@ class AuthenticationActivity : AppCompatActivity() {
         }
 
         if (BiometricAuthManager.verifyPassword(this, password)) {
-            // Set session password for database decryption
-            // SECURITY: Convert to CharArray for secure memory handling
-            val passwordChars = password.toCharArray()
-            com.opensource.i2pradio.data.RadioDatabase.setSessionPassword(passwordChars)
-            // Zero out local CharArray copy (RadioDatabase made its own copy)
-            passwordChars.fill(0.toChar())
+            // Set session password for database decryption (only if encryption is enabled)
+            if (com.opensource.i2pradio.utils.DatabaseEncryptionManager.isDatabaseEncryptionEnabled(this)) {
+                // SECURITY: Convert to CharArray for secure memory handling
+                val passwordChars = password.toCharArray()
+                com.opensource.i2pradio.data.RadioDatabase.setSessionPassword(passwordChars)
+                // Zero out local CharArray copy (RadioDatabase made its own copy)
+                passwordChars.fill(0.toChar())
+            }
             unlockSuccess()
         } else {
             showError(getString(R.string.auth_error_wrong_password))

--- a/app/src/main/java/com/opensource/i2pradio/data/RadioDatabase.kt
+++ b/app/src/main/java/com/opensource/i2pradio/data/RadioDatabase.kt
@@ -209,11 +209,11 @@ abstract class RadioDatabase : RoomDatabase() {
             return synchronized(this) {
                 // Check again inside synchronized block - another thread might have initialized it
                 INSTANCE ?: run {
-                    // Initialize SQLCipher
-                    DatabaseEncryptionManager.initializeSQLCipher(context)
-
                     // Get SupportFactory for encryption (null if encryption disabled or no password set)
                     val supportFactory = if (DatabaseEncryptionManager.isDatabaseEncryptionEnabled(context)) {
+                        // Initialize SQLCipher only when encryption is enabled
+                        DatabaseEncryptionManager.initializeSQLCipher(context)
+
                         val password = sessionPassword
                             ?: throw IllegalStateException(
                                 "Database encryption is enabled but session password not set. " +


### PR DESCRIPTION
…n disabled

Before this change, app lock was slow even with database encryption disabled because SQLCipher native libraries were being loaded on every database access.

Changes:
1. RadioDatabase: Only initialize SQLCipher when encryption is enabled
2. AuthenticationActivity: Only set session password when encryption enabled
3. DatabaseEncryptionManager: Make initializeSQLCipher() idempotent to prevent repeated library loads even when encryption is enabled

This restores fast app lock unlock times when database encryption is off, while maintaining full SQLCipher performance when encryption is enabled.

Files modified:
- app/src/main/java/com/opensource/i2pradio/data/RadioDatabase.kt
- app/src/main/java/com/opensource/i2pradio/AuthenticationActivity.kt
- app/src/main/java/com/opensource/i2pradio/utils/DatabaseEncryptionManager.kt