### PR TITLE
Fix listening connection drops when phone is idle

### DIFF
--- a/app/src/main/java/com/opensource/i2pradio/RadioService.kt
+++ b/app/src/main/java/com/opensource/i2pradio/RadioService.kt
@@ -1676,13 +1676,13 @@ class RadioService : Service() {
 
                     builder
                         .connectTimeout(timeout, TimeUnit.SECONDS)
-                        .readTimeout(timeout, TimeUnit.SECONDS)
+                        .readTimeout(0, TimeUnit.SECONDS) // No read timeout for streaming - data arrives sporadically
                         .build()
                 } else {
                     OkHttpClient.Builder()
                         .addInterceptor(BandwidthTrackingInterceptor(this))
                         .connectTimeout(30, TimeUnit.SECONDS)
-                        .readTimeout(30, TimeUnit.SECONDS)
+                        .readTimeout(0, TimeUnit.SECONDS) // No read timeout for streaming - data arrives sporadically
                         .build()
                 }
                 currentOkHttpClient!!


### PR DESCRIPTION
The playback OkHttpClient was using a 30-60 second readTimeout, which caused connections to drop when the phone went idle. Radio streams send data sporadically based on bitrate and content - during silent moments or with low bitrate streams, 30+ seconds can easily pass between packets.

The recording client already correctly used readTimeout(0), which is why recordings continued working while playback dropped.

Changed both proxied and direct playback OkHttpClient configurations to use readTimeout(0) to match the recording client behavior.