### PR TITLE
Add intelligent filter logic so filters respect each other

### DIFF
--- a/app/src/main/java/com/opensource/i2pradio/ui/browse/BrowseStationsFragment.kt
+++ b/app/src/main/java/com/opensource/i2pradio/ui/browse/BrowseStationsFragment.kt
@@ -595,7 +595,7 @@ class BrowseStationsFragment : Fragment() {
             showCountryFilterDialog()
         }
         countryFilterChip.setOnCloseIconClickListener {
-            viewModel.filterByCountry(null)
+            viewModel.clearCountryFilter()
             countryFilterChip.visibility = View.GONE
         }
 
@@ -604,7 +604,7 @@ class BrowseStationsFragment : Fragment() {
             showGenreFilterDialog()
         }
         genreFilterChip.setOnCloseIconClickListener {
-            viewModel.filterByTag(null)
+            viewModel.clearTagFilter()
             genreFilterChip.visibility = View.GONE
         }
 
@@ -613,7 +613,7 @@ class BrowseStationsFragment : Fragment() {
             showLanguageFilterDialog()
         }
         languageFilterChip.setOnCloseIconClickListener {
-            viewModel.filterByLanguage(null)
+            viewModel.clearLanguageFilter()
             languageFilterChip.visibility = View.GONE
         }
 
@@ -1180,9 +1180,10 @@ class BrowseStationsFragment : Fragment() {
             .setNegativeButton(android.R.string.cancel, null)
             .setPositiveButton(android.R.string.ok) { _, _ ->
                 if (tempSelectedCountryIndex == null) {
-                    viewModel.filterByCountry(null)
+                    viewModel.clearCountryFilter()
                 } else {
-                    viewModel.filterByCountry(countries[tempSelectedCountryIndex!!])
+                    // Use addCountryFilter to keep current category (intelligent filtering)
+                    viewModel.addCountryFilter(countries[tempSelectedCountryIndex!!])
                 }
             }
             .create()
@@ -1212,9 +1213,10 @@ class BrowseStationsFragment : Fragment() {
             .setNegativeButton(android.R.string.cancel, null)
             .setPositiveButton(android.R.string.ok) { _, _ ->
                 if (tempSelectedTagIndex == null) {
-                    viewModel.filterByTag(null)
+                    viewModel.clearTagFilter()
                 } else {
-                    viewModel.filterByTag(tags[tempSelectedTagIndex!!])
+                    // Use addTagFilter to keep current category (intelligent filtering)
+                    viewModel.addTagFilter(tags[tempSelectedTagIndex!!])
                 }
             }
             .create()
@@ -1244,9 +1246,10 @@ class BrowseStationsFragment : Fragment() {
             .setNegativeButton(android.R.string.cancel, null)
             .setPositiveButton(android.R.string.ok) { _, _ ->
                 if (tempSelectedLanguageIndex == null) {
-                    viewModel.filterByLanguage(null)
+                    viewModel.clearLanguageFilter()
                 } else {
-                    viewModel.filterByLanguage(languages[tempSelectedLanguageIndex!!])
+                    // Use addLanguageFilter to keep current category (intelligent filtering)
+                    viewModel.addLanguageFilter(languages[tempSelectedLanguageIndex!!])
                 }
             }
             .create()


### PR DESCRIPTION
Filters now work together across ALL categories. For example:
- "Rock" filter + "History" = only history stations with rock tag
- "Germany" filter + "Top Voted" = top voted stations from Germany
- Multiple filters stack: "Rock" + "Germany" = rock stations from Germany

Changes:
- Add applyActiveFilters() method to filter results client-side
- Add addXFilter() methods to add filters without changing category
- Add clearXFilter() methods to remove filters and re-fetch
- Update filter dialogs to use addXFilter() for intelligent filtering
- Update filter chip close handlers to use clearXFilter()