### PR TITLE
Fix search text cutoff in results mode

### DIFF
--- a/app/src/main/res/layout/fragment_browse_stations.xml
+++ b/app/src/main/res/layout/fragment_browse_stations.xml
@@ -489,7 +489,9 @@
                     android:hint="@string/search_radio_browser"
                     android:inputType="text"
                     android:imeOptions="actionSearch"
-                    android:maxLines="1" />
+                    android:maxLines="1"
+                    android:paddingStart="20dp"
+                    android:paddingEnd="48dp" />
 
             </com.google.android.material.textfield.TextInputLayout>
 


### PR DESCRIPTION
Add proper padding to the search input field to prevent the hint text from being cut off by the clear icon and rounded corners.