### PR TITLE
Fix unlike button not working on browse cards

### DIFF
--- a/app/src/main/java/com/opensource/i2pradio/ui/browse/BrowseViewModel.kt
+++ b/app/src/main/java/com/opensource/i2pradio/ui/browse/BrowseViewModel.kt
@@ -542,9 +542,12 @@ class BrowseViewModel(application: Application) : AndroidViewModel(application) 
      */
     fun toggleLike(station: RadioBrowserStation) {
         val uuid = station.stationuuid
-        val isCurrentlyLiked = _likedStationUuids.value.orEmpty().contains(uuid)
 
         viewModelScope.launch {
+            // Check current state from database to avoid race conditions
+            val existingStation = repository.getStationInfoByUuid(uuid)
+            val isCurrentlyLiked = existingStation?.isLiked == true
+
             if (isCurrentlyLiked) {
                 // Unlike: remove the station from library entirely
                 val deleted = repository.deleteStationByUuid(uuid)


### PR DESCRIPTION
The unlike functionality was broken due to a race condition in BrowseViewModel.toggleLike(). The liked state was checked outside the coroutine scope, which meant:
- Multiple rapid clicks would all see the same stale state
- The state could change between check and execution

Fixed by moving the state check inside the coroutine and reading directly from the database instead of relying on LiveData values.