### PR TITLE
Add I2P and Tor genre chips to browse screen

### DIFF
--- a/app/src/main/java/com/opensource/i2pradio/data/DefaultStations.kt
+++ b/app/src/main/java/com/opensource/i2pradio/data/DefaultStations.kt
@@ -13,6 +13,8 @@ import org.json.JSONObject
 object DefaultStations {
     private const val TAG = "DefaultStations"
     private const val BUNDLED_STATIONS_FILE = "bundled_stations.json"
+    private const val I2P_STATIONS_FILE = "i2p_stations.json"
+    private const val TOR_STATIONS_FILE = "tor_stations.json"
 
     /**
      * Get preset stations from bundled JSON asset.
@@ -20,7 +22,7 @@ object DefaultStations {
      */
     fun getPresetStations(context: Context): List<RadioStation> {
         return try {
-            loadBundledStations(context)
+            loadStationsFromFile(context, BUNDLED_STATIONS_FILE)
         } catch (e: Exception) {
             Log.e(TAG, "Failed to load bundled stations, using fallback", e)
             getFallbackStations()
@@ -28,11 +30,35 @@ object DefaultStations {
     }
 
     /**
-     * Load stations from the bundled JSON asset file.
+     * Get I2P curated stations from JSON asset.
      */
-    private fun loadBundledStations(context: Context): List<RadioStation> {
+    fun getI2pStations(context: Context): List<RadioStation> {
+        return try {
+            loadStationsFromFile(context, I2P_STATIONS_FILE)
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to load I2P stations", e)
+            emptyList()
+        }
+    }
+
+    /**
+     * Get Tor curated stations from JSON asset.
+     */
+    fun getTorStations(context: Context): List<RadioStation> {
+        return try {
+            loadStationsFromFile(context, TOR_STATIONS_FILE)
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to load Tor stations", e)
+            emptyList()
+        }
+    }
+
+    /**
+     * Load stations from a JSON asset file.
+     */
+    private fun loadStationsFromFile(context: Context, fileName: String): List<RadioStation> {
         val stations = mutableListOf<RadioStation>()
-        val jsonString = context.assets.open(BUNDLED_STATIONS_FILE).bufferedReader().use { it.readText() }
+        val jsonString = context.assets.open(fileName).bufferedReader().use { it.readText() }
         val json = JSONObject(jsonString)
         val stationsArray = json.getJSONArray("stations")
 

--- a/app/src/main/java/com/opensource/i2pradio/data/radiobrowser/RadioBrowserStation.kt
+++ b/app/src/main/java/com/opensource/i2pradio/data/radiobrowser/RadioBrowserStation.kt
@@ -1,6 +1,8 @@
 package com.opensource.i2pradio.data.radiobrowser
 
+import com.opensource.i2pradio.data.RadioStation
 import org.json.JSONObject
+import java.util.UUID
 
 /**
  * Data class representing a radio station from the RadioBrowser API.
@@ -60,6 +62,37 @@ data class RadioBrowserStation(
                 sslError = json.optInt("ssl_error", 0) == 1,
                 geoLat = json.optDouble("geo_lat").takeIf { !it.isNaN() },
                 geoLong = json.optDouble("geo_long").takeIf { !it.isNaN() }
+            )
+        }
+
+        /**
+         * Convert a RadioStation (from curated lists) to RadioBrowserStation
+         */
+        fun fromRadioStation(station: RadioStation): RadioBrowserStation {
+            return RadioBrowserStation(
+                stationuuid = UUID.randomUUID().toString(),
+                name = station.name,
+                url = station.streamUrl,
+                urlResolved = station.streamUrl,
+                homepage = "",
+                favicon = station.coverArtUri ?: "",
+                tags = station.genre,
+                country = station.country,
+                countrycode = station.countryCode,
+                state = "",
+                language = "",
+                languagecodes = "",
+                votes = 0,
+                lastchangetime = "",
+                codec = station.codec,
+                bitrate = station.bitrate,
+                hls = false,
+                lastcheckok = true,
+                clickcount = 0,
+                clicktrend = 0,
+                sslError = false,
+                geoLat = null,
+                geoLong = null
             )
         }
     }

--- a/app/src/main/java/com/opensource/i2pradio/ui/browse/BrowseStationsFragment.kt
+++ b/app/src/main/java/com/opensource/i2pradio/ui/browse/BrowseStationsFragment.kt
@@ -134,7 +134,9 @@ class BrowseStationsFragment : Fragment() {
         GenreChipData("r&b", R.string.genre_r_and_b),
         GenreChipData("news", R.string.genre_news),
         GenreChipData("talk", R.string.genre_talk),
-        GenreChipData("sports", R.string.genre_sports)
+        GenreChipData("sports", R.string.genre_sports),
+        GenreChipData("i2p", R.string.genre_i2p),
+        GenreChipData("tor", R.string.genre_tor)
     )
 
     /**
@@ -336,21 +338,33 @@ class BrowseStationsFragment : Fragment() {
         }
 
         chip.setOnClickListener {
-            // Find the tag in loaded tags using normalized comparison
-            // This handles variants like "hip hop", "hip-hop", "hiphop" all matching the same tag
-            val tags = viewModel.tags.value
-            val normalizedChipTag = normalizeGenreName(genreData.tag)
-            val tagInfo = tags?.find { normalizeGenreName(it.name) == normalizedChipTag }
-
             currentResultsTitle = getString(R.string.browse_all_stations)
             switchToResultsMode()
 
-            if (tagInfo != null) {
-                viewModel.addTagFilter(tagInfo)
-                viewModel.loadAllStations()
-            } else {
-                // Search by tag name directly if TagInfo not available
-                viewModel.search(genreData.tag)
+            // Special handling for I2P and Tor chips - load curated lists
+            when (genreData.tag.lowercase()) {
+                "i2p" -> {
+                    viewModel.loadCuratedI2pStations()
+                }
+                "tor" -> {
+                    viewModel.loadCuratedTorStations()
+                }
+                else -> {
+                    // Normal genre chip handling
+                    // Find the tag in loaded tags using normalized comparison
+                    // This handles variants like "hip hop", "hip-hop", "hiphop" all matching the same tag
+                    val tags = viewModel.tags.value
+                    val normalizedChipTag = normalizeGenreName(genreData.tag)
+                    val tagInfo = tags?.find { normalizeGenreName(it.name) == normalizedChipTag }
+
+                    if (tagInfo != null) {
+                        viewModel.addTagFilter(tagInfo)
+                        viewModel.loadAllStations()
+                    } else {
+                        // Search by tag name directly if TagInfo not available
+                        viewModel.search(genreData.tag)
+                    }
+                }
             }
         }
 

--- a/app/src/main/java/com/opensource/i2pradio/ui/browse/BrowseViewModel.kt
+++ b/app/src/main/java/com/opensource/i2pradio/ui/browse/BrowseViewModel.kt
@@ -290,6 +290,46 @@ class BrowseViewModel(application: Application) : AndroidViewModel(application) 
     }
 
     /**
+     * Load curated I2P stations from bundled JSON
+     */
+    fun loadCuratedI2pStations() {
+        _currentCategory.value = BrowseCategory.ALL_STATIONS
+        currentOffset = 0
+        _isLoading.value = true
+        viewModelScope.launch(Dispatchers.IO) {
+            try {
+                val i2pStations = com.opensource.i2pradio.data.DefaultStations.getI2pStations(getApplication())
+                val browserStations = i2pStations.map { RadioBrowserStation.fromRadioStation(it) }
+                _stations.postValue(browserStations)
+                _isLoading.postValue(false)
+            } catch (e: Exception) {
+                _errorMessage.postValue("Failed to load I2P stations: ${e.message}")
+                _isLoading.postValue(false)
+            }
+        }
+    }
+
+    /**
+     * Load curated Tor stations from bundled JSON
+     */
+    fun loadCuratedTorStations() {
+        _currentCategory.value = BrowseCategory.ALL_STATIONS
+        currentOffset = 0
+        _isLoading.value = true
+        viewModelScope.launch(Dispatchers.IO) {
+            try {
+                val torStations = com.opensource.i2pradio.data.DefaultStations.getTorStations(getApplication())
+                val browserStations = torStations.map { RadioBrowserStation.fromRadioStation(it) }
+                _stations.postValue(browserStations)
+                _isLoading.postValue(false)
+            } catch (e: Exception) {
+                _errorMessage.postValue("Failed to load Tor stations: ${e.message}")
+                _isLoading.postValue(false)
+            }
+        }
+    }
+
+    /**
      * Check if any filters (tag, country, or language) are currently active
      */
     private fun hasActiveFilters(): Boolean {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -42,6 +42,8 @@
     <string name="genre_dance">Dance</string>
     <string name="genre_edm">EDM</string>
     <string name="genre_electronic">Electronic</string>
+    <string name="genre_i2p">I2P</string>
+    <string name="genre_tor">Tor</string>
     <string name="genre_folk">Folk</string>
     <string name="genre_funk">Funk</string>
     <string name="genre_gospel">Gospel</string>


### PR DESCRIPTION
These chips allow users to easily discover I2P and Tor radio stations:
- Added "I2P" and "Tor" string resources
- Added chips to the second row of genre chips
- Created methods to load curated I2P/Tor stations from bundled JSON files
- Added conversion from RadioStation to RadioBrowserStation for curated lists
- Clicking I2P/Tor chips now displays the respective curated station lists