### PR TITLE
Fix signed APK crash by adding SQLCipher ProGuard rules

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -53,3 +53,8 @@
 # Keep Coil image loader
 -keep class coil.** { *; }
 -dontwarn coil.**
+
+# Keep SQLCipher classes - required for JNI native library access
+# The native libsqlcipher.so accesses fields like mNativeHandle via JNI
+-keep class net.sqlcipher.** { *; }
+-keep class net.sqlcipher.database.** { *; }


### PR DESCRIPTION
The native libsqlcipher.so library accesses SQLCipher class fields via JNI. Without ProGuard rules, R8 obfuscates field names like mNativeHandle, causing NoSuchFieldError crashes at runtime in release builds.