### PR TITLE
Fix category filter chip showing genre name instead of sort option

### DIFF
--- a/app/src/main/java/com/opensource/i2pradio/ui/browse/BrowseStationsFragment.kt
+++ b/app/src/main/java/com/opensource/i2pradio/ui/browse/BrowseStationsFragment.kt
@@ -324,7 +324,7 @@ class BrowseStationsFragment : Fragment() {
             val tags = viewModel.tags.value
             val tagInfo = tags?.find { it.name.equals(genreData.tag, ignoreCase = true) }
 
-            currentResultsTitle = getString(genreData.displayName)
+            currentResultsTitle = getString(R.string.browse_top_voted)
             switchToResultsMode()
 
             if (tagInfo != null) {
@@ -946,7 +946,7 @@ class BrowseStationsFragment : Fragment() {
                 holder.itemView.setOnClickListener {
                     dialog.dismiss()
                     // Navigate to results with this genre
-                    currentResultsTitle = displayName
+                    currentResultsTitle = getString(R.string.browse_top_voted)
                     switchToResultsMode()
                     viewModel.filterByTag(tag)
                 }


### PR DESCRIPTION
When selecting a genre from discovery mode, the category filter chip was incorrectly showing the genre name (e.g., "Pop") instead of the sort option (e.g., "Top Voted"). The genre is already displayed in the separate genreFilterChip, so the categoryFilterChip should show the current sort order. Fixed in both genre chip click handler and the full genre dialog.