### PR TITLE
Fix browse screen scroll issues and add more discovery categories

### DIFF
--- a/app/src/main/java/com/opensource/i2pradio/MainActivity.kt
+++ b/app/src/main/java/com/opensource/i2pradio/MainActivity.kt
@@ -534,6 +534,11 @@ class MainActivity : AppCompatActivity() {
         val adapter = ViewPagerAdapter(this)
         viewPager.adapter = adapter
 
+        // Disable horizontal swipe navigation to prevent conflicts with horizontal
+        // scrolling elements (carousels, chips) in the browse tab. Users can still
+        // switch tabs by tapping on the tab bar.
+        viewPager.isUserInputEnabled = false
+
         // Add smooth page transformation with fade and slight scale
         viewPager.setPageTransformer { page, position ->
             val absPosition = kotlin.math.abs(position)

--- a/app/src/main/java/com/opensource/i2pradio/ui/browse/BrowseViewModel.kt
+++ b/app/src/main/java/com/opensource/i2pradio/ui/browse/BrowseViewModel.kt
@@ -143,6 +143,36 @@ class BrowseViewModel(application: Application) : AndroidViewModel(application) 
     }
 
     /**
+     * Load stations by country code (e.g., "US", "DE", "GB")
+     */
+    fun loadByCountryCode(countryCode: String) {
+        // Find or create a CountryInfo for this country code
+        val existingCountry = _countries.value?.find { it.iso3166_1 == countryCode }
+        if (existingCountry != null) {
+            filterByCountry(existingCountry)
+        } else {
+            // Create a temporary CountryInfo if not found in list
+            val tempCountry = CountryInfo(name = countryCode, iso3166_1 = countryCode, stationCount = 0)
+            filterByCountry(tempCountry)
+        }
+    }
+
+    /**
+     * Load stations by language (e.g., "english", "spanish")
+     */
+    fun loadByLanguage(language: String) {
+        // Find or create a LanguageInfo for this language
+        val existingLanguage = _languages.value?.find { it.name.equals(language, ignoreCase = true) }
+        if (existingLanguage != null) {
+            filterByLanguage(existingLanguage)
+        } else {
+            // Create a temporary LanguageInfo if not found in list
+            val tempLanguage = LanguageInfo(name = language, stationCount = 0)
+            filterByLanguage(tempLanguage)
+        }
+    }
+
+    /**
      * Search stations by name
      * This now preserves active filters (tag, country, language) and combines them with search
      */

--- a/app/src/main/res/layout/fragment_browse_stations.xml
+++ b/app/src/main/res/layout/fragment_browse_stations.xml
@@ -103,6 +103,64 @@
 
             </HorizontalScrollView>
 
+            <!-- Country Section Header -->
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="20dp"
+                android:layout_marginTop="24dp"
+                android:text="@string/browse_by_country"
+                android:textColor="?attr/colorOnSurface"
+                android:textSize="13sp"
+                android:textStyle="bold"
+                android:letterSpacing="0.05" />
+
+            <!-- Country Chips Row -->
+            <HorizontalScrollView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="12dp"
+                android:scrollbars="none"
+                android:clipToPadding="false"
+                android:paddingHorizontal="16dp">
+
+                <LinearLayout
+                    android:id="@+id/countryChipsRow"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:orientation="horizontal" />
+
+            </HorizontalScrollView>
+
+            <!-- Language Section Header -->
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="20dp"
+                android:layout_marginTop="24dp"
+                android:text="@string/browse_by_language"
+                android:textColor="?attr/colorOnSurface"
+                android:textSize="13sp"
+                android:textStyle="bold"
+                android:letterSpacing="0.05" />
+
+            <!-- Language Chips Row -->
+            <HorizontalScrollView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="12dp"
+                android:scrollbars="none"
+                android:clipToPadding="false"
+                android:paddingHorizontal="16dp">
+
+                <LinearLayout
+                    android:id="@+id/languageChipsRow"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:orientation="horizontal" />
+
+            </HorizontalScrollView>
+
             <!-- Trending Now Section -->
             <LinearLayout
                 android:layout_width="match_parent"
@@ -211,6 +269,45 @@
             <!-- Popular Carousel -->
             <androidx.recyclerview.widget.RecyclerView
                 android:id="@+id/popularRecyclerView"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="14dp"
+                android:clipToPadding="false"
+                android:paddingHorizontal="16dp"
+                android:orientation="horizontal"
+                app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager" />
+
+            <!-- New Stations Section -->
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="24dp"
+                android:gravity="center_vertical"
+                android:orientation="horizontal"
+                android:paddingHorizontal="20dp">
+
+                <TextView
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:text="@string/browse_new_stations"
+                    android:textColor="?attr/colorOnSurface"
+                    android:textSize="18sp"
+                    android:textStyle="bold" />
+
+                <TextView
+                    android:id="@+id/newStationsSeeAll"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/see_all"
+                    android:textColor="?attr/colorPrimary"
+                    android:textSize="14sp"
+                    android:textStyle="bold" />
+            </LinearLayout>
+
+            <!-- New Stations Carousel -->
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/newStationsRecyclerView"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="14dp"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -96,7 +96,10 @@
     <string name="station_removed_from_favorites">%s removed from favorites</string>
     <string name="tor_required_warning">Force Tor is enabled but Tor is not connected. Connect to Tor to browse stations.</string>
     <string name="browse_by_genre">Browse by Genre</string>
+    <string name="browse_by_country">Browse by Country</string>
+    <string name="browse_by_language">Browse by Language</string>
     <string name="browse_trending">Trending Now</string>
+    <string name="browse_new_stations">New Stations</string>
     <string name="see_all">See All</string>
     <string name="add_filter">+ Filter</string>
     <string name="browse_results_count">Loading…</string>


### PR DESCRIPTION
- Disable ViewPager2 horizontal swipe navigation to prevent tab switching when scrolling through carousels and chips in the browse tab (users can still switch tabs by tapping the tab bar)
- Add "Browse by Country" section with 12 popular country chips (USA, Germany, UK, France, Spain, Brazil, Italy, Mexico, Canada, Australia, Japan, Russia)
- Add "Browse by Language" section with 12 language chips (English, Spanish, German, French, Portuguese, Italian, Russian, Chinese, Japanese, Arabic, Hindi, Korean)
- Add "New Stations" carousel showing recently added stations
- Add loadByCountryCode() and loadByLanguage() methods to BrowseViewModel