### PR TITLE
Fix unresolved getString references in LibraryFragment ViewHolder

### DIFF
--- a/app/src/main/java/com/opensource/i2pradio/ui/LibraryFragment.kt
+++ b/app/src/main/java/com/opensource/i2pradio/ui/LibraryFragment.kt
@@ -912,8 +912,8 @@ class RadioStationAdapter(
             // Show proxy type indicator (I2P or Tor only - Custom proxy is indicated by top-right icon)
             val proxyIndicator = if (station.useProxy) {
                 when (station.getProxyTypeEnum()) {
-                    ProxyType.I2P -> getString(R.string.proxy_label_i2p)
-                    ProxyType.TOR -> getString(R.string.proxy_label_tor)
+                    ProxyType.I2P -> itemView.context.getString(R.string.proxy_label_i2p)
+                    ProxyType.TOR -> itemView.context.getString(R.string.proxy_label_tor)
                     ProxyType.CUSTOM -> ""
                     ProxyType.NONE -> ""
                 }


### PR DESCRIPTION
Use itemView.context.getString() instead of getString() since ViewHolder classes don't have direct access to the getString method.