### PR TITLE
Fix record and volume buttons cut off in landscape mode

### DIFF
--- a/app/src/main/res/layout-land/fragment_now_playing.xml
+++ b/app/src/main/res/layout-land/fragment_now_playing.xml
@@ -7,6 +7,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="?attr/colorSurface"
+    android:clipChildren="false"
     android:clipToPadding="false"
     android:fitsSystemWindows="false"
     android:padding="16dp">
@@ -122,6 +123,8 @@
         android:id="@+id/rightContentContainer"
         android:layout_width="0dp"
         android:layout_height="0dp"
+        android:clipChildren="false"
+        android:clipToPadding="false"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toEndOf="@id/nowPlayingCoverCard"
@@ -206,7 +209,7 @@
         <!-- Playback Controls - Right below stream info -->
         <androidx.constraintlayout.widget.ConstraintLayout
             android:id="@+id/nowPlayingControlsContainer"
-            android:layout_width="0dp"
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginTop="12dp"
             android:padding="8dp"
@@ -215,8 +218,7 @@
             app:layout_constraintBottom_toTopOf="@id/bufferBarContainer"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/nowPlayingInfoContainer"
-            app:layout_constraintWidth_max="280dp">
+            app:layout_constraintTop_toBottomOf="@id/nowPlayingInfoContainer">
 
             <!-- Record Button (Left) - Primary container for Material You consistency -->
             <com.google.android.material.floatingactionbutton.FloatingActionButton


### PR DESCRIPTION
- Add clipChildren="false" and clipToPadding="false" to root and rightContentContainer to prevent button/shadow clipping
- Change controls container from 0dp width with max constraint to wrap_content for proper sizing and centering