### PR TITLE
Migrate offline import to use dynamic API with fallback

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -261,9 +261,9 @@
     <string name="settings_import_from_file">Import from File</string>
     <string name="settings_import_from_file_description">Import from CSV, JSON, M3U, or PLS</string>
     <string name="settings_add_i2p_stations">Add I2P Stations</string>
-    <string name="settings_add_i2p_stations_description">%d bundled I2P stations (offline, no network)</string>
+    <string name="settings_add_i2p_stations_description">%d I2P stations from Radio Registry</string>
     <string name="settings_add_tor_stations">Add Tor Stations</string>
-    <string name="settings_add_tor_stations_description">%d bundled Tor stations (offline, no network)</string>
+    <string name="settings_add_tor_stations_description">%d Tor stations from Radio Registry</string>
     <string name="settings_export_stations">Export Stations</string>
     <string name="settings_export_stations_description">Export your stations to a file</string>
 
@@ -536,7 +536,7 @@
     <string name="import_message">Select a file to import radio stations from.\n\nSupported formats:\n• CSV\n• JSON\n• M3U playlist\n• PLS playlist</string>
     <string name="button_select_file">Select File</string>
     <string name="import_curated_title">Add %s Stations</string>
-    <string name="import_curated_message">Add %1$d bundled %2$s radio stations?\n\nThese stations are pre-configured with proxy settings and ready to use. This is an offline operation.</string>
+    <string name="import_curated_message">Add %1$d %2$s radio stations from the Radio Registry?\n\nThese stations are pre-configured with proxy settings and ready to use.</string>
     <string name="no_stations_found_in_list">No stations found in %s list</string>
     <string name="failed_to_import_stations">Failed to add %1$s stations: %2$s</string>
     <string name="dialog_export_stations_title">Export Stations</string>


### PR DESCRIPTION
Update the curated station import (I2P/Tor) in Settings to fetch from
the Radio Registry API first, falling back to bundled JSON files if
the API request fails. This ensures users get the latest stations when
online while maintaining offline functionality.

Changes:
- Add RadioRegistryRepository to SettingsFragment
- Update showImportCuratedListDialog to fetch count from API first
- Update importCuratedList to import stations from API with fallback