### PR TITLE
Route privacy station cover art through Tor when available

### DIFF
--- a/app/src/main/java/com/opensource/i2pradio/ui/LibraryFragment.kt
+++ b/app/src/main/java/com/opensource/i2pradio/ui/LibraryFragment.kt
@@ -34,6 +34,7 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import coil.request.Disposable
 import com.opensource.i2pradio.util.loadSecure
+import com.opensource.i2pradio.util.loadSecurePrivacy
 import com.google.android.material.button.MaterialButton
 import com.google.android.material.floatingactionbutton.FloatingActionButton
 import com.google.android.material.textfield.TextInputEditText
@@ -932,11 +933,20 @@ class RadioStationAdapter(
             coverArt.setImageResource(R.drawable.ic_radio)
 
             // Use loadSecure to route remote URLs through Tor when Force Tor is enabled
+            // For privacy stations (Tor/I2P), use loadSecurePrivacy to route through Tor when available
             if (station.coverArtUri != null) {
-                imageLoadDisposable = coverArt.loadSecure(station.coverArtUri) {
+                val isPrivacyStation = station.getProxyTypeEnum().let {
+                    it == ProxyType.TOR || it == ProxyType.I2P
+                }
+                val imageLoadBuilder: coil.request.ImageRequest.Builder.() -> Unit = {
                     crossfade(true)
                     placeholder(R.drawable.ic_radio)
                     error(R.drawable.ic_radio)
+                }
+                imageLoadDisposable = if (isPrivacyStation) {
+                    coverArt.loadSecurePrivacy(station.coverArtUri, imageLoadBuilder)
+                } else {
+                    coverArt.loadSecure(station.coverArtUri, imageLoadBuilder)
                 }
             }
 

--- a/app/src/main/java/com/opensource/i2pradio/ui/browse/PrivacyRadioCarouselAdapter.kt
+++ b/app/src/main/java/com/opensource/i2pradio/ui/browse/PrivacyRadioCarouselAdapter.kt
@@ -16,7 +16,7 @@ import androidx.recyclerview.widget.RecyclerView
 import coil.request.Disposable
 import com.opensource.i2pradio.R
 import com.opensource.i2pradio.data.radioregistry.RadioRegistryStation
-import com.opensource.i2pradio.util.loadSecure
+import com.opensource.i2pradio.util.loadSecurePrivacy
 
 /**
  * Adapter for horizontal carousel of Privacy Radio stations (Tor/I2P from Radio Registry API).
@@ -99,7 +99,7 @@ class PrivacyRadioCarouselAdapter(
             imageLoadDisposable?.dispose()
             stationImage.setImageResource(R.drawable.ic_radio)
             if (!station.faviconUrl.isNullOrEmpty()) {
-                imageLoadDisposable = stationImage.loadSecure(station.faviconUrl) {
+                imageLoadDisposable = stationImage.loadSecurePrivacy(station.faviconUrl) {
                     crossfade(true)
                     placeholder(R.drawable.ic_radio)
                     error(R.drawable.ic_radio)


### PR DESCRIPTION
Add loadSecurePrivacy() extension for privacy stations that routes cover art through Tor when connected, even without Force Tor mode. This allows Tor/I2P station cover art to load over Tor for privacy while keeping clearnet station images on direct connection.

- Add getPrivacyImageLoader() and getPrivacyProxyConfig() methods
- Update PrivacyRadioCarouselAdapter to use loadSecurePrivacy()
- Update LibraryFragment, MiniPlayerView, NowPlayingFragment to detect privacy stations and use appropriate loader