### PR TITLE
Add privacy notice translations for Tor and custom proxy settings

### DIFF
--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -207,6 +207,7 @@
     <string name="settings_force_tor_except_i2p">فرض Tor باستثناء I2P</string>
     <string name="settings_force_tor_except_i2p_description">توجيه clearnet عبر Tor، وبث I2P مباشرة إلى وكيل I2P.</string>
     <string name="settings_tor_info">يتطلب InviZible Pro (مجاني من Play Store أو F-Droid). انقر على أيقونة Tor في شريط الأدوات للوصول السريع.\n\nتحظر أوضاع الفرض الاتصالات عندما يكون Tor غير متوفر.</string>
+    <string name="settings_tor_privacy_notice">الخصوصية: بدون تفعيل فرض Tor، تتصل محطات clearnet والصور مباشرة بالإنترنت. تستخدم التسجيلات نفس الاتصال المستخدم للبث.</string>
 
     <!-- Settings - Custom Proxy -->
     <string name="settings_custom_proxy">وكيل مخصص</string>
@@ -218,6 +219,7 @@
     <string name="settings_force_custom_proxy_description">توجيه كل حركة المرور عبر وكيل مخصص. لن يتصل بدون وكيل.</string>
     <string name="settings_force_custom_proxy_except_tor_i2p">فرض وكيل مخصص باستثناء محطات Tor/I2P</string>
     <string name="settings_force_custom_proxy_except_tor_i2p_description">توجيه جميع حركة المرور clearnet عبر وكيل مخصص، ولكن السماح لمحطات Tor و I2P باستخدام وكلائها الأصليين.</string>
+    <string name="settings_custom_proxy_privacy_notice">الخصوصية: بدون تفعيل فرض الوكيل المخصص، تتصل محطات clearnet والصور مباشرة بالإنترنت. تستخدم التسجيلات نفس الاتصال المستخدم للبث.</string>
 
     <!-- Settings - Bandwidth -->
     <string name="settings_bandwidth_usage">استخدام النطاق الترددي</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -207,6 +207,7 @@
     <string name="settings_force_tor_except_i2p">Tor erzwingen außer I2P</string>
     <string name="settings_force_tor_except_i2p_description">Clearnet über Tor leiten, I2P-Streams direkt zum I2P-Proxy.</string>
     <string name="settings_tor_info">Erfordert InviZible Pro (kostenlos im Play Store oder F-Droid). Tippen Sie auf das Tor-Symbol in der Symbolleiste für schnellen Zugriff.\n\nErzwingungsmodi blockieren Verbindungen, wenn Tor nicht verfügbar ist.</string>
+    <string name="settings_tor_privacy_notice">Datenschutz: Ohne aktiviertes Tor erzwingen verbinden sich Clearnet-Sender und Bilder direkt mit dem Internet. Aufnahmen verwenden dieselbe Verbindung wie der Stream.</string>
 
     <!-- Settings - Custom Proxy -->
     <string name="settings_custom_proxy">Benutzerdefinierter Proxy</string>
@@ -218,6 +219,7 @@
     <string name="settings_force_custom_proxy_description">Gesamten Datenverkehr über benutzerdefinierten Proxy leiten. Verbindet nicht ohne Proxy.</string>
     <string name="settings_force_custom_proxy_except_tor_i2p">Benutzerdefinierten Proxy erzwingen außer Tor/I2P-Sender</string>
     <string name="settings_force_custom_proxy_except_tor_i2p_description">Gesamten Clearnet-Datenverkehr über benutzerdefinierten Proxy leiten, aber Tor- und I2P-Sendern erlauben, ihre nativen Proxys zu verwenden.</string>
+    <string name="settings_custom_proxy_privacy_notice">Datenschutz: Ohne aktivierten benutzerdefinierten Proxy erzwingen verbinden sich Clearnet-Sender und Bilder direkt mit dem Internet. Aufnahmen verwenden dieselbe Verbindung wie der Stream.</string>
 
     <!-- Settings - Bandwidth -->
     <string name="settings_bandwidth_usage">Bandbreitennutzung</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -211,6 +211,7 @@
     <string name="settings_force_tor_except_i2p">Forzar Tor excepto I2P</string>
     <string name="settings_force_tor_except_i2p_description">Enrutar clearnet a través de Tor, transmisiones I2P directamente al proxy I2P.</string>
     <string name="settings_tor_info">Requiere InviZible Pro (gratis desde Play Store o F-Droid). Toca el ícono de Tor en la barra de herramientas para acceso rápido.\n\nLos modos forzados bloquean conexiones cuando Tor no está disponible.</string>
+    <string name="settings_tor_privacy_notice">Privacidad: Sin forzar Tor habilitado, las estaciones clearnet y las imágenes se conectan directamente a Internet. Las grabaciones usan la misma conexión que la transmisión.</string>
 
     <!-- Settings - Custom Proxy -->
     <string name="settings_custom_proxy">Proxy personalizado</string>
@@ -222,6 +223,7 @@
     <string name="settings_force_custom_proxy_description">Enrutar todo el tráfico a través del proxy personalizado. No se conectará sin proxy.</string>
     <string name="settings_force_custom_proxy_except_tor_i2p">Forzar proxy personalizado excepto estaciones Tor/I2P</string>
     <string name="settings_force_custom_proxy_except_tor_i2p_description">Enrutar todo el tráfico clearnet a través del proxy personalizado, pero permitir que las estaciones Tor e I2P usen sus proxies nativos.</string>
+    <string name="settings_custom_proxy_privacy_notice">Privacidad: Sin forzar proxy personalizado habilitado, las estaciones clearnet y las imágenes se conectan directamente a Internet. Las grabaciones usan la misma conexión que la transmisión.</string>
 
     <!-- Settings - Bandwidth -->
     <string name="settings_bandwidth_usage">Uso de ancho de banda</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -207,6 +207,7 @@
     <string name="settings_force_tor_except_i2p">اجبار Tor به جز I2P</string>
     <string name="settings_force_tor_except_i2p_description">مسیریابی clearnet از طریق Tor، جریان‌های I2P مستقیماً به پروکسی I2P.</string>
     <string name="settings_tor_info">به InviZible Pro نیاز دارد (رایگان از Play Store یا F-Droid). برای دسترسی سریع روی آیکون Tor در نوار ابزار ضربه بزنید.\n\nحالت‌های اجبار هنگامی که Tor در دسترس نیست، اتصالات را مسدود می‌کنند.</string>
+    <string name="settings_tor_privacy_notice">حریم خصوصی: بدون فعال‌سازی اجبار Tor، ایستگاه‌های clearnet و تصاویر مستقیماً به اینترنت متصل می‌شوند. ضبط‌ها از همان اتصال جریان استفاده می‌کنند.</string>
 
     <!-- Settings - Custom Proxy -->
     <string name="settings_custom_proxy">پروکسی سفارشی</string>
@@ -218,6 +219,7 @@
     <string name="settings_force_custom_proxy_description">مسیریابی همه ترافیک از طریق پروکسی سفارشی. بدون پروکسی متصل نمی‌شود.</string>
     <string name="settings_force_custom_proxy_except_tor_i2p">اجبار پروکسی سفارشی به جز ایستگاه‌های Tor/I2P</string>
     <string name="settings_force_custom_proxy_except_tor_i2p_description">مسیریابی همه ترافیک clearnet از طریق پروکسی سفارشی، اما اجازه دهید ایستگاه‌های Tor و I2P از پروکسی‌های بومی خود استفاده کنند.</string>
+    <string name="settings_custom_proxy_privacy_notice">حریم خصوصی: بدون فعال‌سازی اجبار پروکسی سفارشی، ایستگاه‌های clearnet و تصاویر مستقیماً به اینترنت متصل می‌شوند. ضبط‌ها از همان اتصال جریان استفاده می‌کنند.</string>
 
     <!-- Settings - Bandwidth -->
     <string name="settings_bandwidth_usage">مصرف پهنای باند</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -214,6 +214,7 @@
     <string name="settings_force_tor_except_i2p">Forcer Tor sauf I2P</string>
     <string name="settings_force_tor_except_i2p_description">Acheminer le clearnet via Tor, flux I2P directement vers le proxy I2P.</string>
     <string name="settings_tor_info">Nécessite InviZible Pro (gratuit sur Play Store ou F-Droid). Utilisez le mode proxy pour une meilleure compatibilité. Appuyez sur l\'icône Tor dans la barre d\'outils pour un accès rapide.\n\nLes modes forcés bloquent les connexions lorsque Tor n\'est pas disponible.</string>
+    <string name="settings_tor_privacy_notice">Confidentialité : Sans forcer Tor activé, les stations clearnet et les images se connectent directement à Internet. Les enregistrements utilisent la même connexion que le flux.</string>
 
     <!-- Settings - Custom Proxy -->
     <string name="settings_custom_proxy">Proxy personnalisé</string>
@@ -225,6 +226,7 @@
     <string name="settings_force_custom_proxy_description">Acheminer tout le trafic via le proxy personnalisé. Ne se connectera pas sans proxy.</string>
     <string name="settings_force_custom_proxy_except_tor_i2p">Forcer le proxy personnalisé sauf stations Tor/I2P</string>
     <string name="settings_force_custom_proxy_except_tor_i2p_description">Acheminer tout le trafic clearnet via le proxy personnalisé, mais autoriser les stations Tor et I2P à utiliser leurs proxys natifs.</string>
+    <string name="settings_custom_proxy_privacy_notice">Confidentialité : Sans forcer le proxy personnalisé activé, les stations clearnet et les images se connectent directement à Internet. Les enregistrements utilisent la même connexion que le flux.</string>
 
     <!-- Settings - Bandwidth -->
     <string name="settings_bandwidth_usage">Utilisation de la bande passante</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -204,6 +204,7 @@
     <string name="settings_force_tor_except_i2p">I2P को छोड़कर Tor फ़ोर्स करें</string>
     <string name="settings_force_tor_except_i2p_description">clearnet को Tor के माध्यम से रूट करें, I2P स्ट्रीम सीधे I2P प्रॉक्सी पर।</string>
     <string name="settings_tor_info">InviZible Pro की आवश्यकता है (Play Store या F-Droid से मुफ़्त)। त्वरित पहुंच के लिए टूलबार में Tor आइकन पर टैप करें।\n\nफ़ोर्स मोड Tor उपलब्ध न होने पर कनेक्शन ब्लॉक करते हैं।</string>
+    <string name="settings_tor_privacy_notice">गोपनीयता: Tor फ़ोर्स सक्षम किए बिना, clearnet स्टेशन और चित्र सीधे इंटरनेट से कनेक्ट होते हैं। रिकॉर्डिंग स्ट्रीम के समान कनेक्शन का उपयोग करती हैं।</string>
 
     <!-- Settings - Custom Proxy -->
     <string name="settings_custom_proxy">कस्टम प्रॉक्सी</string>
@@ -215,6 +216,7 @@
     <string name="settings_force_custom_proxy_description">सभी ट्रैफ़िक को कस्टम प्रॉक्सी के माध्यम से रूट करें। प्रॉक्सी के बिना कनेक्ट नहीं होगा।</string>
     <string name="settings_force_custom_proxy_except_tor_i2p">Tor/I2P स्टेशनों को छोड़कर कस्टम प्रॉक्सी फ़ोर्स करें</string>
     <string name="settings_force_custom_proxy_except_tor_i2p_description">सभी clearnet ट्रैफ़िक को कस्टम प्रॉक्सी के माध्यम से रूट करें, लेकिन Tor और I2P स्टेशनों को उनके मूल प्रॉक्सी का उपयोग करने दें।</string>
+    <string name="settings_custom_proxy_privacy_notice">गोपनीयता: कस्टम प्रॉक्सी फ़ोर्स सक्षम किए बिना, clearnet स्टेशन और चित्र सीधे इंटरनेट से कनेक्ट होते हैं। रिकॉर्डिंग स्ट्रीम के समान कनेक्शन का उपयोग करती हैं।</string>
 
     <!-- Settings - Bandwidth -->
     <string name="settings_bandwidth_usage">बैंडविड्थ उपयोग</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -214,6 +214,7 @@
     <string name="settings_force_tor_except_i2p">Forza Tor eccetto I2P</string>
     <string name="settings_force_tor_except_i2p_description">Instrada clearnet tramite Tor, stream I2P direttamente al proxy I2P.</string>
     <string name="settings_tor_info">Richiede InviZible Pro (gratuito su Play Store o F-Droid). Tocca l\'icona Tor nella barra degli strumenti per l\'accesso rapido.\n\nLe modalità forzate bloccano le connessioni quando Tor non è disponibile.</string>
+    <string name="settings_tor_privacy_notice">Privacy: senza Forza Tor abilitato, le stazioni clearnet e le immagini si connettono direttamente a Internet. Le registrazioni utilizzano la stessa connessione dello stream.</string>
 
     <!-- Settings - Custom Proxy -->
     <string name="settings_custom_proxy">Proxy personalizzato</string>
@@ -225,6 +226,7 @@
     <string name="settings_force_custom_proxy_description">Instrada tutto il traffico tramite proxy personalizzato. Non si connetterà senza proxy.</string>
     <string name="settings_force_custom_proxy_except_tor_i2p">Forza proxy personalizzato eccetto stazioni Tor/I2P</string>
     <string name="settings_force_custom_proxy_except_tor_i2p_description">Instrada tutto il traffico clearnet tramite proxy personalizzato, ma consenti alle stazioni Tor e I2P di usare i loro proxy nativi.</string>
+    <string name="settings_custom_proxy_privacy_notice">Privacy: senza Forza proxy personalizzato abilitato, le stazioni clearnet e le immagini si connettono direttamente a Internet. Le registrazioni utilizzano la stessa connessione dello stream.</string>
 
     <!-- Settings - Bandwidth -->
     <string name="settings_bandwidth_usage">Utilizzo banda</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -207,6 +207,7 @@
     <string name="settings_force_tor_except_i2p">I2P以外にTorを強制</string>
     <string name="settings_force_tor_except_i2p_description">clearnetをTor経由でルーティング、I2PストリームはI2Pプロキシに直接接続。</string>
     <string name="settings_tor_info">InviZible Proが必要です（Play StoreまたはF-Droidから無料）。ツールバーのTorアイコンをタップして素早くアクセスできます。\n\n強制モードは、Torが利用できない場合に接続をブロックします。</string>
+    <string name="settings_tor_privacy_notice">プライバシー：Tor強制が無効の場合、clearnetステーションと画像はインターネットに直接接続されます。録音はストリームと同じ接続を使用します。</string>
 
     <!-- Settings - Custom Proxy -->
     <string name="settings_custom_proxy">カスタムプロキシ</string>
@@ -218,6 +219,7 @@
     <string name="settings_force_custom_proxy_description">すべてのトラフィックをカスタムプロキシ経由でルーティング。プロキシなしでは接続しません。</string>
     <string name="settings_force_custom_proxy_except_tor_i2p">Tor/I2Pステーション以外にカスタムプロキシを強制</string>
     <string name="settings_force_custom_proxy_except_tor_i2p_description">すべてのclearnetトラフィックをカスタムプロキシ経由でルーティングしますが、TorとI2Pステーションがネイティブプロキシを使用することを許可します。</string>
+    <string name="settings_custom_proxy_privacy_notice">プライバシー：カスタムプロキシ強制が無効の場合、clearnetステーションと画像はインターネットに直接接続されます。録音はストリームと同じ接続を使用します。</string>
 
     <!-- Settings - Bandwidth -->
     <string name="settings_bandwidth_usage">帯域幅使用量</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -207,6 +207,7 @@
     <string name="settings_force_tor_except_i2p">I2P 제외하고 Tor 강제</string>
     <string name="settings_force_tor_except_i2p_description">클리어넷을 Tor를 통해 라우팅하고, I2P 스트림은 I2P 프록시로 직접 연결.</string>
     <string name="settings_tor_info">InviZible Pro 필요 (Play Store 또는 F-Droid에서 무료). 빠른 접근을 위해 도구 모음의 Tor 아이콘을 탭하세요.\n\n강제 모드는 Tor를 사용할 수 없을 때 연결을 차단합니다.</string>
+    <string name="settings_tor_privacy_notice">개인정보: Tor 강제가 활성화되지 않으면 클리어넷 방송국 및 이미지가 인터넷에 직접 연결됩니다. 녹음은 스트림과 동일한 연결을 사용합니다.</string>
 
     <!-- Settings - Custom Proxy -->
     <string name="settings_custom_proxy">사용자 지정 프록시</string>
@@ -218,6 +219,7 @@
     <string name="settings_force_custom_proxy_description">모든 트래픽을 사용자 지정 프록시를 통해 라우팅. 프록시 없이는 연결되지 않습니다.</string>
     <string name="settings_force_custom_proxy_except_tor_i2p">Tor/I2P 방송국 제외 사용자 지정 프록시 강제</string>
     <string name="settings_force_custom_proxy_except_tor_i2p_description">모든 클리어넷 트래픽을 사용자 지정 프록시를 통해 라우팅하지만, Tor 및 I2P 방송국은 네이티브 프록시를 사용하도록 허용.</string>
+    <string name="settings_custom_proxy_privacy_notice">개인정보: 사용자 지정 프록시 강제가 활성화되지 않으면 클리어넷 방송국 및 이미지가 인터넷에 직접 연결됩니다. 녹음은 스트림과 동일한 연결을 사용합니다.</string>
 
     <!-- Settings - Bandwidth -->
     <string name="settings_bandwidth_usage">대역폭 사용량</string>

--- a/app/src/main/res/values-my/strings.xml
+++ b/app/src/main/res/values-my/strings.xml
@@ -204,6 +204,7 @@
     <string name="settings_force_tor_except_i2p">I2P မှလွဲ၍ Tor ကို အတင်းအဓမ္မသုံးရန်</string>
     <string name="settings_force_tor_except_i2p_description">clearnet ကို Tor မှတစ်ဆင့်၊ I2P ထုတ်လွှင့်မှုများကို I2P proxy သို့ တိုက်ရိုက် ပို့ပါ။</string>
     <string name="settings_tor_info">InviZible Pro လိုအပ်သည် (Play Store သို့မဟုတ် F-Droid မှ အခမဲ့)။ အမြန်ဝင်ရောက်ရန် toolbar ရှိ Tor အိုင်ကွန်ကို တို့ပါ။\n\nအတင်းအဓမ္မ မုဒ်များသည် Tor မရနိုင်သောအခါ ချိတ်ဆက်မှုများကို ပိတ်ဆို့သည်။</string>
+    <string name="settings_tor_privacy_notice">ကိုယ်ရေးလုံခြုံမှု: Tor အတင်းအဓမ္မ ဖွင့်မထားပါက၊ clearnet စတေးရှင်းများနှင့် ပုံများသည် အင်တာနက်သို့ တိုက်ရိုက်ချိတ်ဆက်သည်။ အသံဖမ်းယူမှုများသည် ထုတ်လွှင့်မှုကဲ့သို့ တူညီသော ချိတ်ဆက်မှုကို သုံးသည်။</string>
 
     <!-- Settings - Custom Proxy -->
     <string name="settings_custom_proxy">စိတ်ကြိုက် Proxy</string>
@@ -215,6 +216,7 @@
     <string name="settings_force_custom_proxy_description">အသွားအလာအားလုံးကို စိတ်ကြိုက် proxy မှတစ်ဆင့် ပို့ပါ။ proxy မရှိဘဲ ချိတ်ဆက်မည်မဟုတ်ပါ။</string>
     <string name="settings_force_custom_proxy_except_tor_i2p">Tor/I2P စတေးရှင်းများမှလွဲ၍ စိတ်ကြိုက် Proxy ကို အတင်းအဓမ္မသုံးရန်</string>
     <string name="settings_force_custom_proxy_except_tor_i2p_description">clearnet အသွားအလာအားလုံးကို စိတ်ကြိုက် proxy မှတစ်ဆင့် ပို့ပါ၊ သို့သော် Tor နှင့် I2P စတေးရှင်းများကို ၎င်းတို့၏ မူရင်း proxies များကို သုံးခွင့်ပြုပါ။</string>
+    <string name="settings_custom_proxy_privacy_notice">ကိုယ်ရေးလုံခြုံမှု: စိတ်ကြိုက် Proxy အတင်းအဓမ္မ ဖွင့်မထားပါက၊ clearnet စတေးရှင်းများနှင့် ပုံများသည် အင်တာနက်သို့ တိုက်ရိုက်ချိတ်ဆက်သည်။ အသံဖမ်းယူမှုများသည် ထုတ်လွှင့်မှုကဲ့သို့ တူညီသော ချိတ်ဆက်မှုကို သုံးသည်။</string>
 
     <!-- Settings - Bandwidth -->
     <string name="settings_bandwidth_usage">အင်တာနက် အသုံးပြုမှု</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -207,6 +207,7 @@
     <string name="settings_force_tor_except_i2p">Forçar Tor exceto I2P</string>
     <string name="settings_force_tor_except_i2p_description">Rotear clearnet através do Tor, transmissões I2P diretamente para proxy I2P.</string>
     <string name="settings_tor_info">Requer InviZible Pro (grátis na Play Store ou F-Droid). Toque no ícone Tor na barra de ferramentas para acesso rápido.\n\nModos de força bloqueiam conexões quando Tor não está disponível.</string>
+    <string name="settings_tor_privacy_notice">Privacidade: Sem forçar Tor ativado, estações clearnet e imagens conectam-se diretamente à internet. Gravações usam a mesma conexão que a transmissão.</string>
 
     <!-- Settings - Custom Proxy -->
     <string name="settings_custom_proxy">Proxy personalizado</string>
@@ -218,6 +219,7 @@
     <string name="settings_force_custom_proxy_description">Rotear todo o tráfego através do proxy personalizado. Não conectará sem proxy.</string>
     <string name="settings_force_custom_proxy_except_tor_i2p">Forçar proxy personalizado exceto estações Tor/I2P</string>
     <string name="settings_force_custom_proxy_except_tor_i2p_description">Rotear todo o tráfego clearnet através do proxy personalizado, mas permitir que estações Tor e I2P usem seus proxies nativos.</string>
+    <string name="settings_custom_proxy_privacy_notice">Privacidade: Sem forçar proxy personalizado ativado, estações clearnet e imagens conectam-se diretamente à internet. Gravações usam a mesma conexão que a transmissão.</string>
 
     <!-- Settings - Bandwidth -->
     <string name="settings_bandwidth_usage">Uso de largura de banda</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -207,6 +207,7 @@
     <string name="settings_force_tor_except_i2p">Принудительный Tor кроме I2P</string>
     <string name="settings_force_tor_except_i2p_description">Маршрутизировать clearnet через Tor, I2P потоки напрямую к I2P прокси.</string>
     <string name="settings_tor_info">Требуется InviZible Pro (бесплатно в Play Store или F-Droid). Нажмите на иконку Tor на панели инструментов для быстрого доступа.\n\nРежимы принуждения блокируют соединения, когда Tor недоступен.</string>
+    <string name="settings_tor_privacy_notice">Конфиденциальность: Без включенного принудительного Tor, clearnet станции и изображения подключаются напрямую к интернету. Записи используют то же соединение, что и поток.</string>
 
     <!-- Settings - Custom Proxy -->
     <string name="settings_custom_proxy">Пользовательский прокси</string>
@@ -218,6 +219,7 @@
     <string name="settings_force_custom_proxy_description">Маршрутизировать весь трафик через пользовательский прокси. Не подключится без прокси.</string>
     <string name="settings_force_custom_proxy_except_tor_i2p">Принудительный пользовательский прокси кроме Tor/I2P станций</string>
     <string name="settings_force_custom_proxy_except_tor_i2p_description">Маршрутизировать весь clearnet трафик через пользовательский прокси, но разрешить Tor и I2P станциям использовать их собственные прокси.</string>
+    <string name="settings_custom_proxy_privacy_notice">Конфиденциальность: Без включенного принудительного пользовательского прокси, clearnet станции и изображения подключаются напрямую к интернету. Записи используют то же соединение, что и поток.</string>
 
     <!-- Settings - Bandwidth -->
     <string name="settings_bandwidth_usage">Использование трафика</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -207,6 +207,7 @@
     <string name="settings_force_tor_except_i2p">I2P Hariç Tor Zorla</string>
     <string name="settings_force_tor_except_i2p_description">Clearnet\'i Tor üzerinden yönlendir, I2P yayınlarını doğrudan I2P vekil sunucusuna bağla.</string>
     <string name="settings_tor_info">InviZible Pro gerektirir (Play Store veya F-Droid\'den ücretsiz). Hızlı erişim için araç çubuğundaki Tor simgesine dokunun.\n\nZorlama modları Tor kullanılamadığında bağlantıları engeller.</string>
+    <string name="settings_tor_privacy_notice">Gizlilik: Tor Zorla etkinleştirilmeden, clearnet istasyonları ve görseller doğrudan internete bağlanır. Kayıtlar, yayınla aynı bağlantıyı kullanır.</string>
 
     <!-- Settings - Custom Proxy -->
     <string name="settings_custom_proxy">Özel Vekil Sunucu</string>
@@ -218,6 +219,7 @@
     <string name="settings_force_custom_proxy_description">Tüm trafiği özel vekil sunucu üzerinden yönlendir. Vekil sunucu olmadan bağlanmaz.</string>
     <string name="settings_force_custom_proxy_except_tor_i2p">Tor/I2P İstasyonları Hariç Özel Vekil Sunucu Zorla</string>
     <string name="settings_force_custom_proxy_except_tor_i2p_description">Tüm clearnet trafiğini özel vekil sunucu üzerinden yönlendir, ancak Tor ve I2P istasyonlarının yerel vekil sunucularını kullanmasına izin ver.</string>
+    <string name="settings_custom_proxy_privacy_notice">Gizlilik: Özel Vekil Sunucu Zorla etkinleştirilmeden, clearnet istasyonları ve görseller doğrudan internete bağlanır. Kayıtlar, yayınla aynı bağlantıyı kullanır.</string>
 
     <!-- Settings - Bandwidth -->
     <string name="settings_bandwidth_usage">Bant Genişliği Kullanımı</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -207,6 +207,7 @@
     <string name="settings_force_tor_except_i2p">Примусовий Tor крім I2P</string>
     <string name="settings_force_tor_except_i2p_description">Маршрутизувати clearnet через Tor, I2P потоки безпосередньо до I2P проксі.</string>
     <string name="settings_tor_info">Потрібен InviZible Pro (безплатно з Play Store або F-Droid). Натисніть іконку Tor на панелі інструментів для швидкого доступу.\n\nРежими примусу блокують з\'єднання, коли Tor недоступний.</string>
+    <string name="settings_tor_privacy_notice">Конфіденційність: Без увімкненого примусового Tor, clearnet станції та зображення підключаються безпосередньо до інтернету. Записи використовують те саме з\'єднання, що й потік.</string>
 
     <!-- Settings - Custom Proxy -->
     <string name="settings_custom_proxy">Власний проксі</string>
@@ -218,6 +219,7 @@
     <string name="settings_force_custom_proxy_description">Маршрутизувати весь трафік через власний проксі. Не підключатиметься без проксі.</string>
     <string name="settings_force_custom_proxy_except_tor_i2p">Примусовий власний проксі крім Tor/I2P станцій</string>
     <string name="settings_force_custom_proxy_except_tor_i2p_description">Маршрутизувати весь clearnet трафік через власний проксі, але дозволяти Tor та I2P станціям використовувати їх власні проксі.</string>
+    <string name="settings_custom_proxy_privacy_notice">Конфіденційність: Без увімкненого примусового власного проксі, clearnet станції та зображення підключаються безпосередньо до інтернету. Записи використовують те саме з\'єднання, що й потік.</string>
 
     <!-- Settings - Bandwidth -->
     <string name="settings_bandwidth_usage">Використання трафіку</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -207,6 +207,7 @@
     <string name="settings_force_tor_except_i2p">Bắt buộc Tor trừ I2P</string>
     <string name="settings_force_tor_except_i2p_description">Định tuyến clearnet qua Tor, luồng I2P trực tiếp đến proxy I2P.</string>
     <string name="settings_tor_info">Yêu cầu InviZible Pro (miễn phí từ Play Store hoặc F-Droid). Nhấn vào biểu tượng Tor trên thanh công cụ để truy cập nhanh.\n\nChế độ bắt buộc chặn kết nối khi Tor không khả dụng.</string>
+    <string name="settings_tor_privacy_notice">Quyền riêng tư: Nếu không bật Bắt buộc Tor, các trạm clearnet và hình ảnh sẽ kết nối trực tiếp với internet. Các bản ghi âm sử dụng cùng kết nối với luồng.</string>
 
     <!-- Settings - Custom Proxy -->
     <string name="settings_custom_proxy">Proxy tùy chỉnh</string>
@@ -218,6 +219,7 @@
     <string name="settings_force_custom_proxy_description">Định tuyến tất cả lưu lượng qua proxy tùy chỉnh. Không kết nối nếu không có proxy.</string>
     <string name="settings_force_custom_proxy_except_tor_i2p">Bắt buộc proxy tùy chỉnh trừ trạm Tor/I2P</string>
     <string name="settings_force_custom_proxy_except_tor_i2p_description">Định tuyến tất cả lưu lượng clearnet qua proxy tùy chỉnh, nhưng cho phép các trạm Tor và I2P sử dụng proxy gốc của chúng.</string>
+    <string name="settings_custom_proxy_privacy_notice">Quyền riêng tư: Nếu không bật Bắt buộc proxy tùy chỉnh, các trạm clearnet và hình ảnh sẽ kết nối trực tiếp với internet. Các bản ghi âm sử dụng cùng kết nối với luồng.</string>
 
     <!-- Settings - Bandwidth -->
     <string name="settings_bandwidth_usage">Sử dụng băng thông</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -207,6 +207,7 @@
     <string name="settings_force_tor_except_i2p">强制 Tor（I2P 除外）</string>
     <string name="settings_force_tor_except_i2p_description">明网通过 Tor 路由，I2P 流直接连接到 I2P 代理。</string>
     <string name="settings_tor_info">需要 InviZible Pro（可从 Play Store 或 F-Droid 免费获取）。点击工具栏中的 Tor 图标以快速访问。\n\n强制模式会在 Tor 不可用时阻止连接。</string>
+    <string name="settings_tor_privacy_notice">隐私提示：未启用强制 Tor 时，明网电台和图片会直接连接到互联网。录制使用与流相同的连接。</string>
 
     <!-- Settings - Custom Proxy -->
     <string name="settings_custom_proxy">自定义代理</string>
@@ -218,6 +219,7 @@
     <string name="settings_force_custom_proxy_description">通过自定义代理路由所有流量。没有代理不会连接。</string>
     <string name="settings_force_custom_proxy_except_tor_i2p">强制自定义代理（Tor/I2P 电台除外）</string>
     <string name="settings_force_custom_proxy_except_tor_i2p_description">通过自定义代理路由所有明网流量，但允许 Tor 和 I2P 电台使用其原生代理。</string>
+    <string name="settings_custom_proxy_privacy_notice">隐私提示：未启用强制自定义代理时，明网电台和图片会直接连接到互联网。录制使用与流相同的连接。</string>
 
     <!-- Settings - Bandwidth -->
     <string name="settings_bandwidth_usage">带宽使用</string>


### PR DESCRIPTION
Add privacy notices to all language translations (16 languages) informing users that without Force Tor/Proxy enabled, clearnet stations and images connect directly to the internet, and recordings use the same connection as the stream.

Translations added:
- settings_tor_privacy_notice
- settings_custom_proxy_privacy_notice

Languages updated: ar, de, es, fa, fr, hi, it, ja, ko, my, pt, ru, tr, uk, vi, zh