### PR TITLE
Add skeleton screen loading animation to browse tab

### DIFF
--- a/app/src/main/java/com/opensource/i2pradio/ui/ShimmerFrameLayout.kt
+++ b/app/src/main/java/com/opensource/i2pradio/ui/ShimmerFrameLayout.kt
@@ -1,0 +1,116 @@
+package com.opensource.i2pradio.ui
+
+import android.animation.ValueAnimator
+import android.content.Context
+import android.graphics.Canvas
+import android.graphics.LinearGradient
+import android.graphics.Matrix
+import android.graphics.Paint
+import android.graphics.Shader
+import android.util.AttributeSet
+import android.view.animation.LinearInterpolator
+import android.widget.FrameLayout
+import androidx.core.content.ContextCompat
+import com.opensource.i2pradio.R
+
+/**
+ * A FrameLayout that applies a shimmer animation effect to its contents.
+ * Used for skeleton loading screens.
+ */
+class ShimmerFrameLayout @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+    defStyleAttr: Int = 0
+) : FrameLayout(context, attrs, defStyleAttr) {
+
+    private val shimmerPaint = Paint()
+    private var shimmerAnimator: ValueAnimator? = null
+    private var shimmerTranslate: Float = 0f
+    private val shimmerMatrix = Matrix()
+    private var shimmerGradient: LinearGradient? = null
+
+    private var shimmerWidth = 0
+    private var shimmerColor = 0x33FFFFFF // Semi-transparent white
+    private var shimmerDuration = 1200L
+    private var isShimmerStarted = false
+
+    init {
+        setWillNotDraw(false)
+        shimmerPaint.isAntiAlias = true
+    }
+
+    override fun onSizeChanged(w: Int, h: Int, oldw: Int, oldh: Int) {
+        super.onSizeChanged(w, h, oldw, oldh)
+        if (w > 0 && h > 0) {
+            shimmerWidth = w / 3
+            createShimmerGradient()
+        }
+    }
+
+    private fun createShimmerGradient() {
+        shimmerGradient = LinearGradient(
+            0f, 0f, shimmerWidth.toFloat(), 0f,
+            intArrayOf(
+                0x00FFFFFF,
+                shimmerColor,
+                0x00FFFFFF
+            ),
+            floatArrayOf(0f, 0.5f, 1f),
+            Shader.TileMode.CLAMP
+        )
+        shimmerPaint.shader = shimmerGradient
+    }
+
+    override fun dispatchDraw(canvas: Canvas) {
+        super.dispatchDraw(canvas)
+
+        if (isShimmerStarted && shimmerGradient != null && width > 0) {
+            shimmerMatrix.reset()
+            shimmerMatrix.setTranslate(shimmerTranslate, 0f)
+            shimmerGradient?.setLocalMatrix(shimmerMatrix)
+
+            canvas.save()
+            canvas.drawRect(0f, 0f, width.toFloat(), height.toFloat(), shimmerPaint)
+            canvas.restore()
+        }
+    }
+
+    fun startShimmer() {
+        if (isShimmerStarted) return
+        isShimmerStarted = true
+
+        shimmerAnimator?.cancel()
+        shimmerAnimator = ValueAnimator.ofFloat(-shimmerWidth.toFloat(), width.toFloat() + shimmerWidth).apply {
+            duration = shimmerDuration
+            interpolator = LinearInterpolator()
+            repeatCount = ValueAnimator.INFINITE
+            repeatMode = ValueAnimator.RESTART
+            addUpdateListener { animation ->
+                shimmerTranslate = animation.animatedValue as Float
+                invalidate()
+            }
+            start()
+        }
+    }
+
+    fun stopShimmer() {
+        isShimmerStarted = false
+        shimmerAnimator?.cancel()
+        shimmerAnimator = null
+        invalidate()
+    }
+
+    fun isShimmerStarted(): Boolean = isShimmerStarted
+
+    override fun onAttachedToWindow() {
+        super.onAttachedToWindow()
+        if (isShimmerStarted) {
+            startShimmer()
+        }
+    }
+
+    override fun onDetachedFromWindow() {
+        stopShimmer()
+        super.onDetachedFromWindow()
+    }
+}

--- a/app/src/main/java/com/opensource/i2pradio/ui/browse/BrowseViewModel.kt
+++ b/app/src/main/java/com/opensource/i2pradio/ui/browse/BrowseViewModel.kt
@@ -103,6 +103,10 @@ class BrowseViewModel(application: Application) : AndroidViewModel(application) 
     // Track if discovery data has been loaded
     private var discoveryDataLoaded = false
 
+    // Discovery loading state
+    private val _isDiscoveryLoading = MutableLiveData(true)
+    val isDiscoveryLoading: LiveData<Boolean> = _isDiscoveryLoading
+
     // Pagination
     private var currentOffset = 0
     private val pageSize = 50
@@ -136,6 +140,7 @@ class BrowseViewModel(application: Application) : AndroidViewModel(application) 
     fun loadDiscoveryData(forceRefresh: Boolean = false) {
         if (discoveryDataLoaded && !forceRefresh) return
         discoveryDataLoaded = true
+        _isDiscoveryLoading.value = true
 
         viewModelScope.launch {
             // Load USA stations
@@ -185,6 +190,8 @@ class BrowseViewModel(application: Application) : AndroidViewModel(application) 
                 is RadioBrowserResult.Success -> _newStations.value = result.data
                 else -> {}
             }
+
+            _isDiscoveryLoading.value = false
         }
     }
 

--- a/app/src/main/java/com/opensource/i2pradio/ui/browse/SkeletonCarouselAdapter.kt
+++ b/app/src/main/java/com/opensource/i2pradio/ui/browse/SkeletonCarouselAdapter.kt
@@ -1,0 +1,77 @@
+package com.opensource.i2pradio.ui.browse
+
+import android.animation.ValueAnimator
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.view.animation.LinearInterpolator
+import androidx.recyclerview.widget.RecyclerView
+import com.opensource.i2pradio.R
+
+/**
+ * Adapter that displays skeleton placeholder cards with shimmer animation.
+ * Used while carousel data is loading.
+ */
+class SkeletonCarouselAdapter(
+    private val itemCount: Int = 4
+) : RecyclerView.Adapter<SkeletonCarouselAdapter.ViewHolder>() {
+
+    private val shimmerAnimators = mutableListOf<ValueAnimator>()
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
+        val view = LayoutInflater.from(parent.context)
+            .inflate(R.layout.item_browse_station_card_skeleton, parent, false)
+        return ViewHolder(view)
+    }
+
+    override fun onBindViewHolder(holder: ViewHolder, position: Int) {
+        holder.startShimmer(position)
+    }
+
+    override fun onViewRecycled(holder: ViewHolder) {
+        super.onViewRecycled(holder)
+        holder.stopShimmer()
+    }
+
+    override fun getItemCount(): Int = itemCount
+
+    fun stopAllShimmers() {
+        shimmerAnimators.forEach { it.cancel() }
+        shimmerAnimators.clear()
+    }
+
+    inner class ViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
+        private val shimmerOverlay: View = itemView.findViewById(R.id.shimmerOverlay)
+        private var animator: ValueAnimator? = null
+
+        fun startShimmer(position: Int) {
+            val parent = itemView.parent as? ViewGroup ?: return
+            val itemWidth = itemView.width.takeIf { it > 0 } ?: 150.dpToPx(itemView.context)
+            val shimmerWidth = shimmerOverlay.width.takeIf { it > 0 } ?: 80.dpToPx(itemView.context)
+
+            animator?.cancel()
+            animator = ValueAnimator.ofFloat(-shimmerWidth.toFloat(), itemWidth.toFloat()).apply {
+                duration = 1000L
+                startDelay = (position * 100L) // Staggered animation
+                interpolator = LinearInterpolator()
+                repeatCount = ValueAnimator.INFINITE
+                repeatMode = ValueAnimator.RESTART
+                addUpdateListener { animation ->
+                    shimmerOverlay.translationX = animation.animatedValue as Float
+                }
+                start()
+            }
+            animator?.let { shimmerAnimators.add(it) }
+        }
+
+        fun stopShimmer() {
+            animator?.cancel()
+            animator?.let { shimmerAnimators.remove(it) }
+            animator = null
+        }
+
+        private fun Int.dpToPx(context: android.content.Context): Int {
+            return (this * context.resources.displayMetrics.density).toInt()
+        }
+    }
+}

--- a/app/src/main/java/com/opensource/i2pradio/ui/browse/SkeletonListAdapter.kt
+++ b/app/src/main/java/com/opensource/i2pradio/ui/browse/SkeletonListAdapter.kt
@@ -1,0 +1,79 @@
+package com.opensource.i2pradio.ui.browse
+
+import android.animation.ValueAnimator
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.view.animation.LinearInterpolator
+import androidx.recyclerview.widget.RecyclerView
+import com.opensource.i2pradio.R
+
+/**
+ * Adapter that displays skeleton placeholder list items with shimmer animation.
+ * Used while search results are loading.
+ */
+class SkeletonListAdapter(
+    private val itemCount: Int = 6
+) : RecyclerView.Adapter<SkeletonListAdapter.ViewHolder>() {
+
+    private val shimmerAnimators = mutableListOf<ValueAnimator>()
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
+        val view = LayoutInflater.from(parent.context)
+            .inflate(R.layout.item_browse_station_skeleton, parent, false)
+        return ViewHolder(view)
+    }
+
+    override fun onBindViewHolder(holder: ViewHolder, position: Int) {
+        holder.startShimmer(position)
+    }
+
+    override fun onViewRecycled(holder: ViewHolder) {
+        super.onViewRecycled(holder)
+        holder.stopShimmer()
+    }
+
+    override fun getItemCount(): Int = itemCount
+
+    fun stopAllShimmers() {
+        shimmerAnimators.forEach { it.cancel() }
+        shimmerAnimators.clear()
+    }
+
+    inner class ViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
+        private val shimmerOverlay: View = itemView.findViewById(R.id.shimmerOverlay)
+        private var animator: ValueAnimator? = null
+
+        fun startShimmer(position: Int) {
+            // Post to ensure measurements are available
+            itemView.post {
+                val itemWidth = itemView.width.takeIf { it > 0 } ?: return@post
+                val shimmerWidth = shimmerOverlay.width.takeIf { it > 0 } ?: 100.dpToPx(itemView.context)
+
+                animator?.cancel()
+                animator = ValueAnimator.ofFloat(-shimmerWidth.toFloat(), itemWidth.toFloat()).apply {
+                    duration = 1200L
+                    startDelay = (position * 80L) // Staggered animation
+                    interpolator = LinearInterpolator()
+                    repeatCount = ValueAnimator.INFINITE
+                    repeatMode = ValueAnimator.RESTART
+                    addUpdateListener { animation ->
+                        shimmerOverlay.translationX = animation.animatedValue as Float
+                    }
+                    start()
+                }
+                animator?.let { shimmerAnimators.add(it) }
+            }
+        }
+
+        fun stopShimmer() {
+            animator?.cancel()
+            animator?.let { shimmerAnimators.remove(it) }
+            animator = null
+        }
+
+        private fun Int.dpToPx(context: android.content.Context): Int {
+            return (this * context.resources.displayMetrics.density).toInt()
+        }
+    }
+}

--- a/app/src/main/res/drawable/skeleton_placeholder.xml
+++ b/app/src/main/res/drawable/skeleton_placeholder.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Skeleton placeholder background with rounded corners -->
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="?attr/colorSurfaceContainerHighest" />
+    <corners android:radius="8dp" />
+</shape>

--- a/app/src/main/res/drawable/skeleton_placeholder_circle.xml
+++ b/app/src/main/res/drawable/skeleton_placeholder_circle.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Circular skeleton placeholder for icons/avatars -->
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="oval">
+    <solid android:color="?attr/colorSurfaceContainerHighest" />
+</shape>

--- a/app/src/main/res/drawable/skeleton_placeholder_image.xml
+++ b/app/src/main/res/drawable/skeleton_placeholder_image.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Skeleton placeholder for images with medium corner radius -->
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="?attr/colorSurfaceContainerHighest" />
+    <corners android:radius="12dp" />
+</shape>

--- a/app/src/main/res/drawable/skeleton_shimmer_gradient.xml
+++ b/app/src/main/res/drawable/skeleton_shimmer_gradient.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Shimmer gradient for skeleton loading animation -->
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <gradient
+        android:angle="0"
+        android:startColor="@android:color/transparent"
+        android:centerColor="#33FFFFFF"
+        android:endColor="@android:color/transparent"
+        android:type="linear" />
+</shape>

--- a/app/src/main/res/layout/item_browse_station_card_skeleton.xml
+++ b/app/src/main/res/layout/item_browse_station_card_skeleton.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Skeleton placeholder for carousel station cards -->
+<com.google.android.material.card.MaterialCardView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="150dp"
+    android:layout_height="wrap_content"
+    android:layout_marginEnd="12dp"
+    app:cardBackgroundColor="?attr/colorSurfaceContainerLow"
+    app:cardCornerRadius="20dp"
+    app:cardElevation="2dp">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical">
+
+        <!-- Image placeholder with shimmer -->
+        <FrameLayout
+            android:layout_width="match_parent"
+            android:layout_height="130dp">
+
+            <View
+                android:id="@+id/skeletonImage"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:background="@drawable/skeleton_placeholder_image" />
+
+            <!-- Shimmer overlay -->
+            <View
+                android:id="@+id/shimmerOverlay"
+                android:layout_width="80dp"
+                android:layout_height="match_parent"
+                android:background="@drawable/skeleton_shimmer_gradient" />
+
+        </FrameLayout>
+
+        <!-- Text placeholders -->
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:padding="12dp">
+
+            <!-- Title placeholder -->
+            <View
+                android:id="@+id/skeletonTitle"
+                android:layout_width="100dp"
+                android:layout_height="14dp"
+                android:background="@drawable/skeleton_placeholder" />
+
+            <!-- Info placeholder -->
+            <View
+                android:id="@+id/skeletonInfo"
+                android:layout_width="70dp"
+                android:layout_height="12dp"
+                android:layout_marginTop="6dp"
+                android:background="@drawable/skeleton_placeholder" />
+
+        </LinearLayout>
+
+    </LinearLayout>
+
+</com.google.android.material.card.MaterialCardView>

--- a/app/src/main/res/layout/item_browse_station_skeleton.xml
+++ b/app/src/main/res/layout/item_browse_station_skeleton.xml
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Skeleton placeholder for list station items -->
+<com.google.android.material.card.MaterialCardView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginHorizontal="12dp"
+    android:layout_marginVertical="5dp"
+    app:cardBackgroundColor="?attr/colorSurfaceContainerLow"
+    app:cardCornerRadius="20dp"
+    app:cardElevation="1dp"
+    app:strokeWidth="0dp">
+
+    <FrameLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:padding="12dp">
+
+            <!-- Station Icon placeholder -->
+            <View
+                android:id="@+id/skeletonIcon"
+                android:layout_width="56dp"
+                android:layout_height="56dp"
+                android:background="@drawable/skeleton_placeholder_image"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <!-- Station Name placeholder -->
+            <View
+                android:id="@+id/skeletonName"
+                android:layout_width="0dp"
+                android:layout_height="16dp"
+                android:layout_marginStart="12dp"
+                android:layout_marginEnd="48dp"
+                android:background="@drawable/skeleton_placeholder"
+                app:layout_constraintBottom_toTopOf="@id/skeletonInfo"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toEndOf="@id/skeletonIcon"
+                app:layout_constraintTop_toTopOf="parent"
+                app:layout_constraintVertical_chainStyle="packed" />
+
+            <!-- Station Info placeholder -->
+            <View
+                android:id="@+id/skeletonInfo"
+                android:layout_width="0dp"
+                android:layout_height="13dp"
+                android:layout_marginStart="12dp"
+                android:layout_marginTop="6dp"
+                android:layout_marginEnd="80dp"
+                android:background="@drawable/skeleton_placeholder"
+                app:layout_constraintBottom_toTopOf="@id/skeletonQuality"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toEndOf="@id/skeletonIcon"
+                app:layout_constraintTop_toBottomOf="@id/skeletonName" />
+
+            <!-- Quality Info placeholder -->
+            <View
+                android:id="@+id/skeletonQuality"
+                android:layout_width="60dp"
+                android:layout_height="11dp"
+                android:layout_marginStart="12dp"
+                android:layout_marginTop="6dp"
+                android:background="@drawable/skeleton_placeholder"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintStart_toEndOf="@id/skeletonIcon"
+                app:layout_constraintTop_toBottomOf="@id/skeletonInfo" />
+
+            <!-- Action button placeholders -->
+            <View
+                android:id="@+id/skeletonLikeButton"
+                android:layout_width="32dp"
+                android:layout_height="32dp"
+                android:layout_marginEnd="8dp"
+                android:background="@drawable/skeleton_placeholder_circle"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toStartOf="@id/skeletonActionButton"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <View
+                android:id="@+id/skeletonActionButton"
+                android:layout_width="32dp"
+                android:layout_height="32dp"
+                android:background="@drawable/skeleton_placeholder_circle"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+        <!-- Shimmer overlay -->
+        <View
+            android:id="@+id/shimmerOverlay"
+            android:layout_width="100dp"
+            android:layout_height="match_parent"
+            android:background="@drawable/skeleton_shimmer_gradient" />
+
+    </FrameLayout>
+
+</com.google.android.material.card.MaterialCardView>


### PR DESCRIPTION
Implement shimmer-animated skeleton placeholders for the browse tab's carousels and list items. This provides visual feedback while data loads instead of showing a blank screen or spinner.

Changes:
- Add ShimmerFrameLayout custom view for shimmer animation
- Add skeleton layouts for carousel cards and list items
- Add SkeletonCarouselAdapter and SkeletonListAdapter
- Integrate skeleton loading into BrowseStationsFragment
- Add isDiscoveryLoading state to BrowseViewModel