### PR TITLE
Fix carousel display bugs in privacy stations

### DIFF
--- a/app/src/main/java/com/opensource/i2pradio/data/radioregistry/RadioRegistryRepository.kt
+++ b/app/src/main/java/com/opensource/i2pradio/data/radioregistry/RadioRegistryRepository.kt
@@ -351,7 +351,7 @@ class RadioRegistryRepository(private val context: Context) {
             },
             country = country.takeIf { it.isNotEmpty() },
             countryCode = countryCode.takeIf { it.isNotEmpty() },
-            isOnline = true,  // Assume cached stations are online
+            isOnline = true,  // Note: Online status not stored in cache, use fresh API data for accurate status
             lastCheckTime = null,
             status = "approved",
             checkCount = 0,

--- a/app/src/main/java/com/opensource/i2pradio/ui/browse/BrowseViewModel.kt
+++ b/app/src/main/java/com/opensource/i2pradio/ui/browse/BrowseViewModel.kt
@@ -230,8 +230,8 @@ class BrowseViewModel(application: Application) : AndroidViewModel(application) 
 
         viewModelScope.launch {
             try {
-                // Load Tor stations from API
-                when (val result = registryRepository.getTorStations(forceRefresh = forceRefresh, limit = 20)) {
+                // Load Tor stations from API - always force refresh to get accurate online status
+                when (val result = registryRepository.getTorStations(forceRefresh = true, limit = 20)) {
                     is RadioRegistryResult.Success -> {
                         _privacyTorStations.value = result.data.take(10)
                     }
@@ -241,8 +241,8 @@ class BrowseViewModel(application: Application) : AndroidViewModel(application) 
                     is RadioRegistryResult.Loading -> {}
                 }
 
-                // Load I2P stations from API
-                when (val result = registryRepository.getI2pStations(forceRefresh = forceRefresh, limit = 20)) {
+                // Load I2P stations from API - always force refresh to get accurate online status
+                when (val result = registryRepository.getI2pStations(forceRefresh = true, limit = 20)) {
                     is RadioRegistryResult.Success -> {
                         _privacyI2pStations.value = result.data.take(10)
                     }

--- a/app/src/main/res/layout/item_browse_station_card.xml
+++ b/app/src/main/res/layout/item_browse_station_card.xml
@@ -29,7 +29,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 android:background="?attr/colorSurfaceContainerHighest"
-                android:scaleType="centerCrop"
+                android:scaleType="fitCenter"
                 app:shapeAppearanceOverlay="@style/ShapeAppearance.Material3.Corner.Medium" />
 
             <!-- Rank badge (optional, for trending) -->


### PR DESCRIPTION
Fixes two bugs in the privacy stations carousel:

1. Small radio icon display:
   - Changed scaleType from centerCrop to fitCenter in item_browse_station_card.xml
   - centerCrop doesn't scale up small vector drawables (24dp) to fill large ImageViews (150x130dp)
   - fitCenter properly scales placeholder icons when favicons are missing or fail to load

2. Offline Tor stations showing as online:
   - Force fresh API data for privacy station carousels (BrowseViewModel.kt)
   - Previously used cached data where isOnline was always hardcoded to true
   - Now always fetches from API to get accurate real-time online status
   - Updated comment in RadioRegistryRepository.kt to clarify cache limitation