### PR TITLE
Fix string substitution format errors in all localized strings

### DIFF
--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -466,11 +466,11 @@
     <string name="auth_biometric_negative">استخدام كلمة المرور</string>
 
     <!-- Delete Confirmation Dialog -->
-    <string name="delete_stations_message">هل أنت متأكد من حذف %d محطة%s؟</string>
+    <string name="delete_stations_message">هل أنت متأكد من حذف %1$d محطة%2$s؟</string>
     <string name="delete_stations_message_single">هل أنت متأكد من حذف %d محطة؟</string>
     <string name="delete_stations_message_plural">هل أنت متأكد من حذف %d محطة؟</string>
     <string name="button_delete">حذف</string>
-    <string name="deleted_stations_message">تم حذف %d محطة%s</string>
+    <string name="deleted_stations_message">تم حذف %1$d محطة%2$s</string>
     <string name="deleted_stations_message_single">تم حذف %d محطة</string>
     <string name="deleted_stations_message_plural">تم حذف %d محطة</string>
 
@@ -524,7 +524,7 @@
     <string name="import_curated_title">استيراد محطات %s</string>
     <string name="import_curated_message">استيراد %1$d محطة راديو %2$s منتقاة؟\n\nهذه المحطات مهيأة مسبقًا بإعدادات البروكسي وجاهزة للاستخدام.</string>
     <string name="no_stations_found_in_list">لم يتم العثور على محطات في قائمة %s</string>
-    <string name="failed_to_import_stations">فشل استيراد محطات %s: %s</string>
+    <string name="failed_to_import_stations">فشل استيراد محطات %1$s: %2$s</string>
     <string name="dialog_export_stations_title">تصدير المحطات</string>
     <string name="no_stations_in_file">لم يتم العثور على محطات في الملف</string>
     <string name="dialog_import_failed">فشل الاستيراد</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -467,11 +467,11 @@
     <string name="auth_biometric_negative">Passwort verwenden</string>
 
     <!-- Delete Confirmation Dialog -->
-    <string name="delete_stations_message">Möchten Sie wirklich %d Sender%s löschen?</string>
+    <string name="delete_stations_message">Möchten Sie wirklich %1$d Sender%2$s löschen?</string>
     <string name="delete_stations_message_single">Möchten Sie wirklich %d Sender löschen?</string>
     <string name="delete_stations_message_plural">Möchten Sie wirklich %d Sender löschen?</string>
     <string name="button_delete">Löschen</string>
-    <string name="deleted_stations_message">%d Sender%s gelöscht</string>
+    <string name="deleted_stations_message">%1$d Sender%2$s gelöscht</string>
     <string name="deleted_stations_message_single">%d Sender gelöscht</string>
     <string name="deleted_stations_message_plural">%d Sender gelöscht</string>
 
@@ -525,7 +525,7 @@
     <string name="import_curated_title">%s-Sender importieren</string>
     <string name="import_curated_message">%1$d ausgewählte %2$s-Radiosender importieren?\n\nDiese Sender sind vorkonfiguriert und sofort einsatzbereit.</string>
     <string name="no_stations_found_in_list">Keine Sender in %s-Liste gefunden</string>
-    <string name="failed_to_import_stations">Import von %s-Sendern fehlgeschlagen: %s</string>
+    <string name="failed_to_import_stations">Import von %1$s-Sendern fehlgeschlagen: %2$s</string>
     <string name="dialog_export_stations_title">Sender exportieren</string>
     <string name="no_stations_in_file">Keine Sender in der Datei gefunden</string>
     <string name="dialog_import_failed">Import fehlgeschlagen</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -471,11 +471,11 @@
     <string name="auth_biometric_negative">Usar contraseña</string>
 
     <!-- Delete Confirmation Dialog -->
-    <string name="delete_stations_message">¿Estás seguro de que quieres eliminar %d estación%s?</string>
+    <string name="delete_stations_message">¿Estás seguro de que quieres eliminar %1$d estación%2$s?</string>
     <string name="delete_stations_message_single">¿Estás seguro de que quieres eliminar %d estación?</string>
     <string name="delete_stations_message_plural">¿Estás seguro de que quieres eliminar %d estaciones?</string>
     <string name="button_delete">Eliminar</string>
-    <string name="deleted_stations_message">%d estación%s eliminada</string>
+    <string name="deleted_stations_message">%1$d estación%2$s eliminada</string>
     <string name="deleted_stations_message_single">%d estación eliminada</string>
     <string name="deleted_stations_message_plural">%d estaciones eliminadas</string>
 
@@ -529,7 +529,7 @@
     <string name="import_curated_title">Importar estaciones %s</string>
     <string name="import_curated_message">¿Importar %1$d estaciones de radio %2$s seleccionadas?\n\nEstas estaciones están preconfiguradas con ajustes de proxy y listas para usar.</string>
     <string name="no_stations_found_in_list">No se encontraron estaciones en la lista %s</string>
-    <string name="failed_to_import_stations">Error al importar estaciones %s: %s</string>
+    <string name="failed_to_import_stations">Error al importar estaciones %1$s: %2$s</string>
     <string name="dialog_export_stations_title">Exportar estaciones</string>
     <string name="no_stations_in_file">No se encontraron estaciones en el archivo</string>
     <string name="dialog_import_failed">Importación fallida</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -467,11 +467,11 @@
     <string name="auth_biometric_negative">استفاده از رمز عبور</string>
 
     <!-- Delete Confirmation Dialog -->
-    <string name="delete_stations_message">آیا مطمئن هستید که می‌خواهید %d ایستگاه%s را حذف کنید؟</string>
+    <string name="delete_stations_message">آیا مطمئن هستید که می‌خواهید %1$d ایستگاه%2$s را حذف کنید؟</string>
     <string name="delete_stations_message_single">آیا مطمئن هستید که می‌خواهید %d ایستگاه را حذف کنید؟</string>
     <string name="delete_stations_message_plural">آیا مطمئن هستید که می‌خواهید %d ایستگاه را حذف کنید؟</string>
     <string name="button_delete">حذف</string>
-    <string name="deleted_stations_message">%d ایستگاه%s حذف شد</string>
+    <string name="deleted_stations_message">%1$d ایستگاه%2$s حذف شد</string>
     <string name="deleted_stations_message_single">%d ایستگاه حذف شد</string>
     <string name="deleted_stations_message_plural">%d ایستگاه حذف شد</string>
 
@@ -525,7 +525,7 @@
     <string name="import_curated_title">وارد کردن ایستگاه‌های %s</string>
     <string name="import_curated_message">وارد کردن %1$d ایستگاه رادیویی %2$s منتخب؟\n\nاین ایستگاه‌ها از قبل با تنظیمات پروکسی پیکربندی شده و آماده استفاده هستند.</string>
     <string name="no_stations_found_in_list">هیچ ایستگاهی در فهرست %s یافت نشد</string>
-    <string name="failed_to_import_stations">وارد کردن ایستگاه‌های %s ناموفق بود: %s</string>
+    <string name="failed_to_import_stations">وارد کردن ایستگاه‌های %1$s ناموفق بود: %2$s</string>
     <string name="dialog_export_stations_title">صادر کردن ایستگاه‌ها</string>
     <string name="no_stations_in_file">هیچ ایستگاهی در فایل یافت نشد</string>
     <string name="dialog_import_failed">وارد کردن ناموفق</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -303,9 +303,9 @@
     <string name="tor_status_leak_warning_description">Le mode Tor forcé est activé mais non connecté. La confidentialité peut être compromise.</string>
 
     <string name="tor_status_tor_required">Tor requis</string>
-    <string name="tor_status_tor_required_description">Les flux sont bloqués jusqu'à ce que Tor se reconnecte. Appuyez pour reconnecter.</string>
+    <string name="tor_status_tor_required_description">Les flux sont bloqués jusqu\'à ce que Tor se reconnecte. Appuyez pour reconnecter.</string>
     <string name="tor_control_title_blocked">Flux bloqués</string>
-    <string name="tor_control_subtitle_blocked">Le mode Tor forcé protège votre vie privée. Tous les flux sont bloqués jusqu'à ce que Tor se reconnecte — aucune donnée n'a été divulguée.</string>
+    <string name="tor_control_subtitle_blocked">Le mode Tor forcé protège votre vie privée. Tous les flux sont bloqués jusqu\'à ce que Tor se reconnecte — aucune donnée n\'a été divulguée.</string>
 
     <string name="tor_status_connecting_message">Connexion à Tor...</string>
     <string name="tor_status_connected_message">Connecté via Tor</string>
@@ -473,11 +473,11 @@
     <string name="auth_biometric_negative">Utiliser le mot de passe</string>
 
     <!-- Delete Confirmation Dialog -->
-    <string name="delete_stations_message">Voulez-vous vraiment supprimer %d station%s ?</string>
+    <string name="delete_stations_message">Voulez-vous vraiment supprimer %1$d station%2$s ?</string>
     <string name="delete_stations_message_single">Voulez-vous vraiment supprimer %d station ?</string>
     <string name="delete_stations_message_plural">Voulez-vous vraiment supprimer %d stations ?</string>
     <string name="button_delete">Supprimer</string>
-    <string name="deleted_stations_message">%d station%s supprimée</string>
+    <string name="deleted_stations_message">%1$d station%2$s supprimée</string>
     <string name="deleted_stations_message_single">%d station supprimée</string>
     <string name="deleted_stations_message_plural">%d stations supprimées</string>
 
@@ -531,7 +531,7 @@
     <string name="import_curated_title">Importer des stations %s</string>
     <string name="import_curated_message">Importer %1$d stations de radio %2$s sélectionnées ?\n\nCes stations sont préconfigurées avec les paramètres proxy et prêtes à l\'emploi.</string>
     <string name="no_stations_found_in_list">Aucune station trouvée dans la liste %s</string>
-    <string name="failed_to_import_stations">Échec de l\'importation des stations %s : %s</string>
+    <string name="failed_to_import_stations">Échec de l\'importation des stations %1$s : %2$s</string>
     <string name="dialog_export_stations_title">Exporter des stations</string>
     <string name="no_stations_in_file">Aucune station trouvée dans le fichier</string>
     <string name="dialog_import_failed">Échec de l\'importation</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -463,11 +463,11 @@
     <string name="auth_biometric_negative">पासवर्ड उपयोग करें</string>
 
     <!-- Delete Confirmation Dialog -->
-    <string name="delete_stations_message">क्या आप वाकई %d स्टेशन%s को हटाना चाहते हैं?</string>
+    <string name="delete_stations_message">क्या आप वाकई %1$d स्टेशन%2$s को हटाना चाहते हैं?</string>
     <string name="delete_stations_message_single">क्या आप वाकई %d स्टेशन को हटाना चाहते हैं?</string>
     <string name="delete_stations_message_plural">क्या आप वाकई %d स्टेशन को हटाना चाहते हैं?</string>
     <string name="button_delete">हटाएं</string>
-    <string name="deleted_stations_message">%d स्टेशन%s हटा दिया गया</string>
+    <string name="deleted_stations_message">%1$d स्टेशन%2$s हटा दिया गया</string>
     <string name="deleted_stations_message_single">%d स्टेशन हटा दिया गया</string>
     <string name="deleted_stations_message_plural">%d स्टेशन हटा दिए गए</string>
 
@@ -521,7 +521,7 @@
     <string name="import_curated_title">%s स्टेशन आयात करें</string>
     <string name="import_curated_message">%1$d चयनित %2$s रेडियो स्टेशन आयात करें?\n\nये स्टेशन प्रॉक्सी सेटिंग्स के साथ पूर्व-कॉन्फ़िगर हैं और उपयोग के लिए तैयार हैं।</string>
     <string name="no_stations_found_in_list">%s सूची में कोई स्टेशन नहीं मिला</string>
-    <string name="failed_to_import_stations">%s स्टेशन आयात करने में विफल: %s</string>
+    <string name="failed_to_import_stations">%1$s स्टेशन आयात करने में विफल: %2$s</string>
     <string name="dialog_export_stations_title">स्टेशन निर्यात करें</string>
     <string name="no_stations_in_file">फ़ाइल में कोई स्टेशन नहीं मिला</string>
     <string name="dialog_import_failed">आयात विफल</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -473,11 +473,11 @@
     <string name="auth_biometric_negative">Usa password</string>
 
     <!-- Delete Confirmation Dialog -->
-    <string name="delete_stations_message">Sei sicuro di voler eliminare %d stazione%s?</string>
+    <string name="delete_stations_message">Sei sicuro di voler eliminare %1$d stazione%2$s?</string>
     <string name="delete_stations_message_single">Sei sicuro di voler eliminare %d stazione?</string>
     <string name="delete_stations_message_plural">Sei sicuro di voler eliminare %d stazioni?</string>
     <string name="button_delete">Elimina</string>
-    <string name="deleted_stations_message">%d stazione%s eliminata</string>
+    <string name="deleted_stations_message">%1$d stazione%2$s eliminata</string>
     <string name="deleted_stations_message_single">%d stazione eliminata</string>
     <string name="deleted_stations_message_plural">%d stazioni eliminate</string>
 
@@ -531,7 +531,7 @@
     <string name="import_curated_title">Importa stazioni %s</string>
     <string name="import_curated_message">Importare %1$d stazioni radio %2$s selezionate?\n\nQueste stazioni sono preconfigurate e pronte all\'uso.</string>
     <string name="no_stations_found_in_list">Nessuna stazione trovata nell\'elenco %s</string>
-    <string name="failed_to_import_stations">Importazione stazioni %s fallita: %s</string>
+    <string name="failed_to_import_stations">Importazione stazioni %1$s fallita: %2$s</string>
     <string name="dialog_export_stations_title">Esporta stazioni</string>
     <string name="no_stations_in_file">Nessuna stazione trovata nel file</string>
     <string name="dialog_import_failed">Importazione fallita</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -466,11 +466,11 @@
     <string name="auth_biometric_negative">パスワードを使用</string>
 
     <!-- Delete Confirmation Dialog -->
-    <string name="delete_stations_message">%d個のステーション%sを削除してもよろしいですか？</string>
+    <string name="delete_stations_message">%1$d個のステーション%2$sを削除してもよろしいですか？</string>
     <string name="delete_stations_message_single">%d個のステーションを削除してもよろしいですか？</string>
     <string name="delete_stations_message_plural">%d個のステーションを削除してもよろしいですか？</string>
     <string name="button_delete">削除</string>
-    <string name="deleted_stations_message">%d個のステーション%sを削除しました</string>
+    <string name="deleted_stations_message">%1$d個のステーション%2$sを削除しました</string>
     <string name="deleted_stations_message_single">%d個のステーションを削除しました</string>
     <string name="deleted_stations_message_plural">%d個のステーションを削除しました</string>
 
@@ -524,7 +524,7 @@
     <string name="import_curated_title">%sステーションをインポート</string>
     <string name="import_curated_message">%1$d個の厳選された%2$sラジオステーションをインポートしますか？\n\nこれらのステーションはプロキシ設定で事前設定されており、すぐに使用できます。</string>
     <string name="no_stations_found_in_list">%sリストにステーションが見つかりません</string>
-    <string name="failed_to_import_stations">%sステーションのインポートに失敗しました: %s</string>
+    <string name="failed_to_import_stations">%1$sステーションのインポートに失敗しました: %2$s</string>
     <string name="dialog_export_stations_title">ステーションをエクスポート</string>
     <string name="no_stations_in_file">ファイルにステーションが見つかりません</string>
     <string name="dialog_import_failed">インポートに失敗しました</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -466,11 +466,11 @@
     <string name="auth_biometric_negative">비밀번호 사용</string>
 
     <!-- Delete Confirmation Dialog -->
-    <string name="delete_stations_message">%d개의 스테이션%s을(를) 삭제하시겠습니까?</string>
+    <string name="delete_stations_message">%1$d개의 스테이션%2$s을(를) 삭제하시겠습니까?</string>
     <string name="delete_stations_message_single">%d개의 스테이션을 삭제하시겠습니까?</string>
     <string name="delete_stations_message_plural">%d개의 스테이션을 삭제하시겠습니까?</string>
     <string name="button_delete">삭제</string>
-    <string name="deleted_stations_message">%d개의 스테이션%s을(를) 삭제했습니다</string>
+    <string name="deleted_stations_message">%1$d개의 스테이션%2$s을(를) 삭제했습니다</string>
     <string name="deleted_stations_message_single">%d개의 스테이션을 삭제했습니다</string>
     <string name="deleted_stations_message_plural">%d개의 스테이션을 삭제했습니다</string>
 
@@ -524,7 +524,7 @@
     <string name="import_curated_title">%s 스테이션 가져오기</string>
     <string name="import_curated_message">%1$d개의 선별된 %2$s 라디오 스테이션을 가져오시겠습니까?\n\n이 스테이션들은 프록시 설정으로 미리 구성되어 있으며 바로 사용할 수 있습니다.</string>
     <string name="no_stations_found_in_list">%s 목록에서 스테이션을 찾을 수 없습니다</string>
-    <string name="failed_to_import_stations">%s 스테이션 가져오기 실패: %s</string>
+    <string name="failed_to_import_stations">%1$s 스테이션 가져오기 실패: %2$s</string>
     <string name="dialog_export_stations_title">스테이션 내보내기</string>
     <string name="no_stations_in_file">파일에서 스테이션을 찾을 수 없습니다</string>
     <string name="dialog_import_failed">가져오기 실패</string>

--- a/app/src/main/res/values-my/strings.xml
+++ b/app/src/main/res/values-my/strings.xml
@@ -464,11 +464,11 @@
     <string name="auth_biometric_negative">စကားဝှက် သုံးပါ</string>
 
     <!-- Delete Confirmation Dialog -->
-    <string name="delete_stations_message">%d ဘူတာ%s ကို ဖျက်ရန် သေချာပါသလား?</string>
+    <string name="delete_stations_message">%1$d ဘူတာ%2$s ကို ဖျက်ရန် သေချာပါသလား?</string>
     <string name="delete_stations_message_single">%d ဘူတာကို ဖျက်ရန် သေချာပါသလား?</string>
     <string name="delete_stations_message_plural">%d ဘူတာကို ဖျက်ရန် သေချာပါသလား?</string>
     <string name="button_delete">ဖျက်ပါ</string>
-    <string name="deleted_stations_message">%d ဘူတာ%s ဖျက်လိုက်ပါပြီ</string>
+    <string name="deleted_stations_message">%1$d ဘူတာ%2$s ဖျက်လိုက်ပါပြီ</string>
     <string name="deleted_stations_message_single">%d ဘူတာ ဖျက်လိုက်ပါပြီ</string>
     <string name="deleted_stations_message_plural">%d ဘူတာ ဖျက်လိုက်ပါပြီ</string>
 
@@ -522,7 +522,7 @@
     <string name="import_curated_title">%s ဘူတာများ တင်သွင်းပါ</string>
     <string name="import_curated_message">%1$d ရွေးချယ်ထားသော %2$s ရေဒီယိုဘူတာများ တင်သွင်းမလား?\n\nဤဘူတာများသည် ပရောက်ဆီ ဆက်တင်များဖြင့် ကြိုတင်ပြင်ဆင်ထားပြီး အသုံးပြုရန် အဆင်သင့်ဖြစ်ပါသည်။</string>
     <string name="no_stations_found_in_list">%s စာရင်းတွင် ဘူတာများ မတွေ့ပါ</string>
-    <string name="failed_to_import_stations">%s ဘူတာများ တင်သွင်းမှု မအောင်မြင်ပါ: %s</string>
+    <string name="failed_to_import_stations">%1$s ဘူတာများ တင်သွင်းမှု မအောင်မြင်ပါ: %2$s</string>
     <string name="dialog_export_stations_title">ဘူတာများ တင်ပို့ပါ</string>
     <string name="no_stations_in_file">ဖိုင်တွင် ဘူတာများ မတွေ့ပါ</string>
     <string name="dialog_import_failed">တင်သွင်းမှု မအောင်မြင်ပါ</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -467,11 +467,11 @@
     <string name="auth_biometric_negative">Usar senha</string>
 
     <!-- Delete Confirmation Dialog -->
-    <string name="delete_stations_message">Tem certeza que deseja excluir %d estação%s?</string>
+    <string name="delete_stations_message">Tem certeza que deseja excluir %1$d estação%2$s?</string>
     <string name="delete_stations_message_single">Tem certeza que deseja excluir %d estação?</string>
     <string name="delete_stations_message_plural">Tem certeza que deseja excluir %d estações?</string>
     <string name="button_delete">Excluir</string>
-    <string name="deleted_stations_message">%d estação%s excluída</string>
+    <string name="deleted_stations_message">%1$d estação%2$s excluída</string>
     <string name="deleted_stations_message_single">%d estação excluída</string>
     <string name="deleted_stations_message_plural">%d estações excluídas</string>
 
@@ -525,7 +525,7 @@
     <string name="import_curated_title">Importar estações %s</string>
     <string name="import_curated_message">Importar %1$d estações de rádio %2$s selecionadas?\n\nEstas estações são pré-configuradas e prontas para usar.</string>
     <string name="no_stations_found_in_list">Nenhuma estação encontrada na lista %s</string>
-    <string name="failed_to_import_stations">Falha ao importar estações %s: %s</string>
+    <string name="failed_to_import_stations">Falha ao importar estações %1$s: %2$s</string>
     <string name="dialog_export_stations_title">Exportar estações</string>
     <string name="no_stations_in_file">Nenhuma estação encontrada no arquivo</string>
     <string name="dialog_import_failed">Importação falhou</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -466,11 +466,11 @@
     <string name="auth_biometric_negative">Использовать пароль</string>
 
     <!-- Delete Confirmation Dialog -->
-    <string name="delete_stations_message">Вы уверены, что хотите удалить %d станци%s?</string>
+    <string name="delete_stations_message">Вы уверены, что хотите удалить %1$d станци%2$s?</string>
     <string name="delete_stations_message_single">Вы уверены, что хотите удалить %d станцию?</string>
     <string name="delete_stations_message_plural">Вы уверены, что хотите удалить %d станций?</string>
     <string name="button_delete">Удалить</string>
-    <string name="deleted_stations_message">Удалено %d станци%s</string>
+    <string name="deleted_stations_message">Удалено %1$d станци%2$s</string>
     <string name="deleted_stations_message_single">Удалена %d станция</string>
     <string name="deleted_stations_message_plural">Удалено %d станций</string>
 
@@ -524,7 +524,7 @@
     <string name="import_curated_title">Импорт станций %s</string>
     <string name="import_curated_message">Импортировать %1$d отобранных радиостанций %2$s?\n\nЭти станции предварительно настроены с параметрами прокси и готовы к использованию.</string>
     <string name="no_stations_found_in_list">Станции не найдены в списке %s</string>
-    <string name="failed_to_import_stations">Не удалось импортировать станции %s: %s</string>
+    <string name="failed_to_import_stations">Не удалось импортировать станции %1$s: %2$s</string>
     <string name="dialog_export_stations_title">Экспорт станций</string>
     <string name="no_stations_in_file">Станции не найдены в файле</string>
     <string name="dialog_import_failed">Импорт не удался</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -467,11 +467,11 @@
     <string name="auth_biometric_negative">Şifre Kullan</string>
 
     <!-- Delete Confirmation Dialog -->
-    <string name="delete_stations_message">%d istasyon%s silmek istediğinizden emin misiniz?</string>
+    <string name="delete_stations_message">%1$d istasyon%2$s silmek istediğinizden emin misiniz?</string>
     <string name="delete_stations_message_single">%d istasyonu silmek istediğinizden emin misiniz?</string>
     <string name="delete_stations_message_plural">%d istasyonu silmek istediğinizden emin misiniz?</string>
     <string name="button_delete">Sil</string>
-    <string name="deleted_stations_message">%d istasyon%s silindi</string>
+    <string name="deleted_stations_message">%1$d istasyon%2$s silindi</string>
     <string name="deleted_stations_message_single">%d istasyon silindi</string>
     <string name="deleted_stations_message_plural">%d istasyon silindi</string>
 
@@ -525,7 +525,7 @@
     <string name="import_curated_title">%s İstasyonlarını İçe Aktar</string>
     <string name="import_curated_message">%1$d seçilmiş %2$s radyo istasyonu içe aktarılsın mı?\n\nBu istasyonlar proxy ayarlarıyla önceden yapılandırılmış ve kullanıma hazır.</string>
     <string name="no_stations_found_in_list">%s listesinde istasyon bulunamadı</string>
-    <string name="failed_to_import_stations">%s istasyonları içe aktarılamadı: %s</string>
+    <string name="failed_to_import_stations">%1$s istasyonları içe aktarılamadı: %2$s</string>
     <string name="dialog_export_stations_title">İstasyonları Dışa Aktar</string>
     <string name="no_stations_in_file">Dosyada istasyon bulunamadı</string>
     <string name="dialog_import_failed">İçe Aktarma Başarısız</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -467,11 +467,11 @@
     <string name="auth_biometric_negative">Використати пароль</string>
 
     <!-- Delete Confirmation Dialog -->
-    <string name="delete_stations_message">Ви впевнені, що хочете видалити %d станці%s?</string>
+    <string name="delete_stations_message">Ви впевнені, що хочете видалити %1$d станці%2$s?</string>
     <string name="delete_stations_message_single">Ви впевнені, що хочете видалити %d станцію?</string>
     <string name="delete_stations_message_plural">Ви впевнені, що хочете видалити %d станцій?</string>
     <string name="button_delete">Видалити</string>
-    <string name="deleted_stations_message">Видалено %d станці%s</string>
+    <string name="deleted_stations_message">Видалено %1$d станці%2$s</string>
     <string name="deleted_stations_message_single">Видалена %d станція</string>
     <string name="deleted_stations_message_plural">Видалено %d станцій</string>
 
@@ -525,7 +525,7 @@
     <string name="import_curated_title">Імпорт станцій %s</string>
     <string name="import_curated_message">Імпортувати %1$d відібраних радіостанцій %2$s?\n\nЦі станції попередньо налаштовані з параметрами проксі і готові до використання.</string>
     <string name="no_stations_found_in_list">Станції не знайдено в списку %s</string>
-    <string name="failed_to_import_stations">Не вдалося імпортувати станції %s: %s</string>
+    <string name="failed_to_import_stations">Не вдалося імпортувати станції %1$s: %2$s</string>
     <string name="dialog_export_stations_title">Експорт станцій</string>
     <string name="no_stations_in_file">Станції не знайдено у файлі</string>
     <string name="dialog_import_failed">Імпорт не вдався</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -467,11 +467,11 @@
     <string name="auth_biometric_negative">Sử dụng mật khẩu</string>
 
     <!-- Delete Confirmation Dialog -->
-    <string name="delete_stations_message">Bạn có chắc chắn muốn xóa %d đài%s không?</string>
+    <string name="delete_stations_message">Bạn có chắc chắn muốn xóa %1$d đài%2$s không?</string>
     <string name="delete_stations_message_single">Bạn có chắc chắn muốn xóa %d đài không?</string>
     <string name="delete_stations_message_plural">Bạn có chắc chắn muốn xóa %d đài không?</string>
     <string name="button_delete">Xóa</string>
-    <string name="deleted_stations_message">Đã xóa %d đài%s</string>
+    <string name="deleted_stations_message">Đã xóa %1$d đài%2$s</string>
     <string name="deleted_stations_message_single">Đã xóa %d đài</string>
     <string name="deleted_stations_message_plural">Đã xóa %d đài</string>
 
@@ -525,7 +525,7 @@
     <string name="import_curated_title">Nhập đài %s</string>
     <string name="import_curated_message">Nhập %1$d đài phát thanh %2$s được tuyển chọn?\n\nCác đài này được cấu hình sẵn với cài đặt proxy và sẵn sàng sử dụng.</string>
     <string name="no_stations_found_in_list">Không tìm thấy đài nào trong danh sách %s</string>
-    <string name="failed_to_import_stations">Không nhập được đài %s: %s</string>
+    <string name="failed_to_import_stations">Không nhập được đài %1$s: %2$s</string>
     <string name="dialog_export_stations_title">Xuất đài</string>
     <string name="no_stations_in_file">Không tìm thấy đài nào trong tệp</string>
     <string name="dialog_import_failed">Nhập thất bại</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -467,11 +467,11 @@
     <string name="auth_biometric_negative">使用密码</string>
 
     <!-- Delete Confirmation Dialog -->
-    <string name="delete_stations_message">确定要删除 %d 个电台%s吗？</string>
+    <string name="delete_stations_message">确定要删除 %1$d 个电台%2$s吗？</string>
     <string name="delete_stations_message_single">确定要删除 %d 个电台吗？</string>
     <string name="delete_stations_message_plural">确定要删除 %d 个电台吗？</string>
     <string name="button_delete">删除</string>
-    <string name="deleted_stations_message">已删除 %d 个电台%s</string>
+    <string name="deleted_stations_message">已删除 %1$d 个电台%2$s</string>
     <string name="deleted_stations_message_single">已删除 %d 个电台</string>
     <string name="deleted_stations_message_plural">已删除 %d 个电台</string>
 
@@ -525,7 +525,7 @@
     <string name="import_curated_title">导入 %s 电台</string>
     <string name="import_curated_message">导入 %1$d 个精选的 %2$s 广播电台？\n\n这些电台已预先配置代理设置，可立即使用。</string>
     <string name="no_stations_found_in_list">在 %s 列表中未找到电台</string>
-    <string name="failed_to_import_stations">导入 %s 电台失败：%s</string>
+    <string name="failed_to_import_stations">导入 %1$s 电台失败：%2$s</string>
     <string name="dialog_export_stations_title">导出电台</string>
     <string name="no_stations_in_file">文件中未找到电台</string>
     <string name="dialog_import_failed">导入失败</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -474,11 +474,11 @@
     <string name="auth_biometric_negative">Use Password</string>
 
     <!-- Delete Confirmation Dialog -->
-    <string name="delete_stations_message">Are you sure you want to delete %d station%s?</string>
+    <string name="delete_stations_message">Are you sure you want to delete %1$d station%2$s?</string>
     <string name="delete_stations_message_single">Are you sure you want to delete %d station?</string>
     <string name="delete_stations_message_plural">Are you sure you want to delete %d stations?</string>
     <string name="button_delete">Delete</string>
-    <string name="deleted_stations_message">Deleted %d station%s</string>
+    <string name="deleted_stations_message">Deleted %1$d station%2$s</string>
     <string name="deleted_stations_message_single">Deleted %d station</string>
     <string name="deleted_stations_message_plural">Deleted %d stations</string>
 
@@ -532,7 +532,7 @@
     <string name="import_curated_title">Add %s Stations</string>
     <string name="import_curated_message">Add %1$d bundled %2$s radio stations?\n\nThese stations are pre-configured with proxy settings and ready to use. This is an offline operation.</string>
     <string name="no_stations_found_in_list">No stations found in %s list</string>
-    <string name="failed_to_import_stations">Failed to add %s stations: %s</string>
+    <string name="failed_to_import_stations">Failed to add %1$s stations: %2$s</string>
     <string name="dialog_export_stations_title">Export Stations</string>
     <string name="no_stations_in_file">No stations found in the file</string>
     <string name="dialog_import_failed">Import Failed</string>


### PR DESCRIPTION
- Fix unescaped apostrophes in French tor_status_tor_required_description and tor_control_subtitle_blocked strings
- Convert non-positional format specifiers to positional format (%d → %1$d, %s → %1$s, etc.) in delete_stations_message, deleted_stations_message, and failed_to_import_stations strings across all 17 language files

This fixes Android resource compilation errors for multiple substitutions.