### PR TITLE
Update playback translations for dynamic API

### DIFF
--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -254,9 +254,11 @@
     <string name="settings_import_from_file">استيراد من ملف</string>
     <string name="settings_import_from_file_description">الاستيراد من CSV أو JSON أو M3U أو PLS</string>
     <string name="settings_add_i2p_stations">إضافة محطات I2P</string>
-    <string name="settings_add_i2p_stations_description">%d محطة I2P مدمجة (بدون اتصال، بدون شبكة)</string>
+    <string name="settings_add_i2p_stations_description">%d محطة I2P متاحة</string>
+    <string name="settings_add_i2p_stations_description_generic">إضافة محطات راديو I2P منتقاة</string>
     <string name="settings_add_tor_stations">إضافة محطات Tor</string>
-    <string name="settings_add_tor_stations_description">%d محطة Tor مدمجة (بدون اتصال، بدون شبكة)</string>
+    <string name="settings_add_tor_stations_description">%d محطة Tor متاحة</string>
+    <string name="settings_add_tor_stations_description_generic">إضافة محطات راديو Tor منتقاة</string>
     <string name="settings_export_stations">تصدير المحطات</string>
     <string name="settings_export_stations_description">تصدير محطاتك إلى ملف</string>
 

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -254,9 +254,11 @@
     <string name="settings_import_from_file">Aus Datei importieren</string>
     <string name="settings_import_from_file_description">Aus CSV, JSON, M3U oder PLS importieren</string>
     <string name="settings_add_i2p_stations">I2P-Sender hinzufügen</string>
-    <string name="settings_add_i2p_stations_description">%d mitgelieferte I2P-Sender (offline, kein Netzwerk)</string>
+    <string name="settings_add_i2p_stations_description">%d I2P-Sender verfügbar</string>
+    <string name="settings_add_i2p_stations_description_generic">Ausgewählte I2P-Radiosender hinzufügen</string>
     <string name="settings_add_tor_stations">Tor-Sender hinzufügen</string>
-    <string name="settings_add_tor_stations_description">%d mitgelieferte Tor-Sender (offline, kein Netzwerk)</string>
+    <string name="settings_add_tor_stations_description">%d Tor-Sender verfügbar</string>
+    <string name="settings_add_tor_stations_description_generic">Ausgewählte Tor-Radiosender hinzufügen</string>
     <string name="settings_export_stations">Sender exportieren</string>
     <string name="settings_export_stations_description">Ihre Sender in eine Datei exportieren</string>
 

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -258,9 +258,11 @@
     <string name="settings_import_from_file">Importar desde archivo</string>
     <string name="settings_import_from_file_description">Importar desde CSV, JSON, M3U o PLS</string>
     <string name="settings_add_i2p_stations">Agregar estaciones I2P</string>
-    <string name="settings_add_i2p_stations_description">%d estaciones I2P incluidas (sin conexión, sin red)</string>
+    <string name="settings_add_i2p_stations_description">%d estaciones I2P disponibles</string>
+    <string name="settings_add_i2p_stations_description_generic">Agregar estaciones de radio I2P seleccionadas</string>
     <string name="settings_add_tor_stations">Agregar estaciones Tor</string>
-    <string name="settings_add_tor_stations_description">%d estaciones Tor incluidas (sin conexión, sin red)</string>
+    <string name="settings_add_tor_stations_description">%d estaciones Tor disponibles</string>
+    <string name="settings_add_tor_stations_description_generic">Agregar estaciones de radio Tor seleccionadas</string>
     <string name="settings_export_stations">Exportar estaciones</string>
     <string name="settings_export_stations_description">Exportar tus estaciones a un archivo</string>
 

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -254,9 +254,11 @@
     <string name="settings_import_from_file">وارد کردن از فایل</string>
     <string name="settings_import_from_file_description">وارد کردن از CSV، JSON، M3U یا PLS</string>
     <string name="settings_add_i2p_stations">افزودن ایستگاه‌های I2P</string>
-    <string name="settings_add_i2p_stations_description">%d ایستگاه I2P داخلی (آفلاین، بدون شبکه)</string>
+    <string name="settings_add_i2p_stations_description">%d ایستگاه I2P موجود</string>
+    <string name="settings_add_i2p_stations_description_generic">افزودن ایستگاه‌های رادیویی I2P منتخب</string>
     <string name="settings_add_tor_stations">افزودن ایستگاه‌های Tor</string>
-    <string name="settings_add_tor_stations_description">%d ایستگاه Tor داخلی (آفلاین، بدون شبکه)</string>
+    <string name="settings_add_tor_stations_description">%d ایستگاه Tor موجود</string>
+    <string name="settings_add_tor_stations_description_generic">افزودن ایستگاه‌های رادیویی Tor منتخب</string>
     <string name="settings_export_stations">خروجی ایستگاه‌ها</string>
     <string name="settings_export_stations_description">خروجی گرفتن ایستگاه‌های خود به فایل</string>
 

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -261,9 +261,11 @@
     <string name="settings_import_from_file">Importer depuis un fichier</string>
     <string name="settings_import_from_file_description">Importer depuis CSV, JSON, M3U ou PLS</string>
     <string name="settings_add_i2p_stations">Ajouter des stations I2P</string>
-    <string name="settings_add_i2p_stations_description">%d stations I2P incluses (hors ligne, pas de réseau)</string>
+    <string name="settings_add_i2p_stations_description">%d stations I2P disponibles</string>
+    <string name="settings_add_i2p_stations_description_generic">Ajouter des stations radio I2P sélectionnées</string>
     <string name="settings_add_tor_stations">Ajouter des stations Tor</string>
-    <string name="settings_add_tor_stations_description">%d stations Tor incluses (hors ligne, pas de réseau)</string>
+    <string name="settings_add_tor_stations_description">%d stations Tor disponibles</string>
+    <string name="settings_add_tor_stations_description_generic">Ajouter des stations radio Tor sélectionnées</string>
     <string name="settings_export_stations">Exporter les stations</string>
     <string name="settings_export_stations_description">Exporter vos stations vers un fichier</string>
 

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -251,9 +251,11 @@
     <string name="settings_import_from_file">फ़ाइल से आयात करें</string>
     <string name="settings_import_from_file_description">CSV, JSON, M3U या PLS से आयात करें</string>
     <string name="settings_add_i2p_stations">I2P स्टेशन जोड़ें</string>
-    <string name="settings_add_i2p_stations_description">%d अंतर्निहित I2P स्टेशन (ऑफ़लाइन, नेटवर्क नहीं)</string>
+    <string name="settings_add_i2p_stations_description">%d I2P स्टेशन उपलब्ध</string>
+    <string name="settings_add_i2p_stations_description_generic">चयनित I2P रेडियो स्टेशन जोड़ें</string>
     <string name="settings_add_tor_stations">Tor स्टेशन जोड़ें</string>
-    <string name="settings_add_tor_stations_description">%d अंतर्निहित Tor स्टेशन (ऑफ़लाइन, नेटवर्क नहीं)</string>
+    <string name="settings_add_tor_stations_description">%d Tor स्टेशन उपलब्ध</string>
+    <string name="settings_add_tor_stations_description_generic">चयनित Tor रेडियो स्टेशन जोड़ें</string>
     <string name="settings_export_stations">स्टेशन निर्यात करें</string>
     <string name="settings_export_stations_description">अपने स्टेशनों को फ़ाइल में निर्यात करें</string>
 

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -261,9 +261,11 @@
     <string name="settings_import_from_file">Importa da file</string>
     <string name="settings_import_from_file_description">Importa da CSV, JSON, M3U o PLS</string>
     <string name="settings_add_i2p_stations">Aggiungi stazioni I2P</string>
-    <string name="settings_add_i2p_stations_description">%d stazioni I2P incluse (offline, nessuna rete)</string>
+    <string name="settings_add_i2p_stations_description">%d stazioni I2P disponibili</string>
+    <string name="settings_add_i2p_stations_description_generic">Aggiungi stazioni radio I2P selezionate</string>
     <string name="settings_add_tor_stations">Aggiungi stazioni Tor</string>
-    <string name="settings_add_tor_stations_description">%d stazioni Tor incluse (offline, nessuna rete)</string>
+    <string name="settings_add_tor_stations_description">%d stazioni Tor disponibili</string>
+    <string name="settings_add_tor_stations_description_generic">Aggiungi stazioni radio Tor selezionate</string>
     <string name="settings_export_stations">Esporta stazioni</string>
     <string name="settings_export_stations_description">Esporta le tue stazioni in un file</string>
 

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -254,9 +254,11 @@
     <string name="settings_import_from_file">ファイルからインポート</string>
     <string name="settings_import_from_file_description">CSV、JSON、M3U、またはPLSからインポート</string>
     <string name="settings_add_i2p_stations">I2Pステーションを追加</string>
-    <string name="settings_add_i2p_stations_description">%d個の同梱I2Pステーション（オフライン、ネットワーク不要）</string>
+    <string name="settings_add_i2p_stations_description">%d個のI2Pステーションが利用可能</string>
+    <string name="settings_add_i2p_stations_description_generic">厳選されたI2Pラジオステーションを追加</string>
     <string name="settings_add_tor_stations">Torステーションを追加</string>
-    <string name="settings_add_tor_stations_description">%d個の同梱Torステーション（オフライン、ネットワーク不要）</string>
+    <string name="settings_add_tor_stations_description">%d個のTorステーションが利用可能</string>
+    <string name="settings_add_tor_stations_description_generic">厳選されたTorラジオステーションを追加</string>
     <string name="settings_export_stations">ステーションをエクスポート</string>
     <string name="settings_export_stations_description">ステーションをファイルにエクスポート</string>
 

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -254,9 +254,11 @@
     <string name="settings_import_from_file">파일에서 가져오기</string>
     <string name="settings_import_from_file_description">CSV, JSON, M3U 또는 PLS에서 가져오기</string>
     <string name="settings_add_i2p_stations">I2P 방송국 추가</string>
-    <string name="settings_add_i2p_stations_description">%d개 포함된 I2P 방송국 (오프라인, 네트워크 불필요)</string>
+    <string name="settings_add_i2p_stations_description">%d개 I2P 방송국 이용 가능</string>
+    <string name="settings_add_i2p_stations_description_generic">선별된 I2P 라디오 방송국 추가</string>
     <string name="settings_add_tor_stations">Tor 방송국 추가</string>
-    <string name="settings_add_tor_stations_description">%d개 포함된 Tor 방송국 (오프라인, 네트워크 불필요)</string>
+    <string name="settings_add_tor_stations_description">%d개 Tor 방송국 이용 가능</string>
+    <string name="settings_add_tor_stations_description_generic">선별된 Tor 라디오 방송국 추가</string>
     <string name="settings_export_stations">방송국 내보내기</string>
     <string name="settings_export_stations_description">방송국을 파일로 내보내기</string>
 

--- a/app/src/main/res/values-my/strings.xml
+++ b/app/src/main/res/values-my/strings.xml
@@ -251,9 +251,11 @@
     <string name="settings_import_from_file">ဖိုင်မှ တင်သွင်းရန်</string>
     <string name="settings_import_from_file_description">CSV၊ JSON၊ M3U သို့မဟုတ် PLS မှ တင်သွင်းပါ</string>
     <string name="settings_add_i2p_stations">I2P စတေးရှင်းများ ထည့်ရန်</string>
-    <string name="settings_add_i2p_stations_description">%d ပါဝင်သော I2P စတေးရှင်း (အော့ဖ်လိုင်း၊ ကွန်ရက်မလို)</string>
+    <string name="settings_add_i2p_stations_description">%d I2P စတေးရှင်း ရရှိနိုင်</string>
+    <string name="settings_add_i2p_stations_description_generic">ရွေးချယ်ထားသော I2P ရေဒီယိုစတေးရှင်းများ ထည့်ရန်</string>
     <string name="settings_add_tor_stations">Tor စတေးရှင်းများ ထည့်ရန်</string>
-    <string name="settings_add_tor_stations_description">%d ပါဝင်သော Tor စတေးရှင်း (အော့ဖ်လိုင်း၊ ကွန်ရက်မလို)</string>
+    <string name="settings_add_tor_stations_description">%d Tor စတေးရှင်း ရရှိနိုင်</string>
+    <string name="settings_add_tor_stations_description_generic">ရွေးချယ်ထားသော Tor ရေဒီယိုစတေးရှင်းများ ထည့်ရန်</string>
     <string name="settings_export_stations">စတေးရှင်းများကို ထုတ်ယူရန်</string>
     <string name="settings_export_stations_description">သင့်စတေးရှင်းများကို ဖိုင်သို့ ထုတ်ယူပါ</string>
 

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -254,9 +254,11 @@
     <string name="settings_import_from_file">Importar de arquivo</string>
     <string name="settings_import_from_file_description">Importar de CSV, JSON, M3U ou PLS</string>
     <string name="settings_add_i2p_stations">Adicionar estações I2P</string>
-    <string name="settings_add_i2p_stations_description">%d estações I2P incluídas (offline, sem rede)</string>
+    <string name="settings_add_i2p_stations_description">%d estações I2P disponíveis</string>
+    <string name="settings_add_i2p_stations_description_generic">Adicionar estações de rádio I2P selecionadas</string>
     <string name="settings_add_tor_stations">Adicionar estações Tor</string>
-    <string name="settings_add_tor_stations_description">%d estações Tor incluídas (offline, sem rede)</string>
+    <string name="settings_add_tor_stations_description">%d estações Tor disponíveis</string>
+    <string name="settings_add_tor_stations_description_generic">Adicionar estações de rádio Tor selecionadas</string>
     <string name="settings_export_stations">Exportar estações</string>
     <string name="settings_export_stations_description">Exportar suas estações para um arquivo</string>
 

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -254,9 +254,11 @@
     <string name="settings_import_from_file">Импорт из файла</string>
     <string name="settings_import_from_file_description">Импорт из CSV, JSON, M3U или PLS</string>
     <string name="settings_add_i2p_stations">Добавить I2P станции</string>
-    <string name="settings_add_i2p_stations_description">%d встроенных I2P станций (офлайн, без сети)</string>
+    <string name="settings_add_i2p_stations_description">%d I2P станций доступно</string>
+    <string name="settings_add_i2p_stations_description_generic">Добавить отобранные I2P радиостанции</string>
     <string name="settings_add_tor_stations">Добавить Tor станции</string>
-    <string name="settings_add_tor_stations_description">%d встроенных Tor станций (офлайн, без сети)</string>
+    <string name="settings_add_tor_stations_description">%d Tor станций доступно</string>
+    <string name="settings_add_tor_stations_description_generic">Добавить отобранные Tor радиостанции</string>
     <string name="settings_export_stations">Экспорт станций</string>
     <string name="settings_export_stations_description">Экспортировать ваши станции в файл</string>
 

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -254,9 +254,11 @@
     <string name="settings_import_from_file">Dosyadan İçe Aktar</string>
     <string name="settings_import_from_file_description">CSV, JSON, M3U veya PLS\'den içe aktar</string>
     <string name="settings_add_i2p_stations">I2P İstasyonlarını Ekle</string>
-    <string name="settings_add_i2p_stations_description">%d yerleşik I2P istasyonu (çevrimdışı, ağ gerektirmez)</string>
+    <string name="settings_add_i2p_stations_description">%d I2P istasyonu mevcut</string>
+    <string name="settings_add_i2p_stations_description_generic">Seçilmiş I2P radyo istasyonları ekle</string>
     <string name="settings_add_tor_stations">Tor İstasyonlarını Ekle</string>
-    <string name="settings_add_tor_stations_description">%d yerleşik Tor istasyonu (çevrimdışı, ağ gerektirmez)</string>
+    <string name="settings_add_tor_stations_description">%d Tor istasyonu mevcut</string>
+    <string name="settings_add_tor_stations_description_generic">Seçilmiş Tor radyo istasyonları ekle</string>
     <string name="settings_export_stations">İstasyonları Dışa Aktar</string>
     <string name="settings_export_stations_description">İstasyonlarınızı bir dosyaya aktar</string>
 

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -254,9 +254,11 @@
     <string name="settings_import_from_file">Імпорт з файлу</string>
     <string name="settings_import_from_file_description">Імпорт з CSV, JSON, M3U або PLS</string>
     <string name="settings_add_i2p_stations">Додати I2P станції</string>
-    <string name="settings_add_i2p_stations_description">%d вбудованих I2P станцій (офлайн, без мережі)</string>
+    <string name="settings_add_i2p_stations_description">%d I2P станцій доступно</string>
+    <string name="settings_add_i2p_stations_description_generic">Додати відібрані I2P радіостанції</string>
     <string name="settings_add_tor_stations">Додати Tor станції</string>
-    <string name="settings_add_tor_stations_description">%d вбудованих Tor станцій (офлайн, без мережі)</string>
+    <string name="settings_add_tor_stations_description">%d Tor станцій доступно</string>
+    <string name="settings_add_tor_stations_description_generic">Додати відібрані Tor радіостанції</string>
     <string name="settings_export_stations">Експорт станцій</string>
     <string name="settings_export_stations_description">Експортувати ваші станції у файл</string>
 

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -254,9 +254,11 @@
     <string name="settings_import_from_file">Nhập từ tệp</string>
     <string name="settings_import_from_file_description">Nhập từ CSV, JSON, M3U hoặc PLS</string>
     <string name="settings_add_i2p_stations">Thêm trạm I2P</string>
-    <string name="settings_add_i2p_stations_description">%d trạm I2P đi kèm (ngoại tuyến, không cần mạng)</string>
+    <string name="settings_add_i2p_stations_description">%d trạm I2P khả dụng</string>
+    <string name="settings_add_i2p_stations_description_generic">Thêm các trạm phát thanh I2P được tuyển chọn</string>
     <string name="settings_add_tor_stations">Thêm trạm Tor</string>
-    <string name="settings_add_tor_stations_description">%d trạm Tor đi kèm (ngoại tuyến, không cần mạng)</string>
+    <string name="settings_add_tor_stations_description">%d trạm Tor khả dụng</string>
+    <string name="settings_add_tor_stations_description_generic">Thêm các trạm phát thanh Tor được tuyển chọn</string>
     <string name="settings_export_stations">Xuất trạm</string>
     <string name="settings_export_stations_description">Xuất các trạm của bạn ra tệp</string>
 

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -254,9 +254,11 @@
     <string name="settings_import_from_file">从文件导入</string>
     <string name="settings_import_from_file_description">从 CSV、JSON、M3U 或 PLS 导入</string>
     <string name="settings_add_i2p_stations">添加 I2P 电台</string>
-    <string name="settings_add_i2p_stations_description">%d 个内置 I2P 电台（离线，无需网络）</string>
+    <string name="settings_add_i2p_stations_description">%d 个 I2P 电台可用</string>
+    <string name="settings_add_i2p_stations_description_generic">添加精选的 I2P 广播电台</string>
     <string name="settings_add_tor_stations">添加 Tor 电台</string>
-    <string name="settings_add_tor_stations_description">%d 个内置 Tor 电台（离线，无需网络）</string>
+    <string name="settings_add_tor_stations_description">%d 个 Tor 电台可用</string>
+    <string name="settings_add_tor_stations_description_generic">添加精选的 Tor 广播电台</string>
     <string name="settings_export_stations">导出电台</string>
     <string name="settings_export_stations_description">将您的电台导出到文件</string>
 


### PR DESCRIPTION
Remove outdated "offline, no network" text from I2P/Tor station descriptions across all 16 language translations. The feature now uses a dynamic API, so strings now show "X stations available" instead of "bundled" stations. Added generic description strings for curated station additions.