### PR TITLE
Fix theme color selection: add Classic as default and restore Blue op…

### DIFF
--- a/app/src/main/java/com/opensource/i2pradio/MainActivity.kt
+++ b/app/src/main/java/com/opensource/i2pradio/MainActivity.kt
@@ -188,11 +188,13 @@ class MainActivity : AppCompatActivity() {
             // Apply custom color scheme based on user preference
             val colorScheme = PreferencesHelper.getColorScheme(this)
             val themeResId = when (colorScheme) {
+                "classic" -> R.style.Theme_I2PRadio // Classic theme (default)
+                "blue" -> R.style.Theme_I2PRadio_Blue
                 "peach" -> R.style.Theme_I2PRadio_Peach
                 "green" -> R.style.Theme_I2PRadio_Green
                 "purple" -> R.style.Theme_I2PRadio_Purple
                 "orange" -> R.style.Theme_I2PRadio_Orange
-                else -> R.style.Theme_I2PRadio // default blue
+                else -> R.style.Theme_I2PRadio // default to Classic for backward compatibility
             }
             setTheme(themeResId)
         } else {

--- a/app/src/main/java/com/opensource/i2pradio/ui/SettingsFragment.kt
+++ b/app/src/main/java/com/opensource/i2pradio/ui/SettingsFragment.kt
@@ -1070,24 +1070,31 @@ class SettingsFragment : Fragment() {
     private fun updateColorSchemeButtonText(button: MaterialButton) {
         val currentScheme = PreferencesHelper.getColorScheme(requireContext())
         button.text = when (currentScheme) {
+            "classic" -> getString(R.string.settings_color_classic)
+            "blue" -> getString(R.string.settings_color_blue)
             "peach" -> getString(R.string.settings_color_peach)
             "green" -> getString(R.string.settings_color_green)
             "purple" -> getString(R.string.settings_color_purple)
             "orange" -> getString(R.string.settings_color_orange)
-            else -> getString(R.string.settings_color_blue)
+            else -> getString(R.string.settings_color_classic) // default to Classic for backward compatibility
         }
     }
 
     private fun showColorSchemeDialog(colorSchemeButton: MaterialButton) {
         val schemes = arrayOf(
-            getString(R.string.settings_color_blue_default),
+            getString(R.string.settings_color_classic_default),
+            getString(R.string.settings_color_blue),
             getString(R.string.settings_color_peach),
             getString(R.string.settings_color_green),
             getString(R.string.settings_color_purple),
             getString(R.string.settings_color_orange)
         )
-        val schemeValues = arrayOf("default", "peach", "green", "purple", "orange")
-        val currentScheme = PreferencesHelper.getColorScheme(requireContext())
+        val schemeValues = arrayOf("classic", "blue", "peach", "green", "purple", "orange")
+        var currentScheme = PreferencesHelper.getColorScheme(requireContext())
+        // Migrate "default" to "classic" for backward compatibility
+        if (currentScheme == "default") {
+            currentScheme = "classic"
+        }
         val selectedIndex = schemeValues.indexOf(currentScheme).coerceAtLeast(0)
 
         AlertDialog.Builder(requireContext())

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -150,8 +150,9 @@
     <string name="settings_material_you_description">Use wallpaper-based dynamic colors</string>
     <string name="settings_color_scheme">Color Scheme</string>
     <string name="settings_color_scheme_description">Choose your preferred color</string>
+    <string name="settings_color_classic">Classic</string>
+    <string name="settings_color_classic_default">Classic (Default)</string>
     <string name="settings_color_blue">Blue</string>
-    <string name="settings_color_blue_default">Blue (Default)</string>
     <string name="settings_color_peach">Peach</string>
     <string name="settings_color_green">Green</string>
     <string name="settings_color_purple">Purple</string>


### PR DESCRIPTION
…tion

This fix addresses the theme selection bug where:
- The app was using Classic theme but displaying "Blue (Default)" in settings
- Users had no way to switch to the Blue theme
- The Classic theme wasn't explicitly selectable

Changes:
- Add "Classic" and "Classic (Default)" string resources
- Update color scheme dialog to show both Classic and Blue as separate options
- Update MainActivity to handle both "classic" and "blue" theme values
- Add migration logic to handle legacy "default" value → "classic"
- Classic (Default) is now the first option, Blue is the second option
- Update button text logic to correctly display the selected theme

Now users can choose between Classic (default) and Blue themes, along with Peach, Green, Purple, and Orange options.