### PR TITLE
Fix Tor state ui sync: auto-enable preference when Tor connects

### DIFF
--- a/app/src/main/java/com/opensource/i2pradio/MainActivity.kt
+++ b/app/src/main/java/com/opensource/i2pradio/MainActivity.kt
@@ -68,6 +68,15 @@ class MainActivity : AppCompatActivity() {
     private val torStateListener: (TorManager.TorState) -> Unit = { state ->
         runOnUiThread {
             torStatusView.updateState(state)
+
+            // Sync preference when Tor becomes connected
+            // This ensures the Settings toggle reflects the actual connection state
+            // and prevents confusion where the status shows "Connected" but the toggle is off
+            if (state == TorManager.TorState.CONNECTED) {
+                if (!PreferencesHelper.isEmbeddedTorEnabled(this@MainActivity)) {
+                    PreferencesHelper.setEmbeddedTorEnabled(this@MainActivity, true)
+                }
+            }
         }
     }
 


### PR DESCRIPTION
When Tor becomes connected (via TorManager state change), automatically sync the Settings toggle by enabling the preference if it's not already set. This prevents user confusion where the top-right Tor status shows "Connected" but the Settings toggle shows disabled.

The fix adds preference sync logic in MainActivity's torStateListener, which is always active while the app is in foreground. When state becomes CONNECTED, it checks if isEmbeddedTorEnabled is false and sets it to true, triggering the Settings preference change listener to update the toggle.