### PR TITLE
Fix miniplayer interpunct spacing

### DIFF
--- a/app/src/main/java/com/opensource/i2pradio/ui/MiniPlayerView.kt
+++ b/app/src/main/java/com/opensource/i2pradio/ui/MiniPlayerView.kt
@@ -184,9 +184,9 @@ class MiniPlayerView @JvmOverloads constructor(
         stationName.text = station.name
         val proxyIndicator = if (station.useProxy) {
             when (station.getProxyTypeEnum()) {
-                ProxyType.I2P -> context.getString(R.string.proxy_label_i2p)
-                ProxyType.TOR -> context.getString(R.string.proxy_label_tor)
-                ProxyType.CUSTOM -> context.getString(R.string.proxy_label_custom)
+                ProxyType.I2P -> " • I2P"
+                ProxyType.TOR -> " • Tor"
+                ProxyType.CUSTOM -> " • Custom"
                 ProxyType.NONE -> ""
             }
         } else ""


### PR DESCRIPTION
Add leading space before interpunct in proxy indicator text to match the spacing used elsewhere in the app (e.g., NowPlayingFragment). Changes "EDM• Tor" to "EDM • Tor".