### PR TITLE
Fix Hip Hop and other genre chips showing 0 stations

### DIFF
--- a/app/src/main/java/com/opensource/i2pradio/ui/browse/BrowseStationsFragment.kt
+++ b/app/src/main/java/com/opensource/i2pradio/ui/browse/BrowseStationsFragment.kt
@@ -136,6 +136,21 @@ class BrowseStationsFragment : Fragment() {
         GenreChipData("sports", R.string.genre_sports)
     )
 
+    /**
+     * Normalize genre name for matching purposes.
+     * Maps known variants (e.g., "hip hop", "hip-hop", "hiphop") to a canonical form.
+     * This must match the normalization in BrowseViewModel.normalizeGenreName().
+     */
+    private fun normalizeGenreName(name: String): String {
+        val lower = name.lowercase().trim()
+        return when {
+            lower in listOf("hip hop", "hip-hop", "hiphop") -> "hiphop"
+            lower in listOf("k-pop", "kpop") -> "kpop"
+            lower in listOf("lo-fi", "lofi") -> "lofi"
+            lower in listOf("r&b", "r and b", "rnb") -> "rnb"
+            else -> lower
+        }
+    }
 
     // Broadcast receiver for like state changes from other views
     private val likeStateReceiver = object : BroadcastReceiver() {
@@ -320,9 +335,11 @@ class BrowseStationsFragment : Fragment() {
         }
 
         chip.setOnClickListener {
-            // Find the tag in loaded tags or create a temporary one
+            // Find the tag in loaded tags using normalized comparison
+            // This handles variants like "hip hop", "hip-hop", "hiphop" all matching the same tag
             val tags = viewModel.tags.value
-            val tagInfo = tags?.find { it.name.equals(genreData.tag, ignoreCase = true) }
+            val normalizedChipTag = normalizeGenreName(genreData.tag)
+            val tagInfo = tags?.find { normalizeGenreName(it.name) == normalizedChipTag }
 
             currentResultsTitle = getString(R.string.browse_all_stations)
             switchToResultsMode()


### PR DESCRIPTION
The RadioBrowser API returns multiple variants of genre tags (e.g., "hip hop", "hip-hop", "hiphop") as separate entries. The existing deduplication using distinctBy { it.name.lowercase() } didn't work because the lowercase variants are still different strings.

This fix:
- Adds normalizeGenreName() to map known genre variants to a canonical form for deduplication (e.g., all hip hop variants map to "hiphop")
- Updates loadTags() to group by normalized name and keep the variant with the highest station count (most reliable for API calls)
- Updates the genre chip click handler to use normalized comparison when finding the matching tag

This ensures clicking "Hip Hop" chip finds the right tag regardless of which variant (hip-hop, hiphop, hip hop) has the most stations in the API.