### PR TITLE
Fix pause between songs on radio streams

### DIFF
--- a/app/src/main/java/com/opensource/i2pradio/RadioService.kt
+++ b/app/src/main/java/com/opensource/i2pradio/RadioService.kt
@@ -1618,8 +1618,8 @@ class RadioService : Service() {
             return
         }
 
-        reconnectAttempts++
         val delay = minOf(1000L * reconnectAttempts, 5000L)
+        reconnectAttempts++
 
         android.util.Log.d("RadioService", "Reconnecting in ${delay}ms (attempt $reconnectAttempts)")
         // Keep buffering state while reconnecting


### PR DESCRIPTION
Move reconnectAttempts increment after delay calculation so the first reconnect attempt has 0ms delay instead of 1000ms. This fixes the issue where darknet radio streams (Tor/I2P) would pause briefly between songs, causing users to miss the first 2-3 seconds of each song.

The issue was that STATE_ENDED events (which can occur during song transitions on continuous streams) triggered scheduleReconnect() with a 1 second delay on first attempt, plus buffering time.