### PR TITLE
Add service detection toast messages for Tor/I2P stations

### DIFF
--- a/app/src/main/java/com/opensource/i2pradio/i2p/I2PManager.kt
+++ b/app/src/main/java/com/opensource/i2pradio/i2p/I2PManager.kt
@@ -1,0 +1,255 @@
+package com.opensource.i2pradio.i2p
+
+import android.os.Handler
+import android.os.Looper
+import android.util.Log
+import java.net.InetSocketAddress
+import java.net.Socket
+import java.util.concurrent.CopyOnWriteArrayList
+
+/**
+ * Manager for I2P connectivity detection.
+ *
+ * Unlike Tor which has Orbot as a standard Android client, I2P requires users
+ * to run their own I2P router (typically via I2P Android app or a desktop router
+ * with the HTTP proxy accessible).
+ *
+ * This manager provides:
+ * - Detection of I2P HTTP proxy availability (default port 4444)
+ * - Real-time status updates via listeners
+ * - Periodic connection health checks
+ *
+ * The I2P HTTP proxy is typically at 127.0.0.1:4444
+ */
+object I2PManager {
+    private const val TAG = "I2PManager"
+
+    // Default I2P HTTP proxy settings
+    const val DEFAULT_I2P_PROXY_HOST = "127.0.0.1"
+    const val DEFAULT_I2P_PROXY_PORT = 4444
+
+    // Connection health check interval (30 seconds)
+    private const val HEALTH_CHECK_INTERVAL = 30_000L
+
+    // Socket connection timeout (ms)
+    private const val SOCKET_TIMEOUT = 2000
+
+    // Connection state
+    enum class I2PState {
+        UNKNOWN,      // Haven't checked yet
+        AVAILABLE,    // I2P proxy is responding
+        UNAVAILABLE   // I2P proxy is not responding
+    }
+
+    private var _state: I2PState = I2PState.UNKNOWN
+    val state: I2PState get() = _state
+
+    private var _proxyHost: String = DEFAULT_I2P_PROXY_HOST
+    val proxyHost: String get() = _proxyHost
+
+    private var _proxyPort: Int = DEFAULT_I2P_PROXY_PORT
+    val proxyPort: Int get() = _proxyPort
+
+    // Last check timestamp
+    private var _lastCheckTime: Long = 0
+    val lastCheckTime: Long get() = _lastCheckTime
+
+    // Listeners for state changes (thread-safe)
+    private val stateListeners = CopyOnWriteArrayList<(I2PState) -> Unit>()
+
+    // Handler for periodic health checks
+    private val healthCheckHandler = Handler(Looper.getMainLooper())
+    private var healthCheckRunnable: Runnable? = null
+
+    // Thread tracking for proper cleanup
+    @Volatile private var checkThread: Thread? = null
+    @Volatile private var isShuttingDown = false
+
+    fun addStateListener(listener: (I2PState) -> Unit, notifyImmediately: Boolean = true) {
+        stateListeners.add(listener)
+        if (notifyImmediately) {
+            listener(_state)
+        }
+    }
+
+    fun removeStateListener(listener: (I2PState) -> Unit) {
+        stateListeners.remove(listener)
+    }
+
+    private fun notifyStateChange(newState: I2PState) {
+        val oldState = _state
+        _state = newState
+        _lastCheckTime = System.currentTimeMillis()
+
+        if (newState == I2PState.AVAILABLE && oldState != I2PState.AVAILABLE) {
+            startHealthCheck()
+        } else if (newState == I2PState.UNAVAILABLE) {
+            stopHealthCheck()
+        }
+
+        stateListeners.forEach { it(newState) }
+
+        Log.d(TAG, "===== I2P STATE CHANGE =====")
+        Log.d(TAG, "I2P state changed: $oldState -> $newState")
+        Log.d(TAG, "HTTP proxy: $_proxyHost:$_proxyPort")
+        Log.d(TAG, "Is available: ${isAvailable()}")
+        Log.d(TAG, "============================")
+    }
+
+    private fun startHealthCheck() {
+        stopHealthCheck()
+        healthCheckRunnable = object : Runnable {
+            override fun run() {
+                if (_state == I2PState.AVAILABLE) {
+                    checkProxyAvailability()
+                    healthCheckHandler.postDelayed(this, HEALTH_CHECK_INTERVAL)
+                }
+            }
+        }
+        healthCheckHandler.postDelayed(healthCheckRunnable!!, HEALTH_CHECK_INTERVAL)
+    }
+
+    private fun stopHealthCheck() {
+        healthCheckRunnable?.let { healthCheckHandler.removeCallbacks(it) }
+        healthCheckRunnable = null
+
+        checkThread?.let { thread ->
+            if (thread.isAlive) {
+                thread.interrupt()
+            }
+        }
+        checkThread = null
+    }
+
+    /**
+     * Check if I2P proxy is available by attempting a socket connection.
+     * This is the primary method for detecting I2P availability.
+     *
+     * @param onComplete Optional callback with the result (true = available)
+     */
+    fun checkProxyAvailability(onComplete: ((Boolean) -> Unit)? = null) {
+        // Cancel any previous check thread
+        checkThread?.let { thread ->
+            if (thread.isAlive) {
+                thread.interrupt()
+            }
+        }
+
+        checkThread = Thread {
+            if (isShuttingDown) {
+                onComplete?.invoke(false)
+                return@Thread
+            }
+
+            Log.d(TAG, "Checking I2P proxy at $_proxyHost:$_proxyPort")
+
+            try {
+                val socket = Socket()
+                socket.connect(InetSocketAddress(_proxyHost, _proxyPort), SOCKET_TIMEOUT)
+                socket.close()
+
+                if (isShuttingDown) return@Thread
+
+                Handler(Looper.getMainLooper()).post {
+                    if (!isShuttingDown) {
+                        Log.d(TAG, "I2P proxy is AVAILABLE at $_proxyHost:$_proxyPort")
+                        notifyStateChange(I2PState.AVAILABLE)
+                        onComplete?.invoke(true)
+                    }
+                }
+            } catch (e: InterruptedException) {
+                Log.d(TAG, "I2P proxy check interrupted (normal during cleanup)")
+                onComplete?.invoke(false)
+            } catch (e: Exception) {
+                if (isShuttingDown) return@Thread
+
+                Handler(Looper.getMainLooper()).post {
+                    if (!isShuttingDown) {
+                        Log.d(TAG, "I2P proxy is UNAVAILABLE: ${e.message}")
+                        notifyStateChange(I2PState.UNAVAILABLE)
+                        onComplete?.invoke(false)
+                    }
+                }
+            }
+        }
+        checkThread?.start()
+    }
+
+    /**
+     * Synchronously check if I2P proxy is available.
+     * WARNING: This blocks the calling thread. Do not call from main thread.
+     *
+     * @return true if I2P proxy is available
+     */
+    fun checkProxyAvailabilitySync(): Boolean {
+        return try {
+            val socket = Socket()
+            socket.connect(InetSocketAddress(_proxyHost, _proxyPort), SOCKET_TIMEOUT)
+            socket.close()
+            _state = I2PState.AVAILABLE
+            _lastCheckTime = System.currentTimeMillis()
+            true
+        } catch (e: Exception) {
+            _state = I2PState.UNAVAILABLE
+            _lastCheckTime = System.currentTimeMillis()
+            false
+        }
+    }
+
+    /**
+     * Check if I2P proxy is currently available.
+     * This returns the cached state from the last check.
+     */
+    fun isAvailable(): Boolean {
+        return _state == I2PState.AVAILABLE
+    }
+
+    /**
+     * Initialize and check for I2P proxy availability.
+     * Call this when the app starts to detect if I2P router is running.
+     */
+    fun initialize() {
+        isShuttingDown = false
+        checkProxyAvailability()
+    }
+
+    /**
+     * Cleanup resources.
+     * Call this when the app is being destroyed.
+     */
+    fun cleanup() {
+        isShuttingDown = true
+        stopHealthCheck()
+    }
+
+    /**
+     * Configure custom proxy host and port.
+     * Use this if the user has a non-standard I2P proxy configuration.
+     */
+    fun configure(host: String, port: Int) {
+        _proxyHost = host
+        _proxyPort = port
+        // Re-check with new configuration
+        checkProxyAvailability()
+    }
+
+    /**
+     * Reset to default I2P proxy configuration.
+     */
+    fun resetToDefaults() {
+        _proxyHost = DEFAULT_I2P_PROXY_HOST
+        _proxyPort = DEFAULT_I2P_PROXY_PORT
+        checkProxyAvailability()
+    }
+
+    /**
+     * Get a user-friendly status message.
+     */
+    fun getStatusMessage(): String {
+        return when (_state) {
+            I2PState.UNKNOWN -> "I2P status unknown"
+            I2PState.AVAILABLE -> "I2P proxy available"
+            I2PState.UNAVAILABLE -> "I2P proxy not available"
+        }
+    }
+}

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -560,4 +560,9 @@
 
     <!-- Database Encryption -->
     <string name="password_change_rekey_failed">تم تغيير كلمة المرور لكن فشل إعادة تشفير قاعدة البيانات: %s</string>
+
+    <!-- Service Detection Toast Messages -->
+    <string name="toast_tor_not_running">Tor لا يعمل. قم بتشغيل Orbot لتشغيل محطات .onion.</string>
+    <string name="toast_i2p_not_running">I2P لا يعمل. قم بتشغيل موجه I2P لتشغيل محطات .i2p.</string>
+    <string name="toast_tor_not_installed">Orbot غير مثبت. قم بتثبيت Orbot لتشغيل محطات .onion.</string>
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -561,4 +561,9 @@
 
     <!-- Database Encryption -->
     <string name="password_change_rekey_failed">Passwort geändert, aber Datenbank-Neucodierung fehlgeschlagen: %s</string>
+
+    <!-- Service Detection Toast Messages -->
+    <string name="toast_tor_not_running">Tor läuft nicht. Starten Sie Orbot, um .onion-Stationen abzuspielen.</string>
+    <string name="toast_i2p_not_running">I2P läuft nicht. Starten Sie Ihren I2P-Router, um .i2p-Stationen abzuspielen.</string>
+    <string name="toast_tor_not_installed">Orbot ist nicht installiert. Installieren Sie Orbot, um .onion-Stationen abzuspielen.</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -578,4 +578,9 @@
 
     <!-- Database Encryption -->
     <string name="password_change_rekey_failed">Contraseña cambiada pero fallo al renovar clave de base de datos: %s</string>
+
+    <!-- Service Detection Toast Messages -->
+    <string name="toast_tor_not_running">Tor no está ejecutándose. Inicia Orbot para reproducir estaciones .onion.</string>
+    <string name="toast_i2p_not_running">I2P no está ejecutándose. Inicia tu enrutador I2P para reproducir estaciones .i2p.</string>
+    <string name="toast_tor_not_installed">Orbot no está instalado. Instala Orbot para reproducir estaciones .onion.</string>
 </resources>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -561,4 +561,9 @@
 
     <!-- Database Encryption -->
     <string name="password_change_rekey_failed">رمز عبور تغییر کرد اما رمزگذاری مجدد پایگاه داده ناموفق بود: %s</string>
+
+    <!-- Service Detection Toast Messages -->
+    <string name="toast_tor_not_running">Tor در حال اجرا نیست. Orbot را برای پخش ایستگاه‌های .onion راه‌اندازی کنید.</string>
+    <string name="toast_i2p_not_running">I2P در حال اجرا نیست. روتر I2P خود را برای پخش ایستگاه‌های .i2p راه‌اندازی کنید.</string>
+    <string name="toast_tor_not_installed">Orbot نصب نشده است. Orbot را برای پخش ایستگاه‌های .onion نصب کنید.</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -566,4 +566,9 @@
 
     <!-- Database Encryption -->
     <string name="password_change_rekey_failed">Mot de passe modifié mais échec de la re-clé de la base de données : %s</string>
+
+    <!-- Service Detection Toast Messages -->
+    <string name="toast_tor_not_running">Tor ne fonctionne pas. Démarrez Orbot pour lire les stations .onion.</string>
+    <string name="toast_i2p_not_running">I2P ne fonctionne pas. Démarrez votre routeur I2P pour lire les stations .i2p.</string>
+    <string name="toast_tor_not_installed">Orbot n\'est pas installé. Installez Orbot pour lire les stations .onion.</string>
 </resources>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -557,4 +557,9 @@
 
     <!-- Database Encryption -->
     <string name="password_change_rekey_failed">पासवर्ड बदल गया लेकिन डेटाबेस पुन: एन्क्रिप्ट करने में विफल: %s</string>
+
+    <!-- Service Detection Toast Messages -->
+    <string name="toast_tor_not_running">Tor नहीं चल रहा है। .onion स्टेशन चलाने के लिए Orbot शुरू करें।</string>
+    <string name="toast_i2p_not_running">I2P नहीं चल रहा है। .i2p स्टेशन चलाने के लिए अपना I2P राउटर शुरू करें।</string>
+    <string name="toast_tor_not_installed">Orbot इंस्टॉल नहीं है। .onion स्टेशन चलाने के लिए Orbot इंस्टॉल करें।</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -566,4 +566,9 @@
 
     <!-- Database Encryption -->
     <string name="password_change_rekey_failed">Password modificata ma re-chiave database fallita: %s</string>
+
+    <!-- Service Detection Toast Messages -->
+    <string name="toast_tor_not_running">Tor non è in esecuzione. Avvia Orbot per riprodurre le stazioni .onion.</string>
+    <string name="toast_i2p_not_running">I2P non è in esecuzione. Avvia il tuo router I2P per riprodurre le stazioni .i2p.</string>
+    <string name="toast_tor_not_installed">Orbot non è installato. Installa Orbot per riprodurre le stazioni .onion.</string>
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -560,4 +560,9 @@
 
     <!-- Database Encryption -->
     <string name="password_change_rekey_failed">パスワードは変更されましたが、データベースの再暗号化に失敗しました: %s</string>
+
+    <!-- Service Detection Toast Messages -->
+    <string name="toast_tor_not_running">Torが実行されていません。.onionステーションを再生するにはOrbotを起動してください。</string>
+    <string name="toast_i2p_not_running">I2Pが実行されていません。.i2pステーションを再生するにはI2Pルーターを起動してください。</string>
+    <string name="toast_tor_not_installed">Orbotがインストールされていません。.onionステーションを再生するにはOrbotをインストールしてください。</string>
 </resources>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -560,4 +560,9 @@
 
     <!-- Database Encryption -->
     <string name="password_change_rekey_failed">비밀번호는 변경되었지만 데이터베이스 재암호화에 실패했습니다: %s</string>
+
+    <!-- Service Detection Toast Messages -->
+    <string name="toast_tor_not_running">Tor가 실행 중이 아닙니다. .onion 방송국을 재생하려면 Orbot을 시작하세요.</string>
+    <string name="toast_i2p_not_running">I2P가 실행 중이 아닙니다. .i2p 방송국을 재생하려면 I2P 라우터를 시작하세요.</string>
+    <string name="toast_tor_not_installed">Orbot이 설치되어 있지 않습니다. .onion 방송국을 재생하려면 Orbot을 설치하세요.</string>
 </resources>

--- a/app/src/main/res/values-my/strings.xml
+++ b/app/src/main/res/values-my/strings.xml
@@ -558,4 +558,9 @@
 
     <!-- Database Encryption -->
     <string name="password_change_rekey_failed">စကားဝှက် ပြောင်းလဲပြီးပါပြီ သို့သော် ဒေတာဘေ့စ် ပြန်လည်ကုဒ်ဝှက်မှု မအောင်မြင်ပါ: %s</string>
+
+    <!-- Service Detection Toast Messages -->
+    <string name="toast_tor_not_running">Tor မလည်ပတ်ပါ။ .onion ဘူတာများဖွင့်ရန် Orbot စတင်ပါ။</string>
+    <string name="toast_i2p_not_running">I2P မလည်ပတ်ပါ။ .i2p ဘူတာများဖွင့်ရန် သင့် I2P router စတင်ပါ။</string>
+    <string name="toast_tor_not_installed">Orbot ထည့်သွင်းမထားပါ။ .onion ဘူတာများဖွင့်ရန် Orbot ထည့်သွင်းပါ။</string>
 </resources>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -561,4 +561,9 @@
 
     <!-- Database Encryption -->
     <string name="password_change_rekey_failed">Senha alterada mas falha ao re-codificar banco de dados: %s</string>
+
+    <!-- Service Detection Toast Messages -->
+    <string name="toast_tor_not_running">Tor não está em execução. Inicie o Orbot para reproduzir estações .onion.</string>
+    <string name="toast_i2p_not_running">I2P não está em execução. Inicie seu roteador I2P para reproduzir estações .i2p.</string>
+    <string name="toast_tor_not_installed">Orbot não está instalado. Instale o Orbot para reproduzir estações .onion.</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -560,4 +560,9 @@
 
     <!-- Database Encryption -->
     <string name="password_change_rekey_failed">Пароль изменён, но не удалось перешифровать базу данных: %s</string>
+
+    <!-- Service Detection Toast Messages -->
+    <string name="toast_tor_not_running">Tor не запущен. Запустите Orbot для воспроизведения .onion станций.</string>
+    <string name="toast_i2p_not_running">I2P не запущен. Запустите I2P роутер для воспроизведения .i2p станций.</string>
+    <string name="toast_tor_not_installed">Orbot не установлен. Установите Orbot для воспроизведения .onion станций.</string>
 </resources>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -561,4 +561,9 @@
 
     <!-- Database Encryption -->
     <string name="password_change_rekey_failed">Şifre değiştirildi ancak veritabanı yeniden şifrelenemedi: %s</string>
+
+    <!-- Service Detection Toast Messages -->
+    <string name="toast_tor_not_running">Tor çalışmıyor. .onion istasyonlarını oynatmak için Orbot\'u başlatın.</string>
+    <string name="toast_i2p_not_running">I2P çalışmıyor. .i2p istasyonlarını oynatmak için I2P yönlendiricinizi başlatın.</string>
+    <string name="toast_tor_not_installed">Orbot yüklü değil. .onion istasyonlarını oynatmak için Orbot\'u yükleyin.</string>
 </resources>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -561,4 +561,9 @@
 
     <!-- Database Encryption -->
     <string name="password_change_rekey_failed">Пароль змінено, але не вдалося перешифрувати базу даних: %s</string>
+
+    <!-- Service Detection Toast Messages -->
+    <string name="toast_tor_not_running">Tor не запущено. Запустіть Orbot для відтворення .onion станцій.</string>
+    <string name="toast_i2p_not_running">I2P не запущено. Запустіть I2P роутер для відтворення .i2p станцій.</string>
+    <string name="toast_tor_not_installed">Orbot не встановлено. Встановіть Orbot для відтворення .onion станцій.</string>
 </resources>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -561,4 +561,9 @@
 
     <!-- Database Encryption -->
     <string name="password_change_rekey_failed">Đã đổi mật khẩu nhưng không thể mã hóa lại cơ sở dữ liệu: %s</string>
+
+    <!-- Service Detection Toast Messages -->
+    <string name="toast_tor_not_running">Tor không chạy. Khởi động Orbot để phát các đài .onion.</string>
+    <string name="toast_i2p_not_running">I2P không chạy. Khởi động bộ định tuyến I2P để phát các đài .i2p.</string>
+    <string name="toast_tor_not_installed">Orbot chưa được cài đặt. Cài đặt Orbot để phát các đài .onion.</string>
 </resources>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -561,4 +561,9 @@
 
     <!-- Database Encryption -->
     <string name="password_change_rekey_failed">密码已更改，但数据库重新加密失败：%s</string>
+
+    <!-- Service Detection Toast Messages -->
+    <string name="toast_tor_not_running">Tor未运行。启动Orbot以播放.onion电台。</string>
+    <string name="toast_i2p_not_running">I2P未运行。启动I2P路由器以播放.i2p电台。</string>
+    <string name="toast_tor_not_installed">未安装Orbot。安装Orbot以播放.onion电台。</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -574,4 +574,9 @@
 
     <!-- Database Encryption -->
     <string name="password_change_rekey_failed">Password changed but failed to re-key database: %s</string>
+
+    <!-- Service Detection Toast Messages -->
+    <string name="toast_tor_not_running">Tor is not running. Start Orbot to play .onion stations.</string>
+    <string name="toast_i2p_not_running">I2P is not running. Start your I2P router to play .i2p stations.</string>
+    <string name="toast_tor_not_installed">Orbot is not installed. Install Orbot to play .onion stations.</string>
 </resources>


### PR DESCRIPTION
When users try to play .onion or .i2p stations without the required service running, they now get a helpful toast message instead of just having the stream fail to connect.

- Add I2PManager for detecting I2P HTTP proxy availability (port 4444)
- Add pre-playback checks in LibraryFragment and BrowseStationsFragment
- Show toast if Orbot not installed for .onion stations
- Show toast if Tor not connected for .onion stations
- Show toast if I2P router not running for .i2p stations
- Add localized toast messages for all 17 supported languages