### PR TITLE
Add All Stations category to show all filtered results

### DIFF
--- a/app/src/main/java/com/opensource/i2pradio/data/radiobrowser/RadioBrowserStation.kt
+++ b/app/src/main/java/com/opensource/i2pradio/data/radiobrowser/RadioBrowserStation.kt
@@ -153,7 +153,8 @@ enum class BrowseCategory {
     BY_COUNTRY,
     BY_TAG,
     BY_LANGUAGE,
-    SEARCH
+    SEARCH,
+    ALL_STATIONS  // Show all stations based on current filter (no ranking applied)
 }
 
 /**

--- a/app/src/main/java/com/opensource/i2pradio/ui/browse/BrowseStationsFragment.kt
+++ b/app/src/main/java/com/opensource/i2pradio/ui/browse/BrowseStationsFragment.kt
@@ -816,6 +816,7 @@ class BrowseStationsFragment : Fragment() {
 
     private fun showCategoryMenu() {
         val categories = arrayOf(
+            getString(R.string.browse_all_stations),
             getString(R.string.browse_top_voted),
             getString(R.string.browse_popular),
             getString(R.string.browse_trending),
@@ -828,18 +829,22 @@ class BrowseStationsFragment : Fragment() {
                 clearSearch()
                 when (which) {
                     0 -> {
+                        currentResultsTitle = getString(R.string.browse_all_stations)
+                        viewModel.loadAllStations()
+                    }
+                    1 -> {
                         currentResultsTitle = getString(R.string.browse_top_voted)
                         viewModel.loadTopVoted()
                     }
-                    1 -> {
+                    2 -> {
                         currentResultsTitle = getString(R.string.browse_popular)
                         viewModel.loadTopClicked()
                     }
-                    2 -> {
+                    3 -> {
                         currentResultsTitle = getString(R.string.browse_trending)
                         viewModel.loadRandom()
                     }
-                    3 -> {
+                    4 -> {
                         currentResultsTitle = getString(R.string.browse_history)
                         viewModel.loadHistory()
                     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -75,6 +75,7 @@
     <string name="browse_popular">Popular</string>
     <string name="browse_random">Random</string>
     <string name="browse_history">History</string>
+    <string name="browse_all_stations">All Stations</string>
     <string name="browse_no_results">No Stations Found</string>
     <string name="browse_no_results_hint">Try a different search or filter</string>
     <string name="filter_country">Country</string>


### PR DESCRIPTION
When browsing genres like Jazz with "Top Voted", only a few stations appear because the global top voted list has few jazz stations. The new "All Stations" category fetches all stations matching the current filter directly from the API without any ranking applied, showing all available stations for that genre/country/language.