### PR TITLE
Fix unresolved reference error in BrowseStationsFragment

### DIFF
--- a/app/src/main/java/com/opensource/i2pradio/ui/browse/BrowseStationsFragment.kt
+++ b/app/src/main/java/com/opensource/i2pradio/ui/browse/BrowseStationsFragment.kt
@@ -1114,7 +1114,7 @@ class BrowseStationsFragment : Fragment() {
     }
 
     private fun playStation(station: RadioBrowserStation) {
-        val streamUrl = station.url_resolved ?: station.url
+        val streamUrl = station.urlResolved ?: station.url
         val isTorStation = streamUrl.contains(".onion")
         val isI2PStation = streamUrl.contains(".i2p")
 


### PR DESCRIPTION
Changed 'url_resolved' to 'urlResolved' to match the property name in RadioBrowserStation data class.