### PR TITLE
Fix InviZible Pro Play Store link and package name

### DIFF
--- a/app/src/main/java/com/opensource/i2pradio/tor/TorManager.kt
+++ b/app/src/main/java/com/opensource/i2pradio/tor/TorManager.kt
@@ -32,9 +32,9 @@ object TorManager {
     private const val TAG = "TorManager"
 
     // InviZible Pro package identifiers
-    private const val INVIZIBLE_PACKAGE_NAME = "pan.alexander.tordnscrypt"
-    private const val INVIZIBLE_MARKET_URI = "market://details?id=$INVIZIBLE_PACKAGE_NAME"
-    private const val INVIZIBLE_FDROID_URI = "https://f-droid.org/packages/$INVIZIBLE_PACKAGE_NAME/"
+    private const val INVIZIBLE_PACKAGE_NAME = "pan.alexander.tordnscrypt.gp"
+    private const val INVIZIBLE_MARKET_URI = "https://play.google.com/store/apps/details?id=$INVIZIBLE_PACKAGE_NAME"
+    private const val INVIZIBLE_FDROID_URI = "https://f-droid.org/packages/pan.alexander.tordnscrypt/"
 
     // Tor Intent actions (standard Tor control protocol, works with InviZible Pro)
     private const val ACTION_START_TOR = "org.torproject.android.intent.action.START"

--- a/app/src/main/java/com/opensource/i2pradio/ui/TorQuickControlBottomSheet.kt
+++ b/app/src/main/java/com/opensource/i2pradio/ui/TorQuickControlBottomSheet.kt
@@ -300,7 +300,7 @@ class TorQuickControlBottomSheet : BottomSheetDialogFragment() {
 
     private fun openInviZibleApp() {
         try {
-            val intent = requireContext().packageManager.getLaunchIntentForPackage("pan.alexander.tordnscrypt")
+            val intent = requireContext().packageManager.getLaunchIntentForPackage("pan.alexander.tordnscrypt.gp")
             if (intent != null) {
                 startActivity(intent)
             } else {
@@ -313,7 +313,7 @@ class TorQuickControlBottomSheet : BottomSheetDialogFragment() {
 
     private fun openInviZibleInStore() {
         try {
-            val intent = Intent(Intent.ACTION_VIEW, Uri.parse("market://details?id=pan.alexander.tordnscrypt"))
+            val intent = Intent(Intent.ACTION_VIEW, Uri.parse("https://play.google.com/store/apps/details?id=pan.alexander.tordnscrypt.gp"))
             startActivity(intent)
         } catch (e: Exception) {
             val intent = Intent(Intent.ACTION_VIEW, Uri.parse("https://f-droid.org/packages/pan.alexander.tordnscrypt/"))


### PR DESCRIPTION
- Update package name from pan.alexander.tordnscrypt to pan.alexander.tordnscrypt.gp
- Replace market:// URI scheme with https://play.google.com/store/apps/ URL
- Update package references in TorManager.kt and TorQuickControlBottomSheet.kt
- Keep F-Droid URL pointing to base package (pan.alexander.tordnscrypt)