### PR TITLE
Fix search text display in results mode

### DIFF
--- a/app/src/main/java/com/opensource/i2pradio/ui/browse/BrowseStationsFragment.kt
+++ b/app/src/main/java/com/opensource/i2pradio/ui/browse/BrowseStationsFragment.kt
@@ -77,8 +77,9 @@ class BrowseStationsFragment : Fragment() {
     // Results mode views
     private lateinit var resultsContainer: LinearLayout
     private lateinit var btnBackToDiscovery: ImageButton
-    private lateinit var resultsSearchInputLayout: TextInputLayout
-    private lateinit var resultsSearchInput: TextInputEditText
+    private lateinit var resultsSearchInputLayout: MaterialCardView
+    private lateinit var resultsSearchInput: android.widget.EditText
+    private lateinit var btnClearSearch: ImageButton
     private lateinit var categoryFilterChip: Chip
     private lateinit var countryFilterChip: Chip
     private lateinit var genreFilterChip: Chip
@@ -195,6 +196,7 @@ class BrowseStationsFragment : Fragment() {
         btnBackToDiscovery = view.findViewById(R.id.btnBackToDiscovery)
         resultsSearchInputLayout = view.findViewById(R.id.resultsSearchInputLayout)
         resultsSearchInput = view.findViewById(R.id.resultsSearchInput)
+        btnClearSearch = view.findViewById(R.id.btnClearSearch)
         categoryFilterChip = view.findViewById(R.id.categoryFilterChip)
         countryFilterChip = view.findViewById(R.id.countryFilterChip)
         genreFilterChip = view.findViewById(R.id.genreFilterChip)
@@ -538,6 +540,9 @@ class BrowseStationsFragment : Fragment() {
             override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {}
             override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {}
             override fun afterTextChanged(s: Editable?) {
+                // Show/hide clear button based on text content
+                btnClearSearch.visibility = if (s.isNullOrEmpty()) View.GONE else View.VISIBLE
+
                 searchDebounceRunnable?.let { resultsSearchInput.removeCallbacks(it) }
                 searchDebounceRunnable = Runnable {
                     val query = s?.toString()?.trim() ?: ""
@@ -570,6 +575,12 @@ class BrowseStationsFragment : Fragment() {
             } else {
                 false
             }
+        }
+
+        // Clear button click handler
+        btnClearSearch.setOnClickListener {
+            clearSearch()
+            resultsSearchInput.requestFocus()
         }
     }
 
@@ -790,6 +801,7 @@ class BrowseStationsFragment : Fragment() {
         searchDebounceRunnable?.let { resultsSearchInput.removeCallbacks(it) }
         isManualSearchClear = true
         resultsSearchInput.setText("")
+        btnClearSearch.visibility = View.GONE
     }
 
     private fun showKeyboard() {

--- a/app/src/main/res/layout/fragment_browse_stations.xml
+++ b/app/src/main/res/layout/fragment_browse_stations.xml
@@ -466,34 +466,55 @@
                 app:tint="?attr/colorOnSurface" />
 
             <!-- Active search field -->
-            <com.google.android.material.textfield.TextInputLayout
+            <com.google.android.material.card.MaterialCardView
                 android:id="@+id/resultsSearchInputLayout"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_weight="1"
                 android:layout_marginStart="4dp"
                 android:layout_marginEnd="8dp"
-                app:boxCornerRadiusBottomEnd="24dp"
-                app:boxCornerRadiusBottomStart="24dp"
-                app:boxCornerRadiusTopEnd="24dp"
-                app:boxCornerRadiusTopStart="24dp"
-                app:hintEnabled="false"
-                app:boxBackgroundColor="?attr/colorSurfaceContainerHigh"
-                app:endIconMode="clear_text"
-                style="@style/Widget.Material3.TextInputLayout.OutlinedBox">
+                app:cardBackgroundColor="?attr/colorSurfaceContainerHigh"
+                app:cardCornerRadius="24dp"
+                app:cardElevation="0dp"
+                app:strokeWidth="0dp">
 
-                <com.google.android.material.textfield.TextInputEditText
-                    android:id="@+id/resultsSearchInput"
+                <LinearLayout
                     android:layout_width="match_parent"
                     android:layout_height="48dp"
-                    android:hint="@string/search_radio_browser"
-                    android:inputType="text"
-                    android:imeOptions="actionSearch"
-                    android:maxLines="1"
+                    android:gravity="center_vertical"
+                    android:orientation="horizontal"
                     android:paddingStart="20dp"
-                    android:paddingEnd="48dp" />
+                    android:paddingEnd="12dp">
 
-            </com.google.android.material.textfield.TextInputLayout>
+                    <EditText
+                        android:id="@+id/resultsSearchInput"
+                        android:layout_width="0dp"
+                        android:layout_height="match_parent"
+                        android:layout_weight="1"
+                        android:background="@null"
+                        android:hint="@string/search_radio_browser"
+                        android:textColorHint="?attr/colorOnSurfaceVariant"
+                        android:textColor="?attr/colorOnSurface"
+                        android:inputType="text"
+                        android:imeOptions="actionSearch"
+                        android:singleLine="true"
+                        android:ellipsize="end"
+                        android:gravity="center_vertical"
+                        android:textSize="16sp" />
+
+                    <ImageButton
+                        android:id="@+id/btnClearSearch"
+                        android:layout_width="36dp"
+                        android:layout_height="36dp"
+                        android:background="?attr/selectableItemBackgroundBorderless"
+                        android:contentDescription="@string/button_clear"
+                        android:src="@drawable/ic_close"
+                        android:visibility="gone"
+                        app:tint="?attr/colorOnSurfaceVariant" />
+
+                </LinearLayout>
+
+            </com.google.android.material.card.MaterialCardView>
 
         </LinearLayout>
 


### PR DESCRIPTION
Replace TextInputLayout with MaterialCardView for the search bar in results mode to fix text cutoff and vertical centering issues:

- Use simpler MaterialCardView + EditText structure matching discovery mode
- Add explicit 48dp height LinearLayout with center_vertical gravity
- Add custom clear button with proper visibility handling
- Use 20dp paddingStart and 12dp paddingEnd for proper text spacing
- Text now properly centered and not cut off by large corner radius