### PR TITLE
Fix unescaped apostrophes in translation strings

### DIFF
--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -622,15 +622,15 @@
     <string name="button_add">Ajouter</string>
     <string name="custom_proxy_blocked_snackbar">Aucune fuite de données — les flux sont bloqués. Configurez votre proxy ci-dessous.</string>
     <string name="custom_proxy_status_proxy_required">Proxy Requis</string>
-    <string name="custom_proxy_status_proxy_required_description">Les flux sont bloqués jusqu'à la configuration du proxy. Appuyez pour configurer.</string>
-    <string name="custom_proxy_status_proxy_required_detail">Flux bloqués jusqu'à configuration</string>
+    <string name="custom_proxy_status_proxy_required_description">Les flux sont bloqués jusqu\'à la configuration du proxy. Appuyez pour configurer.</string>
+    <string name="custom_proxy_status_proxy_required_detail">Flux bloqués jusqu\'à configuration</string>
     <string name="failed_to_fetch_stations">Échec de récupération des stations %s depuis le serveur</string>
     <string name="genre_i2p">I2P</string>
     <string name="genre_tor">Tor</string>
-    <string name="notification_i2p_not_connected">I2P n'est pas en cours d'exécution - flux bloqué</string>
+    <string name="notification_i2p_not_connected">I2P n\'est pas en cours d\'exécution - flux bloqué</string>
     <string name="now_playing_connecting">Connexion…</string>
     <string name="searching">Recherche…</string>
     <string name="settings_color_classic">Classique</string>
     <string name="settings_color_classic_default">Classique (Par défaut)</string>
-    <string name="warning_socks4_dns_limitation">SOCKS4 ne prend pas en charge la résolution DNS distante. Les requêtes DNS peuvent être résolues localement, ce qui pourrait révéler les domaines auxquels vous accédez à votre FAI. Envisagez d'utiliser SOCKS5 pour une meilleure confidentialité.</string>
+    <string name="warning_socks4_dns_limitation">SOCKS4 ne prend pas en charge la résolution DNS distante. Les requêtes DNS peuvent être résolues localement, ce qui pourrait révéler les domaines auxquels vous accédez à votre FAI. Envisagez d\'utiliser SOCKS5 pour une meilleure confidentialité.</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -632,5 +632,5 @@
     <string name="searching">Ricerca…</string>
     <string name="settings_color_classic">Classico</string>
     <string name="settings_color_classic_default">Classico (Predefinito)</string>
-    <string name="warning_socks4_dns_limitation">SOCKS4 non supporta la risoluzione DNS remota. Le query DNS potrebbero essere risolte localmente, il che potrebbe rivelare i domini a cui accedi al tuo ISP. Considera l'uso di SOCKS5 per una migliore privacy.</string>
+    <string name="warning_socks4_dns_limitation">SOCKS4 non supporta la risoluzione DNS remota. Le query DNS potrebbero essere risolte localmente, il che potrebbe rivelare i domini a cui accedi al tuo ISP. Considera l\'uso di SOCKS5 per una migliore privacy.</string>
 </resources>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -621,7 +621,7 @@
     <string name="browse_privacy_radio_subtitle">Tor ve I2P üzerinden anonim radyo istasyonları</string>
     <string name="browse_tor_stations">Tor İstasyonları</string>
     <string name="button_add">Ekle</string>
-    <string name="custom_proxy_blocked_snackbar">Veri sızıntısı yok — yayınlar engellendi. Proxy'nizi aşağıda yapılandırın.</string>
+    <string name="custom_proxy_blocked_snackbar">Veri sızıntısı yok — yayınlar engellendi. Proxy\'nizi aşağıda yapılandırın.</string>
     <string name="custom_proxy_status_proxy_required">Proxy Gerekli</string>
     <string name="custom_proxy_status_proxy_required_description">Proxy yapılandırılana kadar yayınlar engellendi. Yapılandırmak için dokunun.</string>
     <string name="custom_proxy_status_proxy_required_detail">Yapılandırılana kadar yayınlar engellendi</string>
@@ -633,5 +633,5 @@
     <string name="searching">Aranıyor…</string>
     <string name="settings_color_classic">Klasik</string>
     <string name="settings_color_classic_default">Klasik (Varsayılan)</string>
-    <string name="warning_socks4_dns_limitation">SOCKS4 uzak DNS çözümlemesini desteklemez. DNS sorguları yerel olarak çözümlenebilir, bu da eriştiğiniz alan adlarını İSS'nize açığa çıkarabilir. Daha iyi gizlilik için SOCKS5 kullanmayı düşünün.</string>
+    <string name="warning_socks4_dns_limitation">SOCKS4 uzak DNS çözümlemesini desteklemez. DNS sorguları yerel olarak çözümlenebilir, bu da eriştiğiniz alan adlarını İSS\'nize açığa çıkarabilir. Daha iyi gizlilik için SOCKS5 kullanmayı düşünün.</string>
 </resources>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -633,5 +633,5 @@
     <string name="searching">Пошук…</string>
     <string name="settings_color_classic">Класичний</string>
     <string name="settings_color_classic_default">Класичний (За замовчуванням)</string>
-    <string name="warning_socks4_dns_limitation">SOCKS4 не підтримує віддалене розв'язання DNS. DNS-запити можуть розв'язуватися локально, що може розкрити домени, до яких ви звертаєтеся, вашому інтернет-провайдеру. Розгляньте можливість використання SOCKS5 для кращої конфіденційності.</string>
+    <string name="warning_socks4_dns_limitation">SOCKS4 не підтримує віддалене розв\'язання DNS. DNS-запити можуть розв\'язуватися локально, що може розкрити домени, до яких ви звертаєтеся, вашому інтернет-провайдеру. Розгляньте можливість використання SOCKS5 для кращої конфіденційності.</string>
 </resources>


### PR DESCRIPTION
Escape apostrophes in recently added strings for values-fr, values-it, values-tr, and values-uk that were causing Android resource merge failures.