### PR TITLE
Add carousel titles and buttons to localization

### DIFF
--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -98,6 +98,19 @@
     <string name="station_added_to_favorites">تمت إضافة %s إلى المفضلة</string>
     <string name="station_removed_from_favorites">تمت إزالة %s من المفضلة</string>
     <string name="tor_required_warning">تم تمكين فرض Tor لكن Tor غير متصل. اتصل بـ Tor لتصفح المحطات.</string>
+    <string name="browse_by_genre">تصفح حسب النوع</string>
+    <string name="browse_trending">الأكثر رواجاً الآن</string>
+    <string name="browse_new_stations">محطات جديدة</string>
+    <string name="browse_popular_usa">شائع في الولايات المتحدة</string>
+    <string name="browse_popular_germany">شائع في ألمانيا</string>
+    <string name="browse_spanish_radio">الراديو الإسباني</string>
+    <string name="browse_french_radio">الراديو الفرنسي</string>
+    <string name="see_all">عرض الكل</string>
+    <string name="add_filter">فلتر</string>
+    <string name="browse_results_count">جارٍ التحميل…</string>
+    <string name="browse_results_format">%d محطة</string>
+    <string name="back">رجوع</string>
+    <string name="browse_all_stations">جميع المحطات</string>
 
     <!-- Notification and Status Messages -->
     <string name="notification_connecting">جارٍ الاتصال...</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -98,6 +98,19 @@
     <string name="station_added_to_favorites">%s zu Favoriten hinzugefügt</string>
     <string name="station_removed_from_favorites">%s aus Favoriten entfernt</string>
     <string name="tor_required_warning">Tor erzwingen ist aktiviert, aber Tor ist nicht verbunden. Verbinden Sie sich mit Tor, um Sender zu durchsuchen.</string>
+    <string name="browse_by_genre">Nach Genre durchsuchen</string>
+    <string name="browse_trending">Aktuell im Trend</string>
+    <string name="browse_new_stations">Neue Sender</string>
+    <string name="browse_popular_usa">Beliebt in den USA</string>
+    <string name="browse_popular_germany">Beliebt in Deutschland</string>
+    <string name="browse_spanish_radio">Spanisches Radio</string>
+    <string name="browse_french_radio">Französisches Radio</string>
+    <string name="see_all">Alle anzeigen</string>
+    <string name="add_filter">Filter</string>
+    <string name="browse_results_count">Lädt…</string>
+    <string name="browse_results_format">%d Sender</string>
+    <string name="back">Zurück</string>
+    <string name="browse_all_stations">Alle Sender</string>
 
     <!-- Notification and Status Messages -->
     <string name="notification_connecting">Verbinden...</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -98,6 +98,19 @@
     <string name="station_added_to_favorites">%s به علاقه‌مندی‌ها اضافه شد</string>
     <string name="station_removed_from_favorites">%s از علاقه‌مندی‌ها حذف شد</string>
     <string name="tor_required_warning">اجبار Tor فعال است اما Tor متصل نیست. برای مرور ایستگاه‌ها به Tor متصل شوید.</string>
+    <string name="browse_by_genre">مرور بر اساس ژانر</string>
+    <string name="browse_trending">پرطرفدار در حال حاضر</string>
+    <string name="browse_new_stations">ایستگاه‌های جدید</string>
+    <string name="browse_popular_usa">محبوب در ایالات متحده</string>
+    <string name="browse_popular_germany">محبوب در آلمان</string>
+    <string name="browse_spanish_radio">رادیو اسپانیایی</string>
+    <string name="browse_french_radio">رادیو فرانسوی</string>
+    <string name="see_all">مشاهده همه</string>
+    <string name="add_filter">فیلتر</string>
+    <string name="browse_results_count">در حال بارگذاری…</string>
+    <string name="browse_results_format">%d ایستگاه</string>
+    <string name="back">بازگشت</string>
+    <string name="browse_all_stations">همه ایستگاه‌ها</string>
 
     <!-- Notification and Status Messages -->
     <string name="notification_connecting">در حال اتصال...</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -105,6 +105,19 @@
     <string name="station_added_to_favorites">%s ajoutée aux favoris</string>
     <string name="station_removed_from_favorites">%s retirée des favoris</string>
     <string name="tor_required_warning">Forcer Tor est activé mais Tor n\'est pas connecté. Connectez-vous à Tor pour parcourir les stations.</string>
+    <string name="browse_by_genre">Parcourir par genre</string>
+    <string name="browse_trending">Tendances actuelles</string>
+    <string name="browse_new_stations">Nouvelles stations</string>
+    <string name="browse_popular_usa">Populaire aux États-Unis</string>
+    <string name="browse_popular_germany">Populaire en Allemagne</string>
+    <string name="browse_spanish_radio">Radio espagnole</string>
+    <string name="browse_french_radio">Radio française</string>
+    <string name="see_all">Tout voir</string>
+    <string name="add_filter">Filtre</string>
+    <string name="browse_results_count">Chargement…</string>
+    <string name="browse_results_format">%d stations</string>
+    <string name="back">Retour</string>
+    <string name="browse_all_stations">Toutes les stations</string>
 
     <!-- Notification and Status Messages -->
     <string name="notification_connecting">Connexion...</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -95,6 +95,19 @@
     <string name="station_added_to_favorites">%s पसंदीदा में जोड़ा गया</string>
     <string name="station_removed_from_favorites">%s पसंदीदा से हटाया गया</string>
     <string name="tor_required_warning">Tor को फ़ोर्स करें सक्षम है लेकिन Tor कनेक्ट नहीं है। स्टेशनों को ब्राउज़ करने के लिए Tor से कनेक्ट करें।</string>
+    <string name="browse_by_genre">शैली के अनुसार ब्राउज़ करें</string>
+    <string name="browse_trending">अभी ट्रेंडिंग</string>
+    <string name="browse_new_stations">नए स्टेशन</string>
+    <string name="browse_popular_usa">अमेरिका में लोकप्रिय</string>
+    <string name="browse_popular_germany">जर्मनी में लोकप्रिय</string>
+    <string name="browse_spanish_radio">स्पैनिश रेडियो</string>
+    <string name="browse_french_radio">फ्रेंच रेडियो</string>
+    <string name="see_all">सभी देखें</string>
+    <string name="add_filter">फ़िल्टर</string>
+    <string name="browse_results_count">लोड हो रहा है…</string>
+    <string name="browse_results_format">%d स्टेशन</string>
+    <string name="back">वापस</string>
+    <string name="browse_all_stations">सभी स्टेशन</string>
 
     <!-- Notification and Status Messages -->
     <string name="notification_connecting">कनेक्ट हो रहा है...</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -105,6 +105,19 @@
     <string name="station_added_to_favorites">%s aggiunta ai preferiti</string>
     <string name="station_removed_from_favorites">%s rimossa dai preferiti</string>
     <string name="tor_required_warning">Forza Tor è abilitato ma Tor non è connesso. Connettiti a Tor per sfogliare le stazioni.</string>
+    <string name="browse_by_genre">Sfoglia per genere</string>
+    <string name="browse_trending">Di tendenza ora</string>
+    <string name="browse_new_stations">Nuove stazioni</string>
+    <string name="browse_popular_usa">Popolare negli USA</string>
+    <string name="browse_popular_germany">Popolare in Germania</string>
+    <string name="browse_spanish_radio">Radio spagnola</string>
+    <string name="browse_french_radio">Radio francese</string>
+    <string name="see_all">Vedi tutto</string>
+    <string name="add_filter">Filtro</string>
+    <string name="browse_results_count">Caricamento…</string>
+    <string name="browse_results_format">%d stazioni</string>
+    <string name="back">Indietro</string>
+    <string name="browse_all_stations">Tutte le stazioni</string>
 
     <!-- Notification and Status Messages -->
     <string name="notification_connecting">Connessione in corso...</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -98,6 +98,19 @@
     <string name="station_added_to_favorites">%sをお気に入りに追加しました</string>
     <string name="station_removed_from_favorites">%sをお気に入りから削除しました</string>
     <string name="tor_required_warning">Tor強制が有効ですが、Torが接続されていません。ステーションを閲覧するにはTorに接続してください。</string>
+    <string name="browse_by_genre">ジャンル別に閲覧</string>
+    <string name="browse_trending">今人気</string>
+    <string name="browse_new_stations">新しいステーション</string>
+    <string name="browse_popular_usa">アメリカで人気</string>
+    <string name="browse_popular_germany">ドイツで人気</string>
+    <string name="browse_spanish_radio">スペイン語ラジオ</string>
+    <string name="browse_french_radio">フランス語ラジオ</string>
+    <string name="see_all">すべて表示</string>
+    <string name="add_filter">フィルター</string>
+    <string name="browse_results_count">読み込み中…</string>
+    <string name="browse_results_format">%d ステーション</string>
+    <string name="back">戻る</string>
+    <string name="browse_all_stations">すべてのステーション</string>
 
     <!-- Notification and Status Messages -->
     <string name="notification_connecting">接続中...</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -98,6 +98,19 @@
     <string name="station_added_to_favorites">%s이(가) 즐겨찾기에 추가됨</string>
     <string name="station_removed_from_favorites">%s이(가) 즐겨찾기에서 제거됨</string>
     <string name="tor_required_warning">강제 Tor가 활성화되었지만 Tor가 연결되지 않았습니다. 방송국을 탐색하려면 Tor에 연결하세요.</string>
+    <string name="browse_by_genre">장르별로 탐색</string>
+    <string name="browse_trending">지금 인기</string>
+    <string name="browse_new_stations">새로운 스테이션</string>
+    <string name="browse_popular_usa">미국에서 인기</string>
+    <string name="browse_popular_germany">독일에서 인기</string>
+    <string name="browse_spanish_radio">스페인어 라디오</string>
+    <string name="browse_french_radio">프랑스어 라디오</string>
+    <string name="see_all">모두 보기</string>
+    <string name="add_filter">필터</string>
+    <string name="browse_results_count">로딩 중…</string>
+    <string name="browse_results_format">%d개 스테이션</string>
+    <string name="back">뒤로</string>
+    <string name="browse_all_stations">모든 스테이션</string>
 
     <!-- Notification and Status Messages -->
     <string name="notification_connecting">연결 중...</string>

--- a/app/src/main/res/values-my/strings.xml
+++ b/app/src/main/res/values-my/strings.xml
@@ -95,6 +95,19 @@
     <string name="station_added_to_favorites">%s ကို အကြိုက်ဆုံးများသို့ ထည့်ပြီးပါပြီ</string>
     <string name="station_removed_from_favorites">%s ကို အကြိုက်ဆုံးများမှ ဖယ်ရှားပြီးပါပြီ</string>
     <string name="tor_required_warning">Tor ကို အတင်းအဓမ္မ သုံးရန် ဖွင့်ထားသော်လည်း Tor မချိတ်ဆက်ထားပါ။ စတေးရှင်းများကို ရှာကြည့်ရန် Tor သို့ ချိတ်ဆက်ပါ။</string>
+    <string name="browse_by_genre">အမျိုးအစားအလိုက် ရှာဖွေရန်</string>
+    <string name="browse_trending">လက်ရှိ လူကြိုက်များသော</string>
+    <string name="browse_new_stations">စခန်းအသစ်များ</string>
+    <string name="browse_popular_usa">အမေရိကတွင် လူကြိုက်များသော</string>
+    <string name="browse_popular_germany">ဂျာမနီတွင် လူကြိုက်များသော</string>
+    <string name="browse_spanish_radio">စပိန်ရေဒီယို</string>
+    <string name="browse_french_radio">ပြင်သစ်ရေဒီယို</string>
+    <string name="see_all">အားလုံးကြည့်ရန်</string>
+    <string name="add_filter">စစ်ထုတ်မှု</string>
+    <string name="browse_results_count">တင်နေသည်…</string>
+    <string name="browse_results_format">%d စခန်းများ</string>
+    <string name="back">နောက်သို့</string>
+    <string name="browse_all_stations">စခန်းအားလုံး</string>
 
     <!-- Notification and Status Messages -->
     <string name="notification_connecting">ချိတ်ဆက်နေသည်...</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -98,6 +98,19 @@
     <string name="station_added_to_favorites">%s adicionada aos favoritos</string>
     <string name="station_removed_from_favorites">%s removida dos favoritos</string>
     <string name="tor_required_warning">Forçar Tor está ativado mas Tor não está conectado. Conecte-se ao Tor para explorar estações.</string>
+    <string name="browse_by_genre">Navegar por gênero</string>
+    <string name="browse_trending">Em alta agora</string>
+    <string name="browse_new_stations">Novas estações</string>
+    <string name="browse_popular_usa">Popular nos EUA</string>
+    <string name="browse_popular_germany">Popular na Alemanha</string>
+    <string name="browse_spanish_radio">Rádio espanhola</string>
+    <string name="browse_french_radio">Rádio francesa</string>
+    <string name="see_all">Ver tudo</string>
+    <string name="add_filter">Filtro</string>
+    <string name="browse_results_count">Carregando…</string>
+    <string name="browse_results_format">%d estações</string>
+    <string name="back">Voltar</string>
+    <string name="browse_all_stations">Todas as estações</string>
 
     <!-- Notification and Status Messages -->
     <string name="notification_connecting">Conectando...</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -98,6 +98,19 @@
     <string name="station_added_to_favorites">%s добавлена в избранное</string>
     <string name="station_removed_from_favorites">%s удалена из избранного</string>
     <string name="tor_required_warning">Принудительный Tor включён, но Tor не подключён. Подключитесь к Tor для просмотра станций.</string>
+    <string name="browse_by_genre">Обзор по жанрам</string>
+    <string name="browse_trending">В тренде сейчас</string>
+    <string name="browse_new_stations">Новые станции</string>
+    <string name="browse_popular_usa">Популярно в США</string>
+    <string name="browse_popular_germany">Популярно в Германии</string>
+    <string name="browse_spanish_radio">Испанское радио</string>
+    <string name="browse_french_radio">Французское радио</string>
+    <string name="see_all">Показать все</string>
+    <string name="add_filter">Фильтр</string>
+    <string name="browse_results_count">Загрузка…</string>
+    <string name="browse_results_format">%d станций</string>
+    <string name="back">Назад</string>
+    <string name="browse_all_stations">Все станции</string>
 
     <!-- Notification and Status Messages -->
     <string name="notification_connecting">Подключение...</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -98,6 +98,19 @@
     <string name="station_added_to_favorites">%s favorilere eklendi</string>
     <string name="station_removed_from_favorites">%s favorilerden kaldırıldı</string>
     <string name="tor_required_warning">Tor Zorla etkin ancak Tor bağlı değil. İstasyonlara göz atmak için Tor\'a bağlanın.</string>
+    <string name="browse_by_genre">Türe göre göz at</string>
+    <string name="browse_trending">Şu anda popüler</string>
+    <string name="browse_new_stations">Yeni istasyonlar</string>
+    <string name="browse_popular_usa">ABD\'de popüler</string>
+    <string name="browse_popular_germany">Almanya\'da popüler</string>
+    <string name="browse_spanish_radio">İspanyol Radyosu</string>
+    <string name="browse_french_radio">Fransız Radyosu</string>
+    <string name="see_all">Tümünü gör</string>
+    <string name="add_filter">Filtre</string>
+    <string name="browse_results_count">Yükleniyor…</string>
+    <string name="browse_results_format">%d istasyon</string>
+    <string name="back">Geri</string>
+    <string name="browse_all_stations">Tüm istasyonlar</string>
 
     <!-- Notification and Status Messages -->
     <string name="notification_connecting">Bağlanıyor...</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -98,6 +98,19 @@
     <string name="station_added_to_favorites">%s додано до улюблених</string>
     <string name="station_removed_from_favorites">%s видалено з улюблених</string>
     <string name="tor_required_warning">Примусовий Tor увімкнено, але Tor не підключено. Підключіться до Tor для перегляду станцій.</string>
+    <string name="browse_by_genre">Перегляд за жанрами</string>
+    <string name="browse_trending">Зараз у тренді</string>
+    <string name="browse_new_stations">Нові станції</string>
+    <string name="browse_popular_usa">Популярне у США</string>
+    <string name="browse_popular_germany">Популярне у Німеччині</string>
+    <string name="browse_spanish_radio">Іспанське радіо</string>
+    <string name="browse_french_radio">Французьке радіо</string>
+    <string name="see_all">Показати все</string>
+    <string name="add_filter">Фільтр</string>
+    <string name="browse_results_count">Завантаження…</string>
+    <string name="browse_results_format">%d станцій</string>
+    <string name="back">Назад</string>
+    <string name="browse_all_stations">Усі станції</string>
 
     <!-- Notification and Status Messages -->
     <string name="notification_connecting">Підключення...</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -98,6 +98,19 @@
     <string name="station_added_to_favorites">Đã thêm %s vào yêu thích</string>
     <string name="station_removed_from_favorites">Đã xóa %s khỏi yêu thích</string>
     <string name="tor_required_warning">Bắt buộc Tor đã bật nhưng Tor chưa kết nối. Kết nối với Tor để duyệt các trạm.</string>
+    <string name="browse_by_genre">Duyệt theo thể loại</string>
+    <string name="browse_trending">Đang thịnh hành</string>
+    <string name="browse_new_stations">Trạm mới</string>
+    <string name="browse_popular_usa">Phổ biến ở Mỹ</string>
+    <string name="browse_popular_germany">Phổ biến ở Đức</string>
+    <string name="browse_spanish_radio">Radio tiếng Tây Ban Nha</string>
+    <string name="browse_french_radio">Radio tiếng Pháp</string>
+    <string name="see_all">Xem tất cả</string>
+    <string name="add_filter">Bộ lọc</string>
+    <string name="browse_results_count">Đang tải…</string>
+    <string name="browse_results_format">%d trạm</string>
+    <string name="back">Quay lại</string>
+    <string name="browse_all_stations">Tất cả các trạm</string>
 
     <!-- Notification and Status Messages -->
     <string name="notification_connecting">Đang kết nối...</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -98,6 +98,19 @@
     <string name="station_added_to_favorites">%s 已添加到收藏</string>
     <string name="station_removed_from_favorites">%s 已从收藏移除</string>
     <string name="tor_required_warning">强制 Tor 已启用但 Tor 未连接。请连接到 Tor 以浏览电台。</string>
+    <string name="browse_by_genre">按类型浏览</string>
+    <string name="browse_trending">当前热门</string>
+    <string name="browse_new_stations">新电台</string>
+    <string name="browse_popular_usa">美国热门</string>
+    <string name="browse_popular_germany">德国热门</string>
+    <string name="browse_spanish_radio">西班牙语电台</string>
+    <string name="browse_french_radio">法语电台</string>
+    <string name="see_all">查看全部</string>
+    <string name="add_filter">筛选</string>
+    <string name="browse_results_count">加载中…</string>
+    <string name="browse_results_format">%d 个电台</string>
+    <string name="back">返回</string>
+    <string name="browse_all_stations">所有电台</string>
 
     <!-- Notification and Status Messages -->
     <string name="notification_connecting">连接中...</string>


### PR DESCRIPTION
Add translations for carousel titles, "See All", and "Browse by Genre" to all 16 language files (ar, de, es, fa, fr, hi, it, ja, ko, my, pt, ru, tr, uk, vi, zh). These strings were already properly referenced in the layout files but were missing translations in most languages.