### PR TITLE
Fix Tor status not syncing in settings when returning from other tabs

### DIFF
--- a/app/src/main/java/com/opensource/i2pradio/ui/SettingsFragment.kt
+++ b/app/src/main/java/com/opensource/i2pradio/ui/SettingsFragment.kt
@@ -571,6 +571,15 @@ class SettingsFragment : Fragment() {
         // Immediate notification would cancel that debouncing and cause UI flickering.
         TorManager.addStateListener(torStateListener, notifyImmediately = false)
 
+        // FIX: Sync UI with current Tor state when resuming from pause.
+        // This handles the case where Tor state changed while the fragment was paused
+        // (e.g., user switched tabs and Tor disconnected in the meantime).
+        // We manually trigger the listener to ensure UI reflects current state.
+        val currentState = TorManager.state
+        if (lastDisplayedTorState != currentState) {
+            torStateListener(currentState)
+        }
+
         // Register preference change listener to sync Tor switch with preference updates
         requireContext().getSharedPreferences("DeutsiaRadioPrefs", Context.MODE_PRIVATE)
             .registerOnSharedPreferenceChangeListener(preferenceChangeListener)


### PR DESCRIPTION
When the user switched tabs while Tor was connected, then Tor disconnected in the background, the settings tab would still show "Connected" when returning to it. This was because:

1. onPause() removed the Tor state listener
2. Tor state changed while fragment was paused (not receiving notifications)
3. onResume() added listener with notifyImmediately=false to avoid flickering
4. The fragment never learned about the state change

Fix: In onResume(), after adding the listener, check if the current Tor state differs from what's displayed and trigger a manual UI update if needed. This ensures the settings tab always reflects the actual Tor connection status.