### PR TITLE
Fix Tor proxy detection for curated stations in browse tab

### DIFF
--- a/app/src/main/java/com/opensource/i2pradio/data/radiobrowser/RadioBrowserRepository.kt
+++ b/app/src/main/java/com/opensource/i2pradio/data/radiobrowser/RadioBrowserRepository.kt
@@ -260,10 +260,11 @@ class RadioBrowserRepository(context: Context) {
             countryCode = station.countrycode,
             homepage = station.homepage,
             addedTimestamp = now,
-            // Default proxy settings - stations from RadioBrowser are clearnet
-            useProxy = false,
-            proxyHost = "",
-            proxyPort = 0
+            // Use proxy settings from the station (for Tor/I2P curated stations)
+            useProxy = station.useProxy,
+            proxyType = station.proxyType,
+            proxyHost = station.proxyHost,
+            proxyPort = station.proxyPort
         )
     }
 

--- a/app/src/main/java/com/opensource/i2pradio/data/radiobrowser/RadioBrowserStation.kt
+++ b/app/src/main/java/com/opensource/i2pradio/data/radiobrowser/RadioBrowserStation.kt
@@ -31,7 +31,12 @@ data class RadioBrowserStation(
     val clicktrend: Int,
     val sslError: Boolean,
     val geoLat: Double?,
-    val geoLong: Double?
+    val geoLong: Double?,
+    // Proxy settings for Tor/I2P stations
+    val useProxy: Boolean = false,
+    val proxyType: String = "NONE",
+    val proxyHost: String = "",
+    val proxyPort: Int = 0
 ) {
     companion object {
         /**
@@ -99,7 +104,12 @@ data class RadioBrowserStation(
                 clicktrend = 0,
                 sslError = false,
                 geoLat = null,
-                geoLong = null
+                geoLong = null,
+                // Preserve proxy settings from source station
+                useProxy = station.useProxy,
+                proxyType = station.proxyType,
+                proxyHost = station.proxyHost,
+                proxyPort = station.proxyPort
             )
         }
     }

--- a/app/src/main/java/com/opensource/i2pradio/ui/browse/BrowseStationsFragment.kt
+++ b/app/src/main/java/com/opensource/i2pradio/ui/browse/BrowseStationsFragment.kt
@@ -1182,9 +1182,9 @@ class BrowseStationsFragment : Fragment() {
             action = RadioService.ACTION_PLAY
             putExtra("stream_url", radioStation.streamUrl)
             putExtra("station_name", radioStation.name)
-            putExtra("proxy_host", "")
-            putExtra("proxy_port", 0)
-            putExtra("proxy_type", "NONE")
+            putExtra("proxy_host", radioStation.proxyHost)
+            putExtra("proxy_port", radioStation.proxyPort)
+            putExtra("proxy_type", radioStation.proxyType)
             putExtra("cover_art_uri", radioStation.coverArtUri)
             putExtra("custom_proxy_protocol", "HTTP")
             putExtra("proxy_username", "")


### PR DESCRIPTION
The hardcoded Tor section in the genre list was not correctly configuring proxy settings. Stations from tor_stations.json were being treated as clearnet because:

1. RadioBrowserStation didn't carry proxy information
2. fromRadioStation() only added proxy type as a tag
3. convertToRadioStation() always set useProxy=false
4. playStation() hardcoded proxy settings to NONE

Fixed by:
- Adding proxy fields to RadioBrowserStation with defaults
- Preserving proxy settings in fromRadioStation()
- Using proxy settings in convertToRadioStation()
- Passing actual proxy settings in playStation()