### PR TITLE
Remove background color from station count bar for cleaner UI

### DIFF
--- a/app/src/main/res/layout/fragment_browse_stations.xml
+++ b/app/src/main/res/layout/fragment_browse_stations.xml
@@ -594,8 +594,7 @@
             android:gravity="center_vertical"
             android:orientation="horizontal"
             android:paddingHorizontal="16dp"
-            android:paddingVertical="8dp"
-            android:background="?attr/colorSurfaceContainerLowest">
+            android:paddingVertical="8dp">
 
             <TextView
                 android:id="@+id/resultsCount"


### PR DESCRIPTION
The station count bar was using colorSurfaceContainerLowest which created a visually jarring different-colored stripe in both light and dark modes. Removing the background allows it to blend seamlessly with the parent container.