### PR TITLE
Add dynamic API integration for Tor/I2P stations

### DIFF
--- a/app/src/main/java/com/opensource/i2pradio/data/radioregistry/RadioRegistryClient.kt
+++ b/app/src/main/java/com/opensource/i2pradio/data/radioregistry/RadioRegistryClient.kt
@@ -1,0 +1,328 @@
+package com.opensource.i2pradio.data.radioregistry
+
+import android.content.Context
+import android.util.Log
+import com.opensource.i2pradio.tor.TorManager
+import com.opensource.i2pradio.ui.PreferencesHelper
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import okhttp3.Dns
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import org.json.JSONArray
+import org.json.JSONObject
+import java.net.InetAddress
+import java.net.InetSocketAddress
+import java.net.Proxy
+import java.util.concurrent.TimeUnit
+
+/**
+ * Client for the Radio Registry API (api.deutsia.com)
+ *
+ * Provides access to privacy-focused Tor and I2P radio stations.
+ * Supports clearnet access, with optional Tor/custom proxy routing.
+ */
+class RadioRegistryClient(private val context: Context) {
+
+    companion object {
+        private const val TAG = "RadioRegistryClient"
+
+        // API Base URLs
+        private const val CLEARNET_BASE_URL = "https://api.deutsia.com"
+        private const val TOR_BASE_URL = "http://hujzvles33iouzuolttpxpfan4sjaqylc2unkz5tmcobztzfwgkl57yd.onion"
+
+        // Timeouts
+        private const val CONNECT_TIMEOUT_SECONDS = 15L
+        private const val READ_TIMEOUT_SECONDS = 15L
+        private const val CONNECT_TIMEOUT_PROXY_SECONDS = 30L
+        private const val READ_TIMEOUT_PROXY_SECONDS = 30L
+
+        // User agent
+        private const val USER_AGENT = "DeutsiaRadio/1.0 (Android; +https://github.com/deutsia/i2pradio)"
+
+        // Default pagination
+        private const val DEFAULT_LIMIT = 50
+        private const val MAX_LIMIT = 200
+
+        /**
+         * Custom DNS resolver for SOCKS5 proxy to prevent DNS leaks.
+         * Returns a placeholder address, forcing the SOCKS5 proxy to handle DNS resolution.
+         */
+        private val SOCKS5_DNS = object : Dns {
+            override fun lookup(hostname: String): List<InetAddress> {
+                Log.d(TAG, "DNS lookup for '$hostname' - delegating to SOCKS5 proxy")
+                return listOf(InetAddress.getByAddress(hostname, byteArrayOf(0, 0, 0, 0)))
+            }
+        }
+    }
+
+    /**
+     * Build an OkHttpClient respecting Force Tor and Force Custom Proxy settings.
+     *
+     * @return OkHttpClient configured with appropriate proxy, or null if Force Tor is enabled
+     *         but Tor is not available (to prevent IP leaks)
+     */
+    private fun buildHttpClient(): Pair<OkHttpClient?, String> {
+        val builder = OkHttpClient.Builder()
+
+        val torEnabled = PreferencesHelper.isEmbeddedTorEnabled(context)
+        val forceTorAll = PreferencesHelper.isForceTorAll(context)
+        val forceTorExceptI2P = PreferencesHelper.isForceTorExceptI2P(context)
+        val forceCustomProxy = PreferencesHelper.isForceCustomProxy(context)
+        val forceCustomProxyExceptTorI2P = PreferencesHelper.isForceCustomProxyExceptTorI2P(context)
+        val torConnected = TorManager.isConnected()
+
+        Log.d(TAG, "Building HTTP client - ForceTorAll: $forceTorAll, ForceTorExceptI2P: $forceTorExceptI2P, " +
+                "ForceCustomProxy: $forceCustomProxy, TorEnabled: $torEnabled, TorConnected: $torConnected")
+
+        // Priority 1: Force Tor mode
+        if (torEnabled && (forceTorAll || forceTorExceptI2P)) {
+            if (!torConnected) {
+                Log.e(TAG, "BLOCKING Radio Registry API request: Force Tor enabled but Tor is NOT connected")
+                return Pair(null, CLEARNET_BASE_URL)
+            }
+
+            val socksHost = TorManager.getProxyHost()
+            val socksPort = TorManager.getProxyPort()
+
+            if (socksPort > 0) {
+                Log.d(TAG, "Routing Radio Registry API through Tor SOCKS5 proxy at $socksHost:$socksPort")
+                builder.proxy(Proxy(Proxy.Type.SOCKS, InetSocketAddress(socksHost, socksPort)))
+                builder.dns(SOCKS5_DNS)
+                builder.connectTimeout(CONNECT_TIMEOUT_PROXY_SECONDS, TimeUnit.SECONDS)
+                builder.readTimeout(READ_TIMEOUT_PROXY_SECONDS, TimeUnit.SECONDS)
+                // Use the Tor onion service for maximum privacy
+                return Pair(builder.build(), TOR_BASE_URL)
+            } else {
+                Log.e(TAG, "BLOCKING Radio Registry API request: Force Tor enabled but Tor proxy port invalid")
+                return Pair(null, CLEARNET_BASE_URL)
+            }
+        }
+        // Priority 2: Force Custom Proxy
+        else if (forceCustomProxy || forceCustomProxyExceptTorI2P) {
+            val proxyHost = PreferencesHelper.getCustomProxyHost(context)
+            val proxyPort = PreferencesHelper.getCustomProxyPort(context)
+            val proxyProtocol = PreferencesHelper.getCustomProxyProtocol(context)
+            val proxyUsername = PreferencesHelper.getCustomProxyUsername(context)
+            val proxyPassword = PreferencesHelper.getCustomProxyPassword(context)
+
+            if (proxyHost.isNotEmpty() && proxyPort > 0) {
+                val proxyType = when (proxyProtocol.uppercase()) {
+                    "SOCKS4", "SOCKS5", "SOCKS" -> Proxy.Type.SOCKS
+                    "HTTP", "HTTPS" -> Proxy.Type.HTTP
+                    else -> Proxy.Type.HTTP
+                }
+
+                Log.d(TAG, "Routing Radio Registry API through CUSTOM proxy ($proxyProtocol) at $proxyHost:$proxyPort")
+                builder.proxy(Proxy(proxyType, InetSocketAddress(proxyHost, proxyPort)))
+
+                if (proxyType == Proxy.Type.SOCKS) {
+                    builder.dns(SOCKS5_DNS)
+                }
+
+                // Add proxy authentication if configured
+                if (proxyUsername.isNotEmpty() && proxyPassword.isNotEmpty()) {
+                    builder.proxyAuthenticator { _, response ->
+                        val previousAuth = response.request.header("Proxy-Authorization")
+                        if (previousAuth != null) {
+                            return@proxyAuthenticator null
+                        }
+                        val credential = okhttp3.Credentials.basic(proxyUsername, proxyPassword)
+                        response.request.newBuilder()
+                            .header("Proxy-Authorization", credential)
+                            .build()
+                    }
+                }
+
+                builder.connectTimeout(CONNECT_TIMEOUT_PROXY_SECONDS, TimeUnit.SECONDS)
+                builder.readTimeout(READ_TIMEOUT_PROXY_SECONDS, TimeUnit.SECONDS)
+                return Pair(builder.build(), CLEARNET_BASE_URL)
+            } else {
+                Log.e(TAG, "BLOCKING Radio Registry API request: Force Custom Proxy enabled but not configured")
+                return Pair(null, CLEARNET_BASE_URL)
+            }
+        }
+        // Priority 3: Use Tor if available (opportunistic, for privacy)
+        else if (torEnabled && torConnected) {
+            val socksHost = TorManager.getProxyHost()
+            val socksPort = TorManager.getProxyPort()
+
+            if (socksPort > 0) {
+                Log.d(TAG, "Opportunistically routing Radio Registry API through Tor")
+                builder.proxy(Proxy(Proxy.Type.SOCKS, InetSocketAddress(socksHost, socksPort)))
+                builder.dns(SOCKS5_DNS)
+                builder.connectTimeout(CONNECT_TIMEOUT_PROXY_SECONDS, TimeUnit.SECONDS)
+                builder.readTimeout(READ_TIMEOUT_PROXY_SECONDS, TimeUnit.SECONDS)
+                return Pair(builder.build(), TOR_BASE_URL)
+            }
+        }
+
+        // Default: Direct connection to clearnet
+        Log.d(TAG, "Using direct connection for Radio Registry API")
+        builder.connectTimeout(CONNECT_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+        builder.readTimeout(READ_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+        return Pair(builder.build(), CLEARNET_BASE_URL)
+    }
+
+    /**
+     * Execute an API request
+     */
+    private suspend fun <T> executeRequest(
+        endpoint: String,
+        parser: (String) -> T
+    ): RadioRegistryResult<T> {
+        return withContext(Dispatchers.IO) {
+            try {
+                val (client, baseUrl) = buildHttpClient()
+
+                if (client == null) {
+                    Log.e(TAG, "API request blocked: proxy required but not available")
+                    return@withContext RadioRegistryResult.Error(
+                        "Request blocked: Tor/proxy not connected. Enable Tor or disable Force Tor mode.",
+                        null
+                    )
+                }
+
+                val url = "$baseUrl/api$endpoint"
+                Log.d(TAG, "API Request: $url")
+
+                val request = Request.Builder()
+                    .url(url)
+                    .header("User-Agent", USER_AGENT)
+                    .header("Accept", "application/json")
+                    .get()
+                    .build()
+
+                val response = client.newCall(request).execute()
+
+                if (!response.isSuccessful) {
+                    Log.w(TAG, "API request failed with code: ${response.code}")
+                    response.close()
+                    return@withContext RadioRegistryResult.Error("HTTP ${response.code}")
+                }
+
+                val body = response.body?.string()
+                response.close()
+
+                if (body.isNullOrEmpty()) {
+                    Log.w(TAG, "Empty response body")
+                    return@withContext RadioRegistryResult.Error("Empty response")
+                }
+
+                val result = parser(body)
+                RadioRegistryResult.Success(result)
+
+            } catch (e: Exception) {
+                Log.e(TAG, "API request failed: ${e.message}")
+                RadioRegistryResult.Error(e.message ?: "Unknown error", e)
+            }
+        }
+    }
+
+    /**
+     * Get list of stations with optional filtering
+     *
+     * @param network Filter by network: "tor" or "i2p" (null for all)
+     * @param genre Filter by genre
+     * @param limit Maximum number of stations (max 200)
+     * @param offset Pagination offset
+     */
+    suspend fun getStations(
+        network: String? = null,
+        genre: String? = null,
+        limit: Int = DEFAULT_LIMIT,
+        offset: Int = 0
+    ): RadioRegistryResult<StationListResponse> {
+        val params = buildString {
+            append("/stations?limit=${limit.coerceAtMost(MAX_LIMIT)}")
+            append("&offset=$offset")
+            network?.let { append("&network=${java.net.URLEncoder.encode(it, "UTF-8")}") }
+            genre?.let { append("&genre=${java.net.URLEncoder.encode(it, "UTF-8")}") }
+        }
+
+        return executeRequest(params) { body ->
+            StationListResponse.fromJson(JSONObject(body))
+        }
+    }
+
+    /**
+     * Get all Tor stations
+     */
+    suspend fun getTorStations(
+        limit: Int = DEFAULT_LIMIT,
+        offset: Int = 0
+    ): RadioRegistryResult<StationListResponse> {
+        return getStations(network = "tor", limit = limit, offset = offset)
+    }
+
+    /**
+     * Get all I2P stations
+     */
+    suspend fun getI2pStations(
+        limit: Int = DEFAULT_LIMIT,
+        offset: Int = 0
+    ): RadioRegistryResult<StationListResponse> {
+        return getStations(network = "i2p", limit = limit, offset = offset)
+    }
+
+    /**
+     * Get a single station by ID
+     */
+    suspend fun getStation(stationId: String): RadioRegistryResult<RadioRegistryStation> {
+        return executeRequest("/stations/$stationId") { body ->
+            RadioRegistryStation.fromJson(JSONObject(body))
+        }
+    }
+
+    /**
+     * Get API statistics
+     */
+    suspend fun getStats(): RadioRegistryResult<StatsResponse> {
+        return executeRequest("/stats") { body ->
+            StatsResponse.fromJson(JSONObject(body))
+        }
+    }
+
+    /**
+     * Get list of all genres
+     */
+    suspend fun getGenres(): RadioRegistryResult<List<String>> {
+        return executeRequest("/genres") { body ->
+            val jsonArray = JSONArray(body)
+            val genres = mutableListOf<String>()
+            for (i in 0 until jsonArray.length()) {
+                val genre = jsonArray.optString(i, "")
+                if (genre.isNotEmpty()) {
+                    genres.add(genre)
+                }
+            }
+            genres
+        }
+    }
+
+    /**
+     * Check API health
+     */
+    suspend fun checkHealth(): RadioRegistryResult<Boolean> {
+        return executeRequest("/health") { body ->
+            val json = JSONObject(body)
+            json.optString("status", "") == "ok" && json.optBoolean("database", false)
+        }
+    }
+
+    /**
+     * Check if Force Tor is enabled but Tor is not connected
+     */
+    fun isTorRequiredButNotConnected(): Boolean {
+        val torIntegrationEnabled = PreferencesHelper.isEmbeddedTorEnabled(context)
+        if (!torIntegrationEnabled) {
+            return false
+        }
+
+        val forceTorAll = PreferencesHelper.isForceTorAll(context)
+        val forceTorExceptI2P = PreferencesHelper.isForceTorExceptI2P(context)
+        val torConnected = TorManager.isConnected()
+
+        return (forceTorAll || forceTorExceptI2P) && !torConnected
+    }
+}

--- a/app/src/main/java/com/opensource/i2pradio/data/radioregistry/RadioRegistryRepository.kt
+++ b/app/src/main/java/com/opensource/i2pradio/data/radioregistry/RadioRegistryRepository.kt
@@ -1,0 +1,364 @@
+package com.opensource.i2pradio.data.radioregistry
+
+import android.content.Context
+import android.util.Log
+import com.opensource.i2pradio.data.RadioDao
+import com.opensource.i2pradio.data.RadioDatabase
+import com.opensource.i2pradio.data.RadioStation
+import com.opensource.i2pradio.data.StationSource
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+/**
+ * Repository for Radio Registry API data with local caching.
+ *
+ * Manages privacy-focused Tor and I2P stations from the Radio Registry API,
+ * with local caching to reduce network requests.
+ */
+class RadioRegistryRepository(private val context: Context) {
+
+    companion object {
+        private const val TAG = "RadioRegistryRepository"
+
+        // Cache validity: 4 hours (matches API health check interval)
+        private const val CACHE_VALIDITY_MS = 4 * 60 * 60 * 1000L
+    }
+
+    private val client = RadioRegistryClient(context)
+    private val dao: RadioDao by lazy {
+        RadioDatabase.getDatabase(context).radioDao()
+    }
+
+    /**
+     * Get Tor stations from API or cache
+     *
+     * @param forceRefresh If true, always fetch from API
+     * @param onlineOnly If true, filter to only online stations
+     */
+    suspend fun getTorStations(
+        forceRefresh: Boolean = false,
+        onlineOnly: Boolean = true,
+        limit: Int = 50
+    ): RadioRegistryResult<List<RadioRegistryStation>> = withContext(Dispatchers.IO) {
+        try {
+            // Try cache first if not forcing refresh
+            if (!forceRefresh) {
+                val cached = getCachedStations("tor")
+                if (cached.isNotEmpty()) {
+                    Log.d(TAG, "Returning ${cached.size} cached Tor stations")
+                    val result = cached.map { it.toRegistryStation() }
+                    return@withContext RadioRegistryResult.Success(
+                        if (onlineOnly) result.filter { it.isOnline } else result
+                    )
+                }
+            }
+
+            // Fetch from API
+            Log.d(TAG, "Fetching Tor stations from API")
+            when (val result = client.getTorStations(limit = limit)) {
+                is RadioRegistryResult.Success -> {
+                    val stations = result.data.stations
+                    Log.d(TAG, "Fetched ${stations.size} Tor stations from API")
+
+                    // Cache the stations
+                    cacheStations(stations)
+
+                    RadioRegistryResult.Success(
+                        if (onlineOnly) stations.filter { it.isOnline } else stations
+                    )
+                }
+                is RadioRegistryResult.Error -> {
+                    // Try to return cached data on error
+                    val cached = getCachedStations("tor")
+                    if (cached.isNotEmpty()) {
+                        Log.d(TAG, "API error, returning ${cached.size} cached Tor stations")
+                        val cachedResult = cached.map { it.toRegistryStation() }
+                        RadioRegistryResult.Success(
+                            if (onlineOnly) cachedResult.filter { it.isOnline } else cachedResult
+                        )
+                    } else {
+                        result
+                    }
+                }
+                is RadioRegistryResult.Loading -> RadioRegistryResult.Loading
+            }
+        } catch (e: Exception) {
+            Log.e(TAG, "Error getting Tor stations: ${e.message}")
+            RadioRegistryResult.Error(e.message ?: "Unknown error", e)
+        }
+    }
+
+    /**
+     * Get I2P stations from API or cache
+     */
+    suspend fun getI2pStations(
+        forceRefresh: Boolean = false,
+        onlineOnly: Boolean = true,
+        limit: Int = 50
+    ): RadioRegistryResult<List<RadioRegistryStation>> = withContext(Dispatchers.IO) {
+        try {
+            // Try cache first if not forcing refresh
+            if (!forceRefresh) {
+                val cached = getCachedStations("i2p")
+                if (cached.isNotEmpty()) {
+                    Log.d(TAG, "Returning ${cached.size} cached I2P stations")
+                    val result = cached.map { it.toRegistryStation() }
+                    return@withContext RadioRegistryResult.Success(
+                        if (onlineOnly) result.filter { it.isOnline } else result
+                    )
+                }
+            }
+
+            // Fetch from API
+            Log.d(TAG, "Fetching I2P stations from API")
+            when (val result = client.getI2pStations(limit = limit)) {
+                is RadioRegistryResult.Success -> {
+                    val stations = result.data.stations
+                    Log.d(TAG, "Fetched ${stations.size} I2P stations from API")
+
+                    // Cache the stations
+                    cacheStations(stations)
+
+                    RadioRegistryResult.Success(
+                        if (onlineOnly) stations.filter { it.isOnline } else stations
+                    )
+                }
+                is RadioRegistryResult.Error -> {
+                    val cached = getCachedStations("i2p")
+                    if (cached.isNotEmpty()) {
+                        Log.d(TAG, "API error, returning ${cached.size} cached I2P stations")
+                        val cachedResult = cached.map { it.toRegistryStation() }
+                        RadioRegistryResult.Success(
+                            if (onlineOnly) cachedResult.filter { it.isOnline } else cachedResult
+                        )
+                    } else {
+                        result
+                    }
+                }
+                is RadioRegistryResult.Loading -> RadioRegistryResult.Loading
+            }
+        } catch (e: Exception) {
+            Log.e(TAG, "Error getting I2P stations: ${e.message}")
+            RadioRegistryResult.Error(e.message ?: "Unknown error", e)
+        }
+    }
+
+    /**
+     * Get all privacy radio stations (both Tor and I2P)
+     */
+    suspend fun getAllPrivacyStations(
+        forceRefresh: Boolean = false,
+        onlineOnly: Boolean = true
+    ): RadioRegistryResult<List<RadioRegistryStation>> = withContext(Dispatchers.IO) {
+        try {
+            // Try cache first
+            if (!forceRefresh) {
+                val cachedTor = getCachedStations("tor")
+                val cachedI2p = getCachedStations("i2p")
+                if (cachedTor.isNotEmpty() || cachedI2p.isNotEmpty()) {
+                    val all = (cachedTor + cachedI2p).map { it.toRegistryStation() }
+                    return@withContext RadioRegistryResult.Success(
+                        if (onlineOnly) all.filter { it.isOnline } else all
+                    )
+                }
+            }
+
+            // Fetch from API
+            when (val result = client.getStations(limit = 200)) {
+                is RadioRegistryResult.Success -> {
+                    val stations = result.data.stations
+                    cacheStations(stations)
+                    RadioRegistryResult.Success(
+                        if (onlineOnly) stations.filter { it.isOnline } else stations
+                    )
+                }
+                is RadioRegistryResult.Error -> {
+                    val cached = (getCachedStations("tor") + getCachedStations("i2p"))
+                        .map { it.toRegistryStation() }
+                    if (cached.isNotEmpty()) {
+                        RadioRegistryResult.Success(
+                            if (onlineOnly) cached.filter { it.isOnline } else cached
+                        )
+                    } else {
+                        result
+                    }
+                }
+                is RadioRegistryResult.Loading -> RadioRegistryResult.Loading
+            }
+        } catch (e: Exception) {
+            RadioRegistryResult.Error(e.message ?: "Unknown error", e)
+        }
+    }
+
+    /**
+     * Get stations by genre
+     */
+    suspend fun getStationsByGenre(
+        genre: String,
+        network: String? = null
+    ): RadioRegistryResult<List<RadioRegistryStation>> = withContext(Dispatchers.IO) {
+        when (val result = client.getStations(network = network, genre = genre, limit = 100)) {
+            is RadioRegistryResult.Success -> {
+                RadioRegistryResult.Success(result.data.stations.filter { it.isOnline })
+            }
+            is RadioRegistryResult.Error -> result
+            is RadioRegistryResult.Loading -> RadioRegistryResult.Loading
+        }
+    }
+
+    /**
+     * Get API statistics
+     */
+    suspend fun getStats(): RadioRegistryResult<StatsResponse> {
+        return client.getStats()
+    }
+
+    /**
+     * Get available genres
+     */
+    suspend fun getGenres(): RadioRegistryResult<List<String>> {
+        return client.getGenres()
+    }
+
+    /**
+     * Check if Force Tor mode is blocking requests
+     */
+    fun isTorRequiredButNotConnected(): Boolean {
+        return client.isTorRequiredButNotConnected()
+    }
+
+    /**
+     * Convert a RadioRegistryStation to a playable RadioStation
+     */
+    fun toPlayableStation(station: RadioRegistryStation): RadioStation {
+        return station.toRadioStation()
+    }
+
+    /**
+     * Save a station to the library (as liked)
+     */
+    suspend fun saveStationToLibrary(station: RadioRegistryStation): Long = withContext(Dispatchers.IO) {
+        val radioStation = station.toRadioStation().copy(
+            isLiked = true,
+            source = StationSource.RADIOBROWSER.name,
+            cachedAt = System.currentTimeMillis()
+        )
+        dao.insertStation(radioStation)
+    }
+
+    /**
+     * Check if a station is saved in the library
+     */
+    suspend fun isStationSaved(stationId: String): Boolean = withContext(Dispatchers.IO) {
+        val uuid = "registry_$stationId"
+        dao.countByRadioBrowserUuid(uuid) > 0
+    }
+
+    /**
+     * Get station info from library by registry ID
+     */
+    suspend fun getStationFromLibrary(stationId: String): RadioStation? = withContext(Dispatchers.IO) {
+        val uuid = "registry_$stationId"
+        dao.getStationByRadioBrowserUuid(uuid)
+    }
+
+    // ==================== Private Helpers ====================
+
+    /**
+     * Cache stations in the local database
+     */
+    private suspend fun cacheStations(stations: List<RadioRegistryStation>) {
+        try {
+            val now = System.currentTimeMillis()
+            val radioStations = stations.map { station ->
+                station.toRadioStation().copy(
+                    cachedAt = now,
+                    isLiked = false,  // Cached stations are not liked by default
+                    source = StationSource.RADIOBROWSER.name
+                )
+            }
+
+            // Insert or update cached stations
+            for (station in radioStations) {
+                // Check if already exists
+                val existing = dao.getStationByRadioBrowserUuid(station.radioBrowserUuid!!)
+                if (existing != null) {
+                    // Update cache timestamp but preserve liked status
+                    dao.updateStation(existing.copy(
+                        cachedAt = now,
+                        // Update metadata from API
+                        name = station.name,
+                        streamUrl = station.streamUrl,
+                        genre = station.genre,
+                        bitrate = station.bitrate,
+                        codec = station.codec,
+                        coverArtUri = station.coverArtUri
+                    ))
+                } else {
+                    dao.insertStation(station)
+                }
+            }
+
+            Log.d(TAG, "Cached ${stations.size} stations")
+        } catch (e: Exception) {
+            Log.e(TAG, "Error caching stations: ${e.message}")
+        }
+    }
+
+    /**
+     * Get cached stations by network type
+     */
+    private suspend fun getCachedStations(network: String): List<RadioStation> {
+        return try {
+            val threshold = System.currentTimeMillis() - CACHE_VALIDITY_MS
+            val allCached = dao.getStationsBySource(StationSource.RADIOBROWSER.name)
+
+            // Filter by network type and cache validity
+            allCached.filter { station ->
+                station.cachedAt > threshold &&
+                station.radioBrowserUuid?.startsWith("registry_") == true &&
+                when (network.lowercase()) {
+                    "tor" -> station.proxyType == "TOR"
+                    "i2p" -> station.proxyType == "I2P"
+                    else -> true
+                }
+            }
+        } catch (e: Exception) {
+            Log.e(TAG, "Error getting cached stations: ${e.message}")
+            emptyList()
+        }
+    }
+
+    /**
+     * Extension to convert RadioStation back to RadioRegistryStation for display
+     */
+    private fun RadioStation.toRegistryStation(): RadioRegistryStation {
+        val registryId = radioBrowserUuid?.removePrefix("registry_") ?: ""
+        return RadioRegistryStation(
+            id = registryId,
+            name = name,
+            streamUrl = streamUrl,
+            homepage = homepage.takeIf { it.isNotEmpty() },
+            faviconUrl = coverArtUri,
+            genre = genre,
+            codec = codec.takeIf { it.isNotEmpty() },
+            bitrate = bitrate.takeIf { it > 0 },
+            language = null,
+            network = when (proxyType) {
+                "TOR" -> "tor"
+                "I2P" -> "i2p"
+                else -> ""
+            },
+            country = country.takeIf { it.isNotEmpty() },
+            countryCode = countryCode.takeIf { it.isNotEmpty() },
+            isOnline = true,  // Assume cached stations are online
+            lastCheckTime = null,
+            status = "approved",
+            checkCount = 0,
+            checkOkCount = 0,
+            submittedAt = null,
+            createdAt = null,
+            updatedAt = null
+        )
+    }
+}

--- a/app/src/main/java/com/opensource/i2pradio/data/radioregistry/RadioRegistryStation.kt
+++ b/app/src/main/java/com/opensource/i2pradio/data/radioregistry/RadioRegistryStation.kt
@@ -1,0 +1,234 @@
+package com.opensource.i2pradio.data.radioregistry
+
+import com.opensource.i2pradio.data.ProxyType
+import com.opensource.i2pradio.data.RadioStation
+import com.opensource.i2pradio.data.StationSource
+import org.json.JSONObject
+
+/**
+ * Data class representing a radio station from the Radio Registry API.
+ * Maps to the JSON response structure from api.deutsia.com
+ *
+ * The Radio Registry API provides privacy-focused Tor and I2P radio stations.
+ */
+data class RadioRegistryStation(
+    val id: String,
+    val name: String,
+    val streamUrl: String,
+    val homepage: String?,
+    val faviconUrl: String?,
+    val genre: String?,
+    val codec: String?,
+    val bitrate: Int?,
+    val language: String?,
+    val network: String,  // "tor" or "i2p"
+    val country: String?,
+    val countryCode: String?,
+    val isOnline: Boolean,
+    val lastCheckTime: String?,
+    val status: String,  // "approved", "pending", "rejected"
+    val checkCount: Int,
+    val checkOkCount: Int,
+    val submittedAt: String?,
+    val createdAt: String?,
+    val updatedAt: String?
+) {
+    companion object {
+        /**
+         * Parse a RadioRegistryStation from a JSONObject
+         */
+        fun fromJson(json: JSONObject): RadioRegistryStation {
+            return RadioRegistryStation(
+                id = json.optString("id", ""),
+                name = json.optString("name", "").trim(),
+                streamUrl = json.optString("streamUrl", ""),
+                homepage = json.optString("homepage", "").takeIf { it.isNotEmpty() },
+                faviconUrl = json.optString("faviconUrl", "").takeIf { it.isNotEmpty() },
+                genre = json.optString("genre", "").takeIf { it.isNotEmpty() },
+                codec = json.optString("codec", "").takeIf { it.isNotEmpty() },
+                bitrate = json.optInt("bitrate", 0).takeIf { it > 0 },
+                language = json.optString("language", "").takeIf { it.isNotEmpty() },
+                network = json.optString("network", ""),
+                country = json.optString("country", "").takeIf { it.isNotEmpty() },
+                countryCode = json.optString("countryCode", "").takeIf { it.isNotEmpty() },
+                isOnline = json.optBoolean("lastCheckOk", false),
+                lastCheckTime = json.optString("lastCheckTime", "").takeIf { it.isNotEmpty() },
+                status = json.optString("status", "approved"),
+                checkCount = json.optInt("checkCount", 0),
+                checkOkCount = json.optInt("checkOkCount", 0),
+                submittedAt = json.optString("submittedAt", "").takeIf { it.isNotEmpty() },
+                createdAt = json.optString("createdAt", "").takeIf { it.isNotEmpty() },
+                updatedAt = json.optString("updatedAt", "").takeIf { it.isNotEmpty() }
+            )
+        }
+    }
+
+    /**
+     * Calculate uptime percentage based on check history
+     */
+    val uptimePercent: Float
+        get() = if (checkCount > 0) {
+            (checkOkCount.toFloat() / checkCount.toFloat()) * 100f
+        } else 0f
+
+    /**
+     * Check if this station uses Tor
+     */
+    val isTorStation: Boolean
+        get() = network.equals("tor", ignoreCase = true) || streamUrl.contains(".onion")
+
+    /**
+     * Check if this station uses I2P
+     */
+    val isI2pStation: Boolean
+        get() = network.equals("i2p", ignoreCase = true) || streamUrl.contains(".i2p")
+
+    /**
+     * Get the appropriate proxy type for this station
+     */
+    fun getProxyType(): ProxyType {
+        return when {
+            isTorStation -> ProxyType.TOR
+            isI2pStation -> ProxyType.I2P
+            else -> ProxyType.NONE
+        }
+    }
+
+    /**
+     * Get a display string for quality info (bitrate + codec)
+     */
+    fun getQualityInfo(): String {
+        val parts = mutableListOf<String>()
+        bitrate?.let { if (it > 0) parts.add("${it}kbps") }
+        codec?.let { if (it.isNotEmpty()) parts.add(it.uppercase()) }
+        return parts.joinToString(" • ")
+    }
+
+    /**
+     * Get the genre string with network indicator suffix
+     */
+    fun getGenreWithNetwork(): String {
+        val genreText = genre ?: "Other"
+        val networkIndicator = if (isTorStation) "Tor" else if (isI2pStation) "I2P" else null
+        return if (networkIndicator != null && genreText.isNotEmpty() && genreText != "Other") {
+            "$genreText · $networkIndicator"
+        } else if (networkIndicator != null) {
+            networkIndicator
+        } else {
+            genreText
+        }
+    }
+
+    /**
+     * Get the primary genre (without network indicator)
+     */
+    fun getPrimaryGenre(): String = genre ?: "Other"
+
+    /**
+     * Get network indicator (Tor or I2P)
+     */
+    fun getNetworkIndicator(): String? {
+        return when {
+            isTorStation -> "Tor"
+            isI2pStation -> "I2P"
+            else -> null
+        }
+    }
+
+    /**
+     * Convert to the app's RadioStation model for playback
+     */
+    fun toRadioStation(): RadioStation {
+        val proxyType = getProxyType()
+        val defaultPort = proxyType.getDefaultPort()
+        val defaultHost = proxyType.getDefaultHost()
+
+        return RadioStation(
+            id = 0,  // Will be assigned by Room if saved
+            name = name,
+            streamUrl = streamUrl,
+            proxyHost = defaultHost,
+            proxyPort = defaultPort,
+            useProxy = proxyType != ProxyType.NONE,
+            proxyType = proxyType.name,
+            genre = getPrimaryGenre(),
+            coverArtUri = faviconUrl,
+            isPreset = false,
+            isLiked = false,
+            source = StationSource.RADIOBROWSER.name,  // Reusing this source type
+            radioBrowserUuid = "registry_$id",  // Prefix to distinguish from RadioBrowser UUIDs
+            bitrate = bitrate ?: 0,
+            codec = codec ?: "",
+            country = country ?: "",
+            countryCode = countryCode ?: "",
+            homepage = homepage ?: ""
+        )
+    }
+}
+
+/**
+ * Response wrapper for station list endpoint
+ */
+data class StationListResponse(
+    val stations: List<RadioRegistryStation>,
+    val total: Int,
+    val online: Int
+) {
+    companion object {
+        fun fromJson(json: JSONObject): StationListResponse {
+            val stationsArray = json.optJSONArray("stations") ?: org.json.JSONArray()
+            val stations = mutableListOf<RadioRegistryStation>()
+
+            for (i in 0 until stationsArray.length()) {
+                try {
+                    val station = RadioRegistryStation.fromJson(stationsArray.getJSONObject(i))
+                    if (station.name.isNotEmpty() && station.streamUrl.isNotEmpty()) {
+                        stations.add(station)
+                    }
+                } catch (e: Exception) {
+                    // Skip malformed entries
+                }
+            }
+
+            return StationListResponse(
+                stations = stations,
+                total = json.optInt("total", stations.size),
+                online = json.optInt("online", stations.count { it.isOnline })
+            )
+        }
+    }
+}
+
+/**
+ * Response wrapper for stats endpoint
+ */
+data class StatsResponse(
+    val totalStations: Int,
+    val onlineStations: Int,
+    val torStations: Int,
+    val i2pStations: Int,
+    val pendingSubmissions: Int,
+    val lastHealthCheck: String?
+) {
+    companion object {
+        fun fromJson(json: JSONObject): StatsResponse {
+            return StatsResponse(
+                totalStations = json.optInt("total_stations", 0),
+                onlineStations = json.optInt("online_stations", 0),
+                torStations = json.optInt("tor_stations", 0),
+                i2pStations = json.optInt("i2p_stations", 0),
+                pendingSubmissions = json.optInt("pending_submissions", 0),
+                lastHealthCheck = json.optString("last_health_check", "").takeIf { it.isNotEmpty() }
+            )
+        }
+    }
+}
+
+/**
+ * Result wrapper for Radio Registry API calls
+ */
+sealed class RadioRegistryResult<out T> {
+    data class Success<T>(val data: T) : RadioRegistryResult<T>()
+    data class Error(val message: String, val exception: Exception? = null) : RadioRegistryResult<Nothing>()
+    data object Loading : RadioRegistryResult<Nothing>()
+}

--- a/app/src/main/java/com/opensource/i2pradio/ui/browse/PrivacyRadioCarouselAdapter.kt
+++ b/app/src/main/java/com/opensource/i2pradio/ui/browse/PrivacyRadioCarouselAdapter.kt
@@ -1,0 +1,141 @@
+package com.opensource.i2pradio.ui.browse
+
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.ImageButton
+import android.widget.ImageView
+import android.widget.TextView
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
+import coil.request.Disposable
+import com.opensource.i2pradio.R
+import com.opensource.i2pradio.data.radioregistry.RadioRegistryStation
+import com.opensource.i2pradio.util.loadSecure
+
+/**
+ * Adapter for horizontal carousel of Privacy Radio stations (Tor/I2P from Radio Registry API).
+ */
+class PrivacyRadioCarouselAdapter(
+    private val onStationClick: (RadioRegistryStation) -> Unit,
+    private val onLikeClick: (RadioRegistryStation) -> Unit,
+    private val showRankBadge: Boolean = false
+) : ListAdapter<RadioRegistryStation, PrivacyRadioCarouselAdapter.ViewHolder>(DiffCallback()) {
+
+    private var likedUuids: Set<String> = emptySet()
+
+    fun updateLikedUuids(uuids: Set<String>) {
+        val oldLikedUuids = likedUuids
+        likedUuids = uuids
+
+        currentList.forEachIndexed { index, station ->
+            val uuid = "registry_${station.id}"
+            val wasLiked = oldLikedUuids.contains(uuid)
+            val isLiked = uuids.contains(uuid)
+            if (wasLiked != isLiked) {
+                notifyItemChanged(index, PAYLOAD_LIKED_STATUS)
+            }
+        }
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
+        val view = LayoutInflater.from(parent.context)
+            .inflate(R.layout.item_browse_station_card, parent, false)
+        return ViewHolder(view)
+    }
+
+    override fun onBindViewHolder(holder: ViewHolder, position: Int) {
+        holder.bind(getItem(position), position + 1)
+    }
+
+    override fun onBindViewHolder(holder: ViewHolder, position: Int, payloads: MutableList<Any>) {
+        if (payloads.isEmpty()) {
+            super.onBindViewHolder(holder, position, payloads)
+            return
+        }
+        val station = getItem(position)
+        if (payloads.contains(PAYLOAD_LIKED_STATUS)) {
+            val uuid = "registry_${station.id}"
+            holder.updateLikedStatus(likedUuids.contains(uuid))
+        }
+    }
+
+    inner class ViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
+        private val stationImage: ImageView = itemView.findViewById(R.id.stationImage)
+        private val stationName: TextView = itemView.findViewById(R.id.stationName)
+        private val stationInfo: TextView = itemView.findViewById(R.id.stationInfo)
+        private val rankBadge: TextView = itemView.findViewById(R.id.rankBadge)
+        private val btnLike: ImageButton = itemView.findViewById(R.id.btnLike)
+        private var imageLoadDisposable: Disposable? = null
+
+        fun bind(station: RadioRegistryStation, rank: Int) {
+            stationName.text = station.name
+            stationInfo.text = buildString {
+                val genreWithNetwork = station.getGenreWithNetwork()
+                if (genreWithNetwork.isNotEmpty() && genreWithNetwork != "Other") {
+                    append(genreWithNetwork)
+                }
+                val qualityInfo = station.getQualityInfo()
+                if (qualityInfo.isNotEmpty()) {
+                    if (isNotEmpty()) append(" • ")
+                    append(qualityInfo)
+                }
+            }.ifEmpty { station.getNetworkIndicator() ?: "Privacy Radio" }
+
+            // Load station image using secure loader
+            imageLoadDisposable?.dispose()
+            stationImage.setImageResource(R.drawable.ic_radio)
+            if (!station.faviconUrl.isNullOrEmpty()) {
+                imageLoadDisposable = stationImage.loadSecure(station.faviconUrl) {
+                    crossfade(true)
+                    placeholder(R.drawable.ic_radio)
+                    error(R.drawable.ic_radio)
+                }
+            }
+
+            // Rank badge
+            if (showRankBadge) {
+                rankBadge.visibility = View.VISIBLE
+                rankBadge.text = rank.toString()
+            } else {
+                rankBadge.visibility = View.GONE
+            }
+
+            // Like state
+            val uuid = "registry_${station.id}"
+            updateLikedStatus(likedUuids.contains(uuid))
+
+            // Online indicator - change image tint if offline
+            if (!station.isOnline) {
+                stationImage.alpha = 0.5f
+            } else {
+                stationImage.alpha = 1.0f
+            }
+
+            // Click listeners
+            itemView.setOnClickListener { onStationClick(station) }
+            btnLike.setOnClickListener { onLikeClick(station) }
+        }
+
+        fun updateLikedStatus(isLiked: Boolean) {
+            btnLike.setImageResource(
+                if (isLiked) R.drawable.ic_favorite else R.drawable.ic_favorite_border
+            )
+        }
+    }
+
+    private class DiffCallback : DiffUtil.ItemCallback<RadioRegistryStation>() {
+        override fun areItemsTheSame(oldItem: RadioRegistryStation, newItem: RadioRegistryStation): Boolean {
+            return oldItem.id == newItem.id
+        }
+
+        override fun areContentsTheSame(oldItem: RadioRegistryStation, newItem: RadioRegistryStation): Boolean {
+            return oldItem == newItem
+        }
+    }
+
+    companion object {
+        private const val PAYLOAD_LIKED_STATUS = "liked_status"
+    }
+}

--- a/app/src/main/res/drawable/ic_i2p.xml
+++ b/app/src/main/res/drawable/ic_i2p.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <!-- Network/Cloud icon representing I2P -->
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M12,1L3,5v6c0,5.55 3.84,10.74 9,12 5.16,-1.26 9,-6.45 9,-12V5l-9,-4zM12,11.99h7c-0.53,4.12 -3.28,7.79 -7,8.94V12H5V6.3l7,-3.11v8.8z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_tor.xml
+++ b/app/src/main/res/drawable/ic_tor.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <!-- Onion/Shield icon representing Tor -->
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M12,1L3,5v6c0,5.55 3.84,10.74 9,12 5.16,-1.26 9,-6.45 9,-12V5L12,1zM12,11.99h7c-0.53,4.12 -3.28,7.79 -7,8.94V12H5V6.3l7,-3.11v8.8z"/>
+</vector>

--- a/app/src/main/res/layout/fragment_browse_stations.xml
+++ b/app/src/main/res/layout/fragment_browse_stations.xml
@@ -279,6 +279,130 @@
                 android:orientation="horizontal"
                 app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager" />
 
+            <!-- ==================== PRIVACY RADIO SECTION ==================== -->
+
+            <!-- Privacy Radio Header -->
+            <LinearLayout
+                android:id="@+id/privacyRadioSection"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="28dp"
+                android:orientation="vertical">
+
+                <TextView
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:paddingHorizontal="20dp"
+                    android:text="@string/browse_privacy_radio"
+                    android:textColor="?attr/colorOnSurface"
+                    android:textSize="18sp"
+                    android:textStyle="bold" />
+
+                <TextView
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:paddingHorizontal="20dp"
+                    android:layout_marginTop="4dp"
+                    android:text="@string/browse_privacy_radio_subtitle"
+                    android:textColor="?attr/colorOnSurfaceVariant"
+                    android:textSize="13sp" />
+
+            </LinearLayout>
+
+            <!-- Tor Stations Section -->
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="20dp"
+                android:gravity="center_vertical"
+                android:orientation="horizontal"
+                android:paddingHorizontal="20dp">
+
+                <ImageView
+                    android:layout_width="20dp"
+                    android:layout_height="20dp"
+                    android:src="@drawable/ic_tor"
+                    app:tint="?attr/colorPrimary" />
+
+                <TextView
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:layout_marginStart="8dp"
+                    android:text="@string/browse_tor_stations"
+                    android:textColor="?attr/colorOnSurface"
+                    android:textSize="16sp"
+                    android:textStyle="bold" />
+
+                <TextView
+                    android:id="@+id/torStationsSeeAll"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/see_all"
+                    android:textColor="?attr/colorPrimary"
+                    android:textSize="14sp"
+                    android:textStyle="bold" />
+            </LinearLayout>
+
+            <!-- Tor Stations Carousel -->
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/torStationsRecyclerView"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="14dp"
+                android:clipToPadding="false"
+                android:paddingHorizontal="16dp"
+                android:orientation="horizontal"
+                app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager" />
+
+            <!-- I2P Stations Section -->
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="20dp"
+                android:gravity="center_vertical"
+                android:orientation="horizontal"
+                android:paddingHorizontal="20dp">
+
+                <ImageView
+                    android:layout_width="20dp"
+                    android:layout_height="20dp"
+                    android:src="@drawable/ic_i2p"
+                    app:tint="?attr/colorPrimary" />
+
+                <TextView
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:layout_marginStart="8dp"
+                    android:text="@string/browse_i2p_stations"
+                    android:textColor="?attr/colorOnSurface"
+                    android:textSize="16sp"
+                    android:textStyle="bold" />
+
+                <TextView
+                    android:id="@+id/i2pStationsSeeAll"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/see_all"
+                    android:textColor="?attr/colorPrimary"
+                    android:textSize="14sp"
+                    android:textStyle="bold" />
+            </LinearLayout>
+
+            <!-- I2P Stations Carousel -->
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/i2pStationsRecyclerView"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="14dp"
+                android:clipToPadding="false"
+                android:paddingHorizontal="16dp"
+                android:orientation="horizontal"
+                app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager" />
+
+            <!-- ==================== END PRIVACY RADIO SECTION ==================== -->
+
             <!-- Trending Now Section -->
             <LinearLayout
                 android:layout_width="match_parent"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -105,6 +105,10 @@
     <string name="browse_popular_germany">Popular in Germany</string>
     <string name="browse_spanish_radio">Spanish Radio</string>
     <string name="browse_french_radio">French Radio</string>
+    <string name="browse_privacy_radio">Privacy Radio</string>
+    <string name="browse_privacy_radio_subtitle">Anonymous radio stations via Tor and I2P</string>
+    <string name="browse_tor_stations">Tor Stations</string>
+    <string name="browse_i2p_stations">I2P Stations</string>
     <string name="see_all">See All</string>
     <string name="add_filter">Filter</string>
     <string name="browse_results_count">Loading…</string>


### PR DESCRIPTION
Integrate the Radio Registry API (api.deutsia.com) to fetch privacy-focused radio stations dynamically. This replaces the static curated lists with live data from the API, with automatic caching and fallback to curated stations when the API is unavailable.

Changes:
- Add RadioRegistryStation data model matching API response structure
- Add RadioRegistryClient for API communication with proxy support
- Add RadioRegistryRepository for data management and caching
- Add PrivacyRadioCarouselAdapter for displaying API stations
- Add "Privacy Radio" section to Browse screen with Tor/I2P carousels
- Support clearnet, Tor (.onion), and I2P endpoints
- Respect Force Tor and Force Custom Proxy settings
- Cache stations locally for 4 hours (matches API health check interval)