### PR TITLE
Fix browse filter to combine multiple filters in API request

### DIFF
--- a/app/src/main/java/com/opensource/i2pradio/data/radiobrowser/RadioBrowserRepository.kt
+++ b/app/src/main/java/com/opensource/i2pradio/data/radiobrowser/RadioBrowserRepository.kt
@@ -43,13 +43,14 @@ class RadioBrowserRepository(context: Context) {
     }
 
     /**
-     * Search stations with filters
+     * Search stations with filters (supports combining multiple filters)
      */
     suspend fun searchStations(
         name: String? = null,
         tag: String? = null,
         country: String? = null,
         countrycode: String? = null,
+        language: String? = null,
         limit: Int = 50,
         offset: Int = 0
     ): RadioBrowserResult<List<RadioBrowserStation>> {
@@ -58,6 +59,7 @@ class RadioBrowserRepository(context: Context) {
             tag = tag,
             country = country,
             countrycode = countrycode,
+            language = language,
             limit = limit,
             offset = offset
         )

--- a/app/src/main/java/com/opensource/i2pradio/ui/browse/BrowseViewModel.kt
+++ b/app/src/main/java/com/opensource/i2pradio/ui/browse/BrowseViewModel.kt
@@ -773,26 +773,19 @@ class BrowseViewModel(application: Application) : AndroidViewModel(application) 
                     }
                 }
                 BrowseCategory.ALL_STATIONS -> {
-                    // Fetch all stations based on active filters without any ranking
-                    // Priority: tag > country > language > fallback to all stations
+                    // Use searchStations with combined filters to properly support
+                    // multiple active filters (e.g., tag + country + language)
                     val tag = _selectedTag.value
                     val country = _selectedCountry.value
                     val language = _selectedLanguage.value
-                    when {
-                        tag != null -> repository.getByTag(tag.name, pageSize, currentOffset)
-                        country != null -> repository.getByCountryCode(country.iso3166_1, pageSize, currentOffset)
-                        language != null -> repository.getByLanguage(language.name, pageSize, currentOffset)
-                        else -> {
-                            // No filter active, use advanced search to get any stations
-                            repository.searchStations(
-                                name = null,
-                                tag = null,
-                                country = null,
-                                limit = pageSize,
-                                offset = currentOffset
-                            )
-                        }
-                    }
+                    repository.searchStations(
+                        name = null,
+                        tag = tag?.name,
+                        countrycode = country?.iso3166_1,
+                        language = language?.name,
+                        limit = pageSize,
+                        offset = currentOffset
+                    )
                 }
                 null -> RadioBrowserResult.Error("No category selected")
             }


### PR DESCRIPTION
Previously when multiple filters were active (e.g., tag + country), only one filter was used with priority (tag > country > language). This caused issues like "pop + Germany" returning only 3 stations because it fetched 50 pop stations globally, then client-side filtered for Germany.

Now uses searchStations() API with all active filters combined, so the RadioBrowser API returns stations matching ALL selected criteria. Also added language parameter to repository's searchStations method.