### PR TITLE
Fix app lock requiring re-authentication on UI theme changes

### DIFF
--- a/app/src/main/java/com/opensource/i2pradio/MainActivity.kt
+++ b/app/src/main/java/com/opensource/i2pradio/MainActivity.kt
@@ -224,6 +224,14 @@ class MainActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
 
+        // Preserve authentication state if we're recreating for UI changes (theme/color/language)
+        // This prevents requiring re-authentication when the user changes visual settings
+        if (savedInstanceState != null && preserveAuthOnRecreate) {
+            isAuthenticated = true
+            isFirstLaunch = false  // Not a true first launch, just a UI recreation
+            preserveAuthOnRecreate = false
+        }
+
         // Check if database encryption is enabled
         val isDbEncryptionEnabled = com.opensource.i2pradio.utils.DatabaseEncryptionManager.isDatabaseEncryptionEnabled(this)
 
@@ -662,6 +670,19 @@ class MainActivity : AppCompatActivity() {
 
         // Broadcast action for proxy mode changes
         const val BROADCAST_PROXY_MODE_CHANGED = "com.opensource.i2pradio.PROXY_MODE_CHANGED"
+
+        // Flag to preserve authentication state across activity recreation (for UI changes like themes)
+        @Volatile
+        private var preserveAuthOnRecreate = false
+
+        /**
+         * Call this before activity.recreate() to preserve authentication state.
+         * This prevents requiring re-authentication when changing themes, colors, or languages.
+         */
+        @JvmStatic
+        fun prepareForUiRecreate() {
+            preserveAuthOnRecreate = true
+        }
     }
 
     private inner class ViewPagerAdapter(activity: AppCompatActivity) :

--- a/app/src/main/java/com/opensource/i2pradio/ui/SettingsFragment.kt
+++ b/app/src/main/java/com/opensource/i2pradio/ui/SettingsFragment.kt
@@ -32,6 +32,7 @@ import androidx.fragment.app.Fragment
 import com.google.android.material.button.MaterialButton
 import com.google.android.material.materialswitch.MaterialSwitch
 import com.google.android.material.textfield.TextInputEditText
+import com.opensource.i2pradio.MainActivity
 import com.opensource.i2pradio.R
 import com.opensource.i2pradio.RadioService
 import com.opensource.i2pradio.data.ProxyType
@@ -296,6 +297,7 @@ class SettingsFragment : Fragment() {
                 PreferencesHelper.setMaterialYouEnabled(requireContext(), isChecked)
                 // Delay recreate to allow the animation to complete
                 uiHandler.postDelayed({
+                    MainActivity.prepareForUiRecreate()
                     activity?.recreate()
                 }, 300)
             }
@@ -1105,6 +1107,7 @@ class SettingsFragment : Fragment() {
                 updateColorSchemeButtonText(colorSchemeButton)
                 // Recreate activity to apply new color scheme
                 uiHandler.postDelayed({
+                    MainActivity.prepareForUiRecreate()
                     activity?.recreate()
                 }, 300)
                 dialog.dismiss()
@@ -1174,6 +1177,7 @@ class SettingsFragment : Fragment() {
 
                 // Recreate activity to apply new language
                 uiHandler.postDelayed({
+                    MainActivity.prepareForUiRecreate()
                     activity?.recreate()
                 }, 300)
                 dialog.dismiss()


### PR DESCRIPTION
When changing UI settings (light/dark mode, Material You, color theme, or language), activity.recreate() triggers onPause which resets isAuthenticated to false, causing users to re-enter their password.

Added a static flag that preserves authentication state across activity recreations initiated by UI changes, so users don't need to re-authenticate when simply changing visual settings.