### PR TITLE
Fix search bar cropping in browse results mode

### DIFF
--- a/app/src/main/res/layout/fragment_browse_stations.xml
+++ b/app/src/main/res/layout/fragment_browse_stations.xml
@@ -452,7 +452,8 @@
             android:gravity="center_vertical"
             android:orientation="horizontal"
             android:paddingHorizontal="8dp"
-            android:paddingVertical="8dp">
+            android:paddingTop="12dp"
+            android:paddingBottom="8dp">
 
             <!-- Back button to return to discovery -->
             <ImageButton


### PR DESCRIPTION
Increase top padding from 8dp to 12dp to prevent the search bar from being clipped by the tab indicator above.