### PR TITLE
Fix PLS format detection being incorrectly identified as JSON

### DIFF
--- a/app/src/main/java/com/opensource/i2pradio/util/StationImportExport.kt
+++ b/app/src/main/java/com/opensource/i2pradio/util/StationImportExport.kt
@@ -230,11 +230,13 @@ object StationImportExport {
         }
 
         // Detect by content
+        // Note: PLS check must come before JSON check because PLS starts with "[playlist]"
+        // which would otherwise match the generic "[" check for JSON arrays
         return when {
+            trimmedContent.startsWith("[playlist]", ignoreCase = true) -> FileFormat.PLS
             trimmedContent.startsWith("{") || trimmedContent.startsWith("[") -> FileFormat.JSON
             trimmedContent.startsWith("#EXTM3U") ||
                 (trimmedContent.contains("#EXTINF:") && trimmedContent.contains("http")) -> FileFormat.M3U
-            trimmedContent.startsWith("[playlist]", ignoreCase = true) -> FileFormat.PLS
             trimmedContent.contains(",") &&
                 (trimmedContent.lowercase().contains("name,url") ||
                  trimmedContent.lowercase().contains("name,stream")) -> FileFormat.CSV


### PR DESCRIPTION
PLS files start with "[playlist]" which was matching the generic JSON array check "[" before the specific PLS check could run. Reorder the content detection to check for PLS format first.