### PR TITLE
Fix duplicate genre filter chips in browse results

### DIFF
--- a/app/src/main/java/com/opensource/i2pradio/ui/browse/BrowseViewModel.kt
+++ b/app/src/main/java/com/opensource/i2pradio/ui/browse/BrowseViewModel.kt
@@ -503,9 +503,10 @@ class BrowseViewModel(application: Application) : AndroidViewModel(application) 
         viewModelScope.launch {
             when (val result = repository.getTags(200)) {
                 is RadioBrowserResult.Success -> {
-                    // Filter to tags with at least 10 stations and sort alphabetically
+                    // Filter to tags with at least 10 stations, deduplicate by name (case-insensitive), and sort alphabetically
                     _tags.value = result.data
                         .filter { it.stationCount >= 10 }
+                        .distinctBy { it.name.lowercase() }
                         .sortedBy { it.name.lowercase() }
                 }
                 is RadioBrowserResult.Error -> {


### PR DESCRIPTION
Add distinctBy to deduplicate tags by name (case-insensitive) when loading from the RadioBrowser API. This prevents duplicate genre chips like 'Jazz' appearing twice in the filter row.