### PR TITLE
Fix DNS leak in RadioBrowserServerManager for force proxy modes

### DIFF
--- a/app/src/main/java/com/opensource/i2pradio/data/radiobrowser/RadioBrowserClient.kt
+++ b/app/src/main/java/com/opensource/i2pradio/data/radiobrowser/RadioBrowserClient.kt
@@ -167,10 +167,13 @@ class RadioBrowserClient(private val context: Context) {
     }
 
     /**
-     * Get the current API base URL using dynamic server discovery
+     * Get the current API base URL using dynamic server discovery.
+     *
+     * SECURITY: Passes context to RadioBrowserServerManager so that server
+     * discovery respects force proxy settings and prevents DNS/HTTP leaks.
      */
     private suspend fun getApiBaseUrl(): String {
-        return RadioBrowserServerManager.getApiBaseUrl()
+        return RadioBrowserServerManager.getApiBaseUrl(context)
     }
 
     /**

--- a/app/src/main/java/com/opensource/i2pradio/data/radiobrowser/RadioBrowserServerManager.kt
+++ b/app/src/main/java/com/opensource/i2pradio/data/radiobrowser/RadioBrowserServerManager.kt
@@ -1,14 +1,20 @@
 package com.opensource.i2pradio.data.radiobrowser
 
+import android.content.Context
 import android.util.Log
+import com.opensource.i2pradio.tor.TorManager
+import com.opensource.i2pradio.ui.PreferencesHelper
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
+import okhttp3.Dns
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import org.json.JSONArray
 import java.net.InetAddress
+import java.net.InetSocketAddress
+import java.net.Proxy
 import java.util.concurrent.TimeUnit
 import kotlin.random.Random
 
@@ -44,6 +50,10 @@ object RadioBrowserServerManager {
     private const val CACHE_DURATION_MS = 30 * 60 * 1000L // 30 minutes
     private const val DNS_TIMEOUT_MS = 5000L
 
+    // Timeouts for proxied connections (longer to account for Tor latency)
+    private const val PROXY_CONNECT_TIMEOUT_SECONDS = 60L
+    private const val PROXY_READ_TIMEOUT_SECONDS = 60L
+
     // Cached server list
     private var cachedServers: List<String> = emptyList()
     private var cacheTimestamp: Long = 0
@@ -51,12 +61,30 @@ object RadioBrowserServerManager {
     private val mutex = Mutex()
 
     /**
+     * Custom DNS resolver that forces DNS resolution through SOCKS5 proxy.
+     *
+     * By default, OkHttp resolves DNS locally BEFORE connecting through SOCKS,
+     * which leaks DNS queries to clearnet. This resolver returns a placeholder
+     * address, forcing the SOCKS5 proxy (Tor) to handle DNS resolution.
+     */
+    private val SOCKS5_DNS = object : Dns {
+        override fun lookup(hostname: String): List<InetAddress> {
+            Log.d(TAG, "DNS lookup for '$hostname' - delegating to SOCKS5 proxy")
+            return listOf(InetAddress.getByAddress(hostname, byteArrayOf(0, 0, 0, 0)))
+        }
+    }
+
+    /**
      * Get the current API server to use.
      * If no servers are cached, discovers them first.
+     *
+     * @param context Optional context for proxy-aware server discovery.
+     *                When provided and force proxy mode is enabled, server discovery
+     *                will respect proxy settings to prevent DNS/HTTP leaks.
      */
-    suspend fun getCurrentServer(): String = mutex.withLock {
+    suspend fun getCurrentServer(context: Context? = null): String = mutex.withLock {
         if (cachedServers.isEmpty() || isCacheExpired()) {
-            refreshServerList()
+            refreshServerList(context)
         }
 
         if (cachedServers.isEmpty()) {
@@ -85,24 +113,30 @@ object RadioBrowserServerManager {
 
     /**
      * Get the full API base URL for the current server.
+     *
+     * @param context Optional context for proxy-aware server discovery.
      */
-    suspend fun getApiBaseUrl(): String {
-        return "https://${getCurrentServer()}/json"
+    suspend fun getApiBaseUrl(context: Context? = null): String {
+        return "https://${getCurrentServer(context)}/json"
     }
 
     /**
      * Force refresh the server list.
+     *
+     * @param context Optional context for proxy-aware server discovery.
      */
-    suspend fun forceRefresh() = mutex.withLock {
-        refreshServerList()
+    suspend fun forceRefresh(context: Context? = null) = mutex.withLock {
+        refreshServerList(context)
     }
 
     /**
      * Get all available servers (for debugging/display).
+     *
+     * @param context Optional context for proxy-aware server discovery.
      */
-    suspend fun getAllServers(): List<String> = mutex.withLock {
+    suspend fun getAllServers(context: Context? = null): List<String> = mutex.withLock {
         if (cachedServers.isEmpty() || isCacheExpired()) {
-            refreshServerList()
+            refreshServerList(context)
         }
         return@withLock cachedServers.ifEmpty { FALLBACK_SERVERS }
     }
@@ -113,23 +147,61 @@ object RadioBrowserServerManager {
 
     /**
      * Refresh the server list using DNS discovery with API fallback.
+     *
+     * SECURITY: When force proxy mode is enabled, this method ensures NO clearnet
+     * DNS or HTTP requests are made. Discovery either uses the configured proxy
+     * or falls back to hardcoded servers (no network request).
+     *
+     * @param context Optional context for checking proxy settings.
      */
-    private suspend fun refreshServerList() {
+    private suspend fun refreshServerList(context: Context?) {
         Log.d(TAG, "Refreshing server list...")
 
-        // Try DNS lookup first
-        var servers = discoverServersViaDns()
+        // Check if force proxy mode is enabled
+        val torEnabled = context?.let { PreferencesHelper.isEmbeddedTorEnabled(it) } ?: false
+        val forceTorAll = context?.let { PreferencesHelper.isForceTorAll(it) } ?: false
+        val forceTorExceptI2P = context?.let { PreferencesHelper.isForceTorExceptI2P(it) } ?: false
+        val forceCustomProxy = context?.let { PreferencesHelper.isForceCustomProxy(it) } ?: false
+        val forceCustomProxyExceptTorI2P = context?.let { PreferencesHelper.isForceCustomProxyExceptTorI2P(it) } ?: false
 
-        // If DNS fails, try the API endpoint
-        if (servers.isEmpty()) {
-            Log.d(TAG, "DNS discovery failed, trying API endpoint")
-            servers = discoverServersViaApi()
-        }
+        val forceTorEnabled = torEnabled && (forceTorAll || forceTorExceptI2P)
+        val forceCustomProxyEnabled = forceCustomProxy || forceCustomProxyExceptTorI2P
+        val forceProxyEnabled = forceTorEnabled || forceCustomProxyEnabled
 
-        // If both fail, use hardcoded fallbacks
-        if (servers.isEmpty()) {
-            Log.w(TAG, "All discovery methods failed, using hardcoded fallbacks")
-            servers = FALLBACK_SERVERS
+        Log.d(TAG, "Force proxy mode: $forceProxyEnabled (ForceTor: $forceTorEnabled, ForceCustomProxy: $forceCustomProxyEnabled)")
+
+        var servers: List<String> = emptyList()
+
+        if (forceProxyEnabled && context != null) {
+            // SECURITY: Skip DNS discovery entirely in force proxy mode
+            // Java's InetAddress.getAllByName() bypasses proxies and would leak DNS queries
+            Log.d(TAG, "Force proxy mode enabled - skipping DNS discovery to prevent leaks")
+
+            // Try API discovery with proper proxy routing
+            servers = discoverServersViaProxiedApi(context, forceTorEnabled, forceCustomProxyEnabled)
+
+            if (servers.isEmpty()) {
+                // Proxy unavailable or API failed - use hardcoded fallbacks
+                // This is safe because no network request is made
+                Log.w(TAG, "Proxied API discovery failed - using hardcoded fallbacks (no network request)")
+                servers = FALLBACK_SERVERS
+            }
+        } else {
+            // Normal flow - no force proxy mode
+            // Try DNS lookup first
+            servers = discoverServersViaDns()
+
+            // If DNS fails, try the API endpoint
+            if (servers.isEmpty()) {
+                Log.d(TAG, "DNS discovery failed, trying API endpoint")
+                servers = discoverServersViaApi()
+            }
+
+            // If both fail, use hardcoded fallbacks
+            if (servers.isEmpty()) {
+                Log.w(TAG, "All discovery methods failed, using hardcoded fallbacks")
+                servers = FALLBACK_SERVERS
+            }
         }
 
         // Shuffle servers to distribute load
@@ -141,6 +213,127 @@ object RadioBrowserServerManager {
         cachedServers.forEachIndexed { index, server ->
             Log.d(TAG, "  [$index] $server")
         }
+    }
+
+    /**
+     * Discover servers via the API endpoint using the configured proxy.
+     *
+     * SECURITY: This method routes the HTTP request through Tor or custom proxy
+     * to prevent IP/DNS leaks when force proxy mode is enabled.
+     *
+     * @param context Context for reading proxy settings
+     * @param forceTorEnabled True if Force Tor mode is active
+     * @param forceCustomProxyEnabled True if Force Custom Proxy mode is active
+     * @return List of discovered server hostnames, or empty if proxy unavailable/failed
+     */
+    private suspend fun discoverServersViaProxiedApi(
+        context: Context,
+        forceTorEnabled: Boolean,
+        forceCustomProxyEnabled: Boolean
+    ): List<String> = withContext(Dispatchers.IO) {
+        val servers = mutableListOf<String>()
+
+        try {
+            val builder = OkHttpClient.Builder()
+                .connectTimeout(PROXY_CONNECT_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+                .readTimeout(PROXY_READ_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+
+            // Priority 1: Force Tor mode
+            if (forceTorEnabled) {
+                if (!TorManager.isConnected()) {
+                    Log.e(TAG, "BLOCKING server discovery: Force Tor enabled but Tor is NOT connected")
+                    return@withContext emptyList()
+                }
+
+                val socksHost = TorManager.getProxyHost()
+                val socksPort = TorManager.getProxyPort()
+
+                if (socksPort <= 0) {
+                    Log.e(TAG, "BLOCKING server discovery: Force Tor enabled but Tor proxy port invalid ($socksPort)")
+                    return@withContext emptyList()
+                }
+
+                Log.d(TAG, "Routing server discovery through Tor SOCKS5 at $socksHost:$socksPort")
+                builder.proxy(Proxy(Proxy.Type.SOCKS, InetSocketAddress(socksHost, socksPort)))
+                builder.dns(SOCKS5_DNS)  // Force DNS through SOCKS5 to prevent leaks
+            }
+            // Priority 2: Force Custom Proxy mode
+            else if (forceCustomProxyEnabled) {
+                val proxyHost = PreferencesHelper.getCustomProxyHost(context)
+                val proxyPort = PreferencesHelper.getCustomProxyPort(context)
+                val proxyProtocol = PreferencesHelper.getCustomProxyProtocol(context)
+
+                if (proxyHost.isEmpty() || proxyPort <= 0) {
+                    Log.e(TAG, "BLOCKING server discovery: Force Custom Proxy enabled but proxy not configured")
+                    return@withContext emptyList()
+                }
+
+                val proxyType = when (proxyProtocol.uppercase()) {
+                    "SOCKS4", "SOCKS5", "SOCKS" -> Proxy.Type.SOCKS
+                    else -> Proxy.Type.HTTP
+                }
+
+                Log.d(TAG, "Routing server discovery through custom $proxyProtocol proxy at $proxyHost:$proxyPort")
+                builder.proxy(Proxy(proxyType, InetSocketAddress(proxyHost, proxyPort)))
+
+                // Force DNS through SOCKS5 proxy to prevent DNS leaks
+                if (proxyType == Proxy.Type.SOCKS) {
+                    builder.dns(SOCKS5_DNS)
+                }
+
+                // Add proxy authentication if configured
+                val proxyUsername = PreferencesHelper.getCustomProxyUsername(context)
+                val proxyPassword = PreferencesHelper.getCustomProxyPassword(context)
+                if (proxyUsername.isNotEmpty() && proxyPassword.isNotEmpty()) {
+                    builder.proxyAuthenticator { _, response ->
+                        val previousAuth = response.request.header("Proxy-Authorization")
+                        if (previousAuth != null) {
+                            return@proxyAuthenticator null
+                        }
+                        val credential = okhttp3.Credentials.basic(proxyUsername, proxyPassword)
+                        response.request.newBuilder()
+                            .header("Proxy-Authorization", credential)
+                            .build()
+                    }
+                }
+            }
+
+            val client = builder.build()
+
+            Log.d(TAG, "Fetching server list from API (proxied): $FALLBACK_API_URL")
+
+            val request = Request.Builder()
+                .url(FALLBACK_API_URL)
+                .header("User-Agent", "DeutsiaRadio/1.0")
+                .get()
+                .build()
+
+            val response = client.newCall(request).execute()
+
+            if (response.isSuccessful) {
+                val body = response.body?.string()
+                response.close()
+
+                if (!body.isNullOrEmpty()) {
+                    val jsonArray = JSONArray(body)
+                    for (i in 0 until jsonArray.length()) {
+                        val obj = jsonArray.getJSONObject(i)
+                        val name = obj.optString("name", "")
+                        if (name.isNotEmpty() && name.contains("api.radio-browser.info")) {
+                            servers.add(name)
+                            Log.d(TAG, "Proxied API discovered server: $name")
+                        }
+                    }
+                }
+            } else {
+                response.close()
+                Log.w(TAG, "Proxied API server list request failed: ${response.code}")
+            }
+        } catch (e: Exception) {
+            Log.e(TAG, "Proxied API discovery failed: ${e.message}")
+        }
+
+        return@withContext servers
     }
 
     /**


### PR DESCRIPTION
SECURITY FIX: When Force Tor or Force Custom Proxy modes are enabled, server discovery now respects proxy settings to prevent DNS/HTTP leaks.

Changes:
- Add Context parameter to RadioBrowserServerManager methods
- Add SOCKS5_DNS resolver for DNS-through-proxy resolution
- Add discoverServersViaProxiedApi() for proxy-routed API discovery
- Skip clearnet DNS discovery (InetAddress.getAllByName) in force modes
- Block network discovery and use hardcoded fallbacks when proxy unavailable
- Support both Force Tor and Force Custom Proxy (SOCKS and HTTP) modes
- Add proxy authentication support for custom proxies

Before: DNS queries to all.api.radio-browser.info leaked to clearnet
After: All discovery uses configured proxy or falls back to hardcoded servers