### PR TITLE
Add Tor status and control strings to all 16 languages

### DIFF
--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -295,6 +295,11 @@
     <string name="tor_status_install_invizible_description">InviZible Pro غير مثبت. انقر للتثبيت.</string>
     <string name="tor_status_leak_warning_description">تم تمكين وضع Tor الإجباري ولكن غير متصل. قد تكون الخصوصية معرضة للخطر.</string>
 
+    <string name="tor_status_tor_required">Tor مطلوب</string>
+    <string name="tor_status_tor_required_description">البث محظور حتى إعادة اتصال Tor. اضغط لإعادة الاتصال.</string>
+    <string name="tor_control_title_blocked">البث محظور</string>
+    <string name="tor_control_subtitle_blocked">وضع إجبار Tor يحمي خصوصيتك. جميع البث محظور حتى إعادة اتصال Tor — لم تتسرب أي بيانات.</string>
+
     <string name="tor_status_connecting_message">جارٍ الاتصال بـ Tor...</string>
     <string name="tor_status_connected_message">متصل عبر Tor</string>
     <string name="tor_control_title_stopped">تم قطع اتصال Tor</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -295,6 +295,11 @@
     <string name="tor_status_install_invizible_description">InviZible Pro ist nicht installiert. Tippen zum Installieren.</string>
     <string name="tor_status_leak_warning_description">Tor-Zwangsmodus ist aktiviert, aber nicht verbunden. Privatsphäre könnte gefährdet sein.</string>
 
+    <string name="tor_status_tor_required">Tor erforderlich</string>
+    <string name="tor_status_tor_required_description">Streams sind blockiert, bis Tor sich wieder verbindet. Tippen zum Erneut verbinden.</string>
+    <string name="tor_control_title_blocked">Streams blockiert</string>
+    <string name="tor_control_subtitle_blocked">Tor-Zwangsmodus schützt Ihre Privatsphäre. Alle Streams sind blockiert, bis Tor sich wieder verbindet — keine Daten sind durchgesickert.</string>
+
     <string name="tor_status_connecting_message">Verbinde mit Tor...</string>
     <string name="tor_status_connected_message">Über Tor verbunden</string>
     <string name="tor_control_title_stopped">Tor getrennt</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -299,6 +299,11 @@
     <string name="tor_status_install_invizible_description">InviZible Pro no está instalado. Toca para instalar.</string>
     <string name="tor_status_leak_warning_description">Modo Tor forzado está activado pero no conectado. La privacidad puede estar comprometida.</string>
 
+    <string name="tor_status_tor_required">Tor requerido</string>
+    <string name="tor_status_tor_required_description">Las transmisiones están bloqueadas hasta que Tor se reconecte. Toque para reconectar.</string>
+    <string name="tor_control_title_blocked">Transmisiones bloqueadas</string>
+    <string name="tor_control_subtitle_blocked">El modo forzado de Tor está protegiendo tu privacidad. Todas las transmisiones están bloqueadas hasta que Tor se reconecte — no se ha filtrado ningún dato.</string>
+
     <string name="tor_status_connecting_message">Conectando a Tor...</string>
     <string name="tor_status_connected_message">Conectado vía Tor</string>
     <string name="tor_control_title_stopped">Tor desconectado</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -295,6 +295,11 @@
     <string name="tor_status_install_invizible_description">InviZible Pro نصب نشده است. برای نصب لمس کنید.</string>
     <string name="tor_status_leak_warning_description">حالت اجباری Tor فعال است اما متصل نیست. حریم خصوصی ممکن است به خطر افتاده باشد.</string>
 
+    <string name="tor_status_tor_required">Tor مورد نیاز است</string>
+    <string name="tor_status_tor_required_description">جریان‌ها مسدود هستند تا Tor دوباره متصل شود. برای اتصال مجدد ضربه بزنید.</string>
+    <string name="tor_control_title_blocked">جریان‌ها مسدود شده</string>
+    <string name="tor_control_subtitle_blocked">حالت اجباری Tor از حریم خصوصی شما محافظت می‌کند. تمام جریان‌ها مسدود هستند تا Tor دوباره متصل شود — هیچ داده‌ای درز نکرده است.</string>
+
     <string name="tor_status_connecting_message">در حال اتصال به Tor...</string>
     <string name="tor_status_connected_message">از طریق Tor متصل شد</string>
     <string name="tor_control_title_stopped">Tor قطع شد</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -301,6 +301,12 @@
     <string name="tor_status_error_description">Connexion Tor échouée. Appuyez pour réessayer.</string>
     <string name="tor_status_install_invizible_description">InviZible Pro n\'est pas installé. Appuyez pour installer.</string>
     <string name="tor_status_leak_warning_description">Le mode Tor forcé est activé mais non connecté. La confidentialité peut être compromise.</string>
+
+    <string name="tor_status_tor_required">Tor requis</string>
+    <string name="tor_status_tor_required_description">Les flux sont bloqués jusqu'à ce que Tor se reconnecte. Appuyez pour reconnecter.</string>
+    <string name="tor_control_title_blocked">Flux bloqués</string>
+    <string name="tor_control_subtitle_blocked">Le mode Tor forcé protège votre vie privée. Tous les flux sont bloqués jusqu'à ce que Tor se reconnecte — aucune donnée n'a été divulguée.</string>
+
     <string name="tor_status_connecting_message">Connexion à Tor...</string>
     <string name="tor_status_connected_message">Connecté via Tor</string>
     <string name="tor_control_title_stopped">Tor déconnecté</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -292,6 +292,11 @@
     <string name="tor_status_install_invizible_description">InviZible Pro इंस्टॉल नहीं है। इंस्टॉल करने के लिए टैप करें।</string>
     <string name="tor_status_leak_warning_description">फ़ोर्स Tor मोड सक्षम है लेकिन कनेक्ट नहीं है। गोपनीयता खतरे में हो सकती है।</string>
 
+    <string name="tor_status_tor_required">Tor आवश्यक</string>
+    <string name="tor_status_tor_required_description">Tor फिर से कनेक्ट होने तक स्ट्रीम ब्लॉक हैं। फिर से कनेक्ट करने के लिए टैप करें।</string>
+    <string name="tor_control_title_blocked">स्ट्रीम ब्लॉक</string>
+    <string name="tor_control_subtitle_blocked">फोर्स Tor मोड आपकी गोपनीयता की रक्षा कर रहा है। Tor फिर से कनेक्ट होने तक सभी स्ट्रीम ब्लॉक हैं — कोई डेटा लीक नहीं हुआ है।</string>
+
     <string name="tor_status_connecting_message">Tor से कनेक्ट हो रहा है...</string>
     <string name="tor_status_connected_message">Tor के माध्यम से कनेक्ट किया गया</string>
     <string name="tor_control_title_stopped">Tor डिसकनेक्ट किया गया</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -301,6 +301,12 @@
     <string name="tor_status_error_description">Connessione Tor non riuscita. Tocca per riprovare.</string>
     <string name="tor_status_install_invizible_description">InviZible Pro non è installato. Tocca per installare.</string>
     <string name="tor_status_leak_warning_description">La modalità Tor forzata è abilitata ma non connessa. La privacy potrebbe essere compromessa.</string>
+
+    <string name="tor_status_tor_required">Tor richiesto</string>
+    <string name="tor_status_tor_required_description">Gli stream sono bloccati fino a quando Tor non si riconnette. Tocca per riconnetterti.</string>
+    <string name="tor_control_title_blocked">Stream bloccati</string>
+    <string name="tor_control_subtitle_blocked">La modalità Tor forzata sta proteggendo la tua privacy. Tutti gli stream sono bloccati fino a quando Tor non si riconnette — nessun dato è trapelato.</string>
+
     <string name="tor_status_connecting_message">Connessione a Tor...</string>
     <string name="tor_status_connected_message">Connesso tramite Tor</string>
     <string name="tor_control_title_stopped">Tor disconnesso</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -295,6 +295,11 @@
     <string name="tor_status_install_invizible_description">InviZible Proがインストールされていません。タップしてインストールします。</string>
     <string name="tor_status_leak_warning_description">強制Torモードが有効ですが接続されていません。プライバシーが危険にさらされている可能性があります。</string>
 
+    <string name="tor_status_tor_required">Torが必要です</string>
+    <string name="tor_status_tor_required_description">Torが再接続するまでストリームはブロックされています。タップして再接続します。</string>
+    <string name="tor_control_title_blocked">ストリームがブロックされています</string>
+    <string name="tor_control_subtitle_blocked">強制Torモードがプライバシーを保護しています。Torが再接続するまですべてのストリームがブロックされています — データは漏洩していません。</string>
+
     <string name="tor_status_connecting_message">Torに接続中...</string>
     <string name="tor_status_connected_message">Tor経由で接続済み</string>
     <string name="tor_control_title_stopped">Tor切断済み</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -295,6 +295,11 @@
     <string name="tor_status_install_invizible_description">InviZible Pro가 설치되지 않았습니다. 탭하여 설치하세요.</string>
     <string name="tor_status_leak_warning_description">강제 Tor 모드가 활성화되었지만 연결되지 않았습니다. 개인정보가 위험할 수 있습니다.</string>
 
+    <string name="tor_status_tor_required">Tor 필요</string>
+    <string name="tor_status_tor_required_description">Tor가 재연결될 때까지 스트림이 차단되었습니다. 탭하여 재연결하세요.</string>
+    <string name="tor_control_title_blocked">스트림 차단됨</string>
+    <string name="tor_control_subtitle_blocked">강제 Tor 모드가 개인정보를 보호하고 있습니다. Tor가 재연결될 때까지 모든 스트림이 차단되었습니다 — 데이터가 유출되지 않았습니다.</string>
+
     <string name="tor_status_connecting_message">Tor에 연결 중...</string>
     <string name="tor_status_connected_message">Tor를 통해 연결됨</string>
     <string name="tor_control_title_stopped">Tor 연결 끊김</string>

--- a/app/src/main/res/values-my/strings.xml
+++ b/app/src/main/res/values-my/strings.xml
@@ -292,6 +292,11 @@
     <string name="tor_status_install_invizible_description">InviZible Pro တပ်ဆင်မထားပါ။ တပ်ဆင်ရန် တို့ပါ။</string>
     <string name="tor_status_leak_warning_description">အတင်းအဓမ္မ Tor မုဒ် ဖွင့်ထားသည် သို့သော် ချိတ်ဆက်မထားပါ။ ကိုယ်ရေးကိုယ်တာ အန္တရာယ်ရှိနိုင်သည်။</string>
 
+    <string name="tor_status_tor_required">Tor လိုအပ်သည်</string>
+    <string name="tor_status_tor_required_description">Tor ပြန်လည်ချိတ်ဆက်သည်အထိ streams များကို ပိတ်ဆို့ထားသည်။ ပြန်လည်ချိတ်ဆက်ရန် တို့ပါ။</string>
+    <string name="tor_control_title_blocked">Streams များ ပိတ်ဆို့ထားသည်</string>
+    <string name="tor_control_subtitle_blocked">Force Tor mode သည် သင်၏ ကိုယ်ရေးကိုယ်တာကို ကာကွယ်ပေးနေသည်။ Tor ပြန်လည်ချိတ်ဆက်သည်အထိ streams အားလုံးကို ပိတ်ဆို့ထားသည် — ဒေတာများ ယိုစိမ့်ခြင်း မရှိပါ။</string>
+
     <string name="tor_status_connecting_message">Tor သို့ ချိတ်ဆက်နေသည်...</string>
     <string name="tor_status_connected_message">Tor မှတစ်ဆင့် ချိတ်ဆက်ပြီးပါပြီ</string>
     <string name="tor_control_title_stopped">Tor ချိတ်ဆက်မထားပါ</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -295,6 +295,11 @@
     <string name="tor_status_install_invizible_description">InviZible Pro não está instalado. Toque para instalar.</string>
     <string name="tor_status_leak_warning_description">Modo Tor forçado está ativado mas não conectado. A privacidade pode estar comprometida.</string>
 
+    <string name="tor_status_tor_required">Tor necessário</string>
+    <string name="tor_status_tor_required_description">As transmissões estão bloqueadas até que o Tor se reconecte. Toque para reconectar.</string>
+    <string name="tor_control_title_blocked">Transmissões bloqueadas</string>
+    <string name="tor_control_subtitle_blocked">O modo Tor forçado está protegendo sua privacidade. Todas as transmissões estão bloqueadas até que o Tor se reconecte — nenhum dado vazou.</string>
+
     <string name="tor_status_connecting_message">Conectando ao Tor...</string>
     <string name="tor_status_connected_message">Conectado via Tor</string>
     <string name="tor_control_title_stopped">Tor desconectado</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -295,6 +295,11 @@
     <string name="tor_status_install_invizible_description">InviZible Pro не установлен. Нажмите для установки.</string>
     <string name="tor_status_leak_warning_description">Принудительный режим Tor включён, но не подключён. Конфиденциальность может быть под угрозой.</string>
 
+    <string name="tor_status_tor_required">Требуется Tor</string>
+    <string name="tor_status_tor_required_description">Потоки заблокированы до повторного подключения Tor. Нажмите для переподключения.</string>
+    <string name="tor_control_title_blocked">Потоки заблокированы</string>
+    <string name="tor_control_subtitle_blocked">Принудительный режим Tor защищает вашу конфиденциальность. Все потоки заблокированы до повторного подключения Tor — утечки данных не произошло.</string>
+
     <string name="tor_status_connecting_message">Подключение к Tor...</string>
     <string name="tor_status_connected_message">Подключено через Tor</string>
     <string name="tor_control_title_stopped">Tor отключён</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -295,6 +295,11 @@
     <string name="tor_status_install_invizible_description">InviZible Pro yüklü değil. Yüklemek için dokunun.</string>
     <string name="tor_status_leak_warning_description">Zorunlu Tor modu etkin ancak bağlı değil. Gizlilik tehlikeye girebilir.</string>
 
+    <string name="tor_status_tor_required">Tor gerekli</string>
+    <string name="tor_status_tor_required_description">Tor yeniden bağlanana kadar akışlar engellendi. Yeniden bağlanmak için dokunun.</string>
+    <string name="tor_control_title_blocked">Akışlar engellendi</string>
+    <string name="tor_control_subtitle_blocked">Zorunlu Tor modu gizliliğinizi koruyor. Tor yeniden bağlanana kadar tüm akışlar engellendi — hiçbir veri sızmadı.</string>
+
     <string name="tor_status_connecting_message">Tor\'a bağlanıyor...</string>
     <string name="tor_status_connected_message">Tor üzerinden bağlandı</string>
     <string name="tor_control_title_stopped">Tor Bağlantısı Kesildi</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -295,6 +295,11 @@
     <string name="tor_status_install_invizible_description">InviZible Pro не встановлено. Натисніть для встановлення.</string>
     <string name="tor_status_leak_warning_description">Примусовий режим Tor увімкнено, але не підключено. Конфіденційність може бути під загрозою.</string>
 
+    <string name="tor_status_tor_required">Потрібен Tor</string>
+    <string name="tor_status_tor_required_description">Потоки заблоковані до повторного підключення Tor. Натисніть для повторного підключення.</string>
+    <string name="tor_control_title_blocked">Потоки заблоковані</string>
+    <string name="tor_control_subtitle_blocked">Примусовий режим Tor захищає вашу конфіденційність. Усі потоки заблоковані до повторного підключення Tor — витоку даних не сталося.</string>
+
     <string name="tor_status_connecting_message">Підключення до Tor...</string>
     <string name="tor_status_connected_message">Підключено через Tor</string>
     <string name="tor_control_title_stopped">Tor відключено</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -295,6 +295,11 @@
     <string name="tor_status_install_invizible_description">InviZible Pro chưa được cài đặt. Nhấn để cài đặt.</string>
     <string name="tor_status_leak_warning_description">Chế độ Tor bắt buộc đã bật nhưng chưa kết nối. Quyền riêng tư có thể bị ảnh hưởng.</string>
 
+    <string name="tor_status_tor_required">Yêu cầu Tor</string>
+    <string name="tor_status_tor_required_description">Các luồng bị chặn cho đến khi Tor kết nối lại. Nhấn để kết nối lại.</string>
+    <string name="tor_control_title_blocked">Các luồng bị chặn</string>
+    <string name="tor_control_subtitle_blocked">Chế độ bắt buộc Tor đang bảo vệ quyền riêng tư của bạn. Tất cả các luồng bị chặn cho đến khi Tor kết nối lại — không có dữ liệu nào bị rò rỉ.</string>
+
     <string name="tor_status_connecting_message">Đang kết nối với Tor...</string>
     <string name="tor_status_connected_message">Đã kết nối qua Tor</string>
     <string name="tor_control_title_stopped">Tor đã ngắt kết nối</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -295,6 +295,11 @@
     <string name="tor_status_install_invizible_description">未安装InviZible Pro。点击安装。</string>
     <string name="tor_status_leak_warning_description">强制Tor模式已启用但未连接。隐私可能受到威胁。</string>
 
+    <string name="tor_status_tor_required">需要Tor</string>
+    <string name="tor_status_tor_required_description">在Tor重新连接之前，流被阻止。点击以重新连接。</string>
+    <string name="tor_control_title_blocked">流已被阻止</string>
+    <string name="tor_control_subtitle_blocked">强制Tor模式正在保护您的隐私。在Tor重新连接之前，所有流都被阻止——没有数据泄漏。</string>
+
     <string name="tor_status_connecting_message">正在连接到Tor...</string>
     <string name="tor_status_connected_message">已通过Tor连接</string>
     <string name="tor_control_title_stopped">Tor已断开</string>


### PR DESCRIPTION
Add translations for:
- tor_status_tor_required: Tor Required
- tor_status_tor_required_description: Streams are blocked until Tor reconnects. Tap to reconnect.
- tor_control_title_blocked: Streams Blocked
- tor_control_subtitle_blocked: Force Tor mode protection message

Translations added for: English, German, Arabic, Spanish, Persian, French, Hindi, Italian, Japanese, Korean, Burmese, Portuguese, Russian, Turkish, Ukrainian, Vietnamese, and Chinese