### PR TITLE
Localize hardcoded strings in I2PManager and EqualizerManager

### DIFF
--- a/app/src/main/java/com/opensource/i2pradio/audio/EqualizerManager.kt
+++ b/app/src/main/java/com/opensource/i2pradio/audio/EqualizerManager.kt
@@ -5,6 +5,7 @@ import android.media.audiofx.BassBoost
 import android.media.audiofx.Equalizer
 import android.media.audiofx.Virtualizer
 import android.util.Log
+import com.opensource.i2pradio.R
 import com.opensource.i2pradio.ui.PreferencesHelper
 
 /**
@@ -181,7 +182,16 @@ class EqualizerManager(private val context: Context) {
         numberOfBands = FIXED_BAND_COUNT.toShort()
 
         // Create preset names for UI
-        presetNames = listOf("Custom", "Flat", "Bass Boost", "Treble Boost", "Rock", "Pop", "Classical", "Jazz")
+        presetNames = listOf(
+            context.getString(R.string.equalizer_preset_custom),
+            context.getString(R.string.equalizer_preset_flat),
+            context.getString(R.string.equalizer_preset_bass_boost),
+            context.getString(R.string.equalizer_preset_treble_boost),
+            context.getString(R.string.equalizer_preset_rock),
+            context.getString(R.string.equalizer_preset_pop),
+            context.getString(R.string.equalizer_preset_classical),
+            context.getString(R.string.equalizer_preset_jazz)
+        )
 
         // Use fixed frequencies as center frequencies for preview
         centerFrequencies = FIXED_BAND_FREQUENCIES

--- a/app/src/main/java/com/opensource/i2pradio/i2p/I2PManager.kt
+++ b/app/src/main/java/com/opensource/i2pradio/i2p/I2PManager.kt
@@ -1,8 +1,10 @@
 package com.opensource.i2pradio.i2p
 
+import android.content.Context
 import android.os.Handler
 import android.os.Looper
 import android.util.Log
+import com.opensource.i2pradio.R
 import java.net.InetSocketAddress
 import java.net.Socket
 import java.util.concurrent.CopyOnWriteArrayList
@@ -201,11 +203,11 @@ object I2PManager {
     /**
      * Get a human-readable status message.
      */
-    fun getStatusMessage(): String {
+    fun getStatusMessage(context: Context): String {
         return when (_state) {
-            I2PState.UNKNOWN -> "Checking I2P availability..."
-            I2PState.AVAILABLE -> "I2P proxy available at $_host:$_port"
-            I2PState.UNAVAILABLE -> "I2P is not running"
+            I2PState.UNKNOWN -> context.getString(R.string.i2p_status_checking)
+            I2PState.AVAILABLE -> context.getString(R.string.i2p_status_available, _host, _port)
+            I2PState.UNAVAILABLE -> context.getString(R.string.i2p_status_unavailable)
         }
     }
 }

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -633,4 +633,19 @@
     <string name="settings_color_classic">كلاسيكي</string>
     <string name="settings_color_classic_default">كلاسيكي (افتراضي)</string>
     <string name="warning_socks4_dns_limitation">SOCKS4 لا يدعم حل DNS البعيد. قد يتم حل استعلامات DNS محليًا، مما قد يكشف النطاقات التي تصل إليها لمزود خدمة الإنترنت الخاص بك. فكر في استخدام SOCKS5 لمزيد من الخصوصية.</string>
+
+    <!-- Equalizer presets -->
+    <string name="equalizer_preset_custom">مخصص</string>
+    <string name="equalizer_preset_flat">مسطح</string>
+    <string name="equalizer_preset_bass_boost">تعزيز الجهير</string>
+    <string name="equalizer_preset_treble_boost">تعزيز الطبقات العالية</string>
+    <string name="equalizer_preset_rock">روك</string>
+    <string name="equalizer_preset_pop">بوب</string>
+    <string name="equalizer_preset_classical">كلاسيكي</string>
+    <string name="equalizer_preset_jazz">جاز</string>
+
+    <!-- I2P status messages -->
+    <string name="i2p_status_checking">جارٍ التحقق من توفر I2P…</string>
+    <string name="i2p_status_available">وكيل I2P متاح على %1$s:%2$d</string>
+    <string name="i2p_status_unavailable">I2P لا يعمل</string>
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -634,4 +634,19 @@
     <string name="settings_color_classic">Klassisch</string>
     <string name="settings_color_classic_default">Klassisch (Standard)</string>
     <string name="warning_socks4_dns_limitation">SOCKS4 unterstützt keine Remote-DNS-Auflösung. DNS-Abfragen können lokal aufgelöst werden, wodurch die von Ihnen aufgerufenen Domains Ihrem ISP offengelegt werden könnten. Erwägen Sie die Verwendung von SOCKS5 für besseren Datenschutz.</string>
+
+    <!-- Equalizer Preset Names -->
+    <string name="equalizer_preset_custom">Benutzerdefiniert</string>
+    <string name="equalizer_preset_flat">Flach</string>
+    <string name="equalizer_preset_bass_boost">Bass-Verstärkung</string>
+    <string name="equalizer_preset_treble_boost">Höhen-Verstärkung</string>
+    <string name="equalizer_preset_rock">Rock</string>
+    <string name="equalizer_preset_pop">Pop</string>
+    <string name="equalizer_preset_classical">Klassik</string>
+    <string name="equalizer_preset_jazz">Jazz</string>
+
+    <!-- I2P Status Messages -->
+    <string name="i2p_status_checking">Überprüfe I2P-Verfügbarkeit…</string>
+    <string name="i2p_status_available">I2P-Proxy verfügbar unter %1$s:%2$d</string>
+    <string name="i2p_status_unavailable">I2P läuft nicht</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -634,4 +634,19 @@
     <string name="now_playing_connecting">Conectando…</string>
     <string name="searching">Buscando…</string>
     <string name="warning_socks4_dns_limitation">SOCKS4 no admite resolución DNS remota. Las consultas DNS pueden resolverse localmente, lo que podría revelar los dominios a los que accede a su ISP. Considere usar SOCKS5 para mayor privacidad.</string>
+
+    <!-- Equalizer presets -->
+    <string name="equalizer_preset_custom">Personalizado</string>
+    <string name="equalizer_preset_flat">Plano</string>
+    <string name="equalizer_preset_bass_boost">Refuerzo de graves</string>
+    <string name="equalizer_preset_treble_boost">Refuerzo de agudos</string>
+    <string name="equalizer_preset_rock">Rock</string>
+    <string name="equalizer_preset_pop">Pop</string>
+    <string name="equalizer_preset_classical">Clásica</string>
+    <string name="equalizer_preset_jazz">Jazz</string>
+
+    <!-- I2P status messages -->
+    <string name="i2p_status_checking">Comprobando disponibilidad de I2P…</string>
+    <string name="i2p_status_available">Proxy I2P disponible en %1$s:%2$d</string>
+    <string name="i2p_status_unavailable">I2P no está en ejecución</string>
 </resources>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -634,4 +634,19 @@
     <string name="settings_color_classic">کلاسیک</string>
     <string name="settings_color_classic_default">کلاسیک (پیش‌فرض)</string>
     <string name="warning_socks4_dns_limitation">SOCKS4 از تفکیک DNS از راه دور پشتیبانی نمی‌کند. پرس‌وجوهای DNS ممکن است به‌صورت محلی حل شوند که می‌تواند دامنه‌هایی را که به آنها دسترسی دارید به ISP شما فاش کند. برای حریم خصوصی بهتر از SOCKS5 استفاده کنید.</string>
+
+    <!-- Equalizer presets -->
+    <string name="equalizer_preset_custom">سفارشی</string>
+    <string name="equalizer_preset_flat">صاف</string>
+    <string name="equalizer_preset_bass_boost">تقویت بیس</string>
+    <string name="equalizer_preset_treble_boost">تقویت تربل</string>
+    <string name="equalizer_preset_rock">راک</string>
+    <string name="equalizer_preset_pop">پاپ</string>
+    <string name="equalizer_preset_classical">کلاسیک</string>
+    <string name="equalizer_preset_jazz">جز</string>
+
+    <!-- I2P status messages -->
+    <string name="i2p_status_checking">در حال بررسی دسترسی I2P…</string>
+    <string name="i2p_status_available">پروکسی I2P در %1$s:%2$d موجود است</string>
+    <string name="i2p_status_unavailable">I2P در حال اجرا نیست</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -633,4 +633,19 @@
     <string name="settings_color_classic">Classique</string>
     <string name="settings_color_classic_default">Classique (Par défaut)</string>
     <string name="warning_socks4_dns_limitation">SOCKS4 ne prend pas en charge la résolution DNS distante. Les requêtes DNS peuvent être résolues localement, ce qui pourrait révéler les domaines auxquels vous accédez à votre FAI. Envisagez d\'utiliser SOCKS5 pour une meilleure confidentialité.</string>
+
+    <!-- Equalizer presets -->
+    <string name="equalizer_preset_custom">Personnalisé</string>
+    <string name="equalizer_preset_flat">Plat</string>
+    <string name="equalizer_preset_bass_boost">Amplification des basses</string>
+    <string name="equalizer_preset_treble_boost">Amplification des aigus</string>
+    <string name="equalizer_preset_rock">Rock</string>
+    <string name="equalizer_preset_pop">Pop</string>
+    <string name="equalizer_preset_classical">Classique</string>
+    <string name="equalizer_preset_jazz">Jazz</string>
+
+    <!-- I2P status messages -->
+    <string name="i2p_status_checking">Vérification de la disponibilité I2P…</string>
+    <string name="i2p_status_available">Proxy I2P disponible sur %1$s:%2$d</string>
+    <string name="i2p_status_unavailable">I2P n\'est pas en cours d\'exécution</string>
 </resources>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -633,4 +633,19 @@
     <string name="settings_color_classic">क्लासिक</string>
     <string name="settings_color_classic_default">क्लासिक (डिफ़ॉल्ट)</string>
     <string name="warning_socks4_dns_limitation">SOCKS4 रिमोट DNS रिज़ॉल्यूशन का समर्थन नहीं करता है। DNS क्वेरीज़ स्थानीय रूप से हल की जा सकती हैं, जो आपके ISP को उन डोमेन को प्रकट कर सकती हैं जिन्हें आप एक्सेस करते हैं। बेहतर गोपनीयता के लिए SOCKS5 का उपयोग करने पर विचार करें।</string>
+
+    <!-- Equalizer presets -->
+    <string name="equalizer_preset_custom">कस्टम</string>
+    <string name="equalizer_preset_flat">फ़्लैट</string>
+    <string name="equalizer_preset_bass_boost">बास बूस्ट</string>
+    <string name="equalizer_preset_treble_boost">ट्रेबल बूस्ट</string>
+    <string name="equalizer_preset_rock">रॉक</string>
+    <string name="equalizer_preset_pop">पॉप</string>
+    <string name="equalizer_preset_classical">शास्त्रीय</string>
+    <string name="equalizer_preset_jazz">जैज़</string>
+
+    <!-- I2P status messages -->
+    <string name="i2p_status_checking">I2P उपलब्धता की जाँच हो रही है…</string>
+    <string name="i2p_status_available">I2P प्रॉक्सी %1$s:%2$d पर उपलब्ध</string>
+    <string name="i2p_status_unavailable">I2P चल नहीं रहा है</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -633,4 +633,19 @@
     <string name="settings_color_classic">Classico</string>
     <string name="settings_color_classic_default">Classico (Predefinito)</string>
     <string name="warning_socks4_dns_limitation">SOCKS4 non supporta la risoluzione DNS remota. Le query DNS potrebbero essere risolte localmente, il che potrebbe rivelare i domini a cui accedi al tuo ISP. Considera l\'uso di SOCKS5 per una migliore privacy.</string>
+
+    <!-- Equalizer presets -->
+    <string name="equalizer_preset_custom">Personalizzato</string>
+    <string name="equalizer_preset_flat">Piatto</string>
+    <string name="equalizer_preset_bass_boost">Amplificazione bassi</string>
+    <string name="equalizer_preset_treble_boost">Amplificazione alti</string>
+    <string name="equalizer_preset_rock">Rock</string>
+    <string name="equalizer_preset_pop">Pop</string>
+    <string name="equalizer_preset_classical">Classica</string>
+    <string name="equalizer_preset_jazz">Jazz</string>
+
+    <!-- I2P status messages -->
+    <string name="i2p_status_checking">Verifica disponibilità I2P…</string>
+    <string name="i2p_status_available">Proxy I2P disponibile su %1$s:%2$d</string>
+    <string name="i2p_status_unavailable">I2P non è in esecuzione</string>
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -633,4 +633,19 @@
     <string name="settings_color_classic">クラシック</string>
     <string name="settings_color_classic_default">クラシック（デフォルト）</string>
     <string name="warning_socks4_dns_limitation">SOCKS4はリモートDNS解決をサポートしていません。DNSクエリがローカルで解決される可能性があり、アクセスするドメインがISPに明らかになる可能性があります。より良いプライバシーのためにSOCKS5の使用を検討してください。</string>
+
+    <!-- Equalizer presets -->
+    <string name="equalizer_preset_custom">カスタム</string>
+    <string name="equalizer_preset_flat">フラット</string>
+    <string name="equalizer_preset_bass_boost">バスブースト</string>
+    <string name="equalizer_preset_treble_boost">トレブルブースト</string>
+    <string name="equalizer_preset_rock">ロック</string>
+    <string name="equalizer_preset_pop">ポップ</string>
+    <string name="equalizer_preset_classical">クラシック</string>
+    <string name="equalizer_preset_jazz">ジャズ</string>
+
+    <!-- I2P status messages -->
+    <string name="i2p_status_checking">I2Pの可用性を確認中…</string>
+    <string name="i2p_status_available">I2Pプロキシが%1$s:%2$dで利用可能</string>
+    <string name="i2p_status_unavailable">I2Pが実行されていません</string>
 </resources>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -633,4 +633,19 @@
     <string name="settings_color_classic">클래식</string>
     <string name="settings_color_classic_default">클래식 (기본값)</string>
     <string name="warning_socks4_dns_limitation">SOCKS4는 원격 DNS 확인을 지원하지 않습니다. DNS 쿼리가 로컬로 확인될 수 있으며, 이는 액세스하는 도메인을 ISP에 노출할 수 있습니다. 더 나은 프라이버시를 위해 SOCKS5 사용을 고려하세요.</string>
+
+    <!-- Equalizer presets -->
+    <string name="equalizer_preset_custom">사용자 정의</string>
+    <string name="equalizer_preset_flat">플랫</string>
+    <string name="equalizer_preset_bass_boost">베이스 부스트</string>
+    <string name="equalizer_preset_treble_boost">트레블 부스트</string>
+    <string name="equalizer_preset_rock">록</string>
+    <string name="equalizer_preset_pop">팝</string>
+    <string name="equalizer_preset_classical">클래식</string>
+    <string name="equalizer_preset_jazz">재즈</string>
+
+    <!-- I2P status messages -->
+    <string name="i2p_status_checking">I2P 가용성 확인 중…</string>
+    <string name="i2p_status_available">I2P 프록시가 %1$s:%2$d에서 사용 가능</string>
+    <string name="i2p_status_unavailable">I2P가 실행되고 있지 않습니다</string>
 </resources>

--- a/app/src/main/res/values-my/strings.xml
+++ b/app/src/main/res/values-my/strings.xml
@@ -634,4 +634,19 @@
     <string name="settings_color_classic">ဂန္တဝင်</string>
     <string name="settings_color_classic_default">ဂန္တဝင် (မူလသတ်မှတ်)</string>
     <string name="warning_socks4_dns_limitation">SOCKS4 သည် အဝေးမှ DNS ဖြေရှင်းခြင်းကို မပံ့ပိုးပါ။ DNS စုံစမ်းမှုများကို ဒေသတွင်း ဖြေရှင်းနိုင်ပြီး သင့် ISP သို့ သင်ဝင်ရောက်သော ဒိုမိန်းများကို ဖော်ပြနိုင်သည်။ ပိုမိုကောင်းမွန်သော ကိုယ်ရေးကိုယ်တာအတွက် SOCKS5 ကို သုံးစွဲရန် စဉ်းစားပါ။</string>
+
+    <!-- Equalizer presets -->
+    <string name="equalizer_preset_custom">စိတ်ကြိုက်</string>
+    <string name="equalizer_preset_flat">ပုံမှန်</string>
+    <string name="equalizer_preset_bass_boost">အသံနိမ့် မြှင့်တင်ရေး</string>
+    <string name="equalizer_preset_treble_boost">အသံမြင့် မြှင့်တင်ရေး</string>
+    <string name="equalizer_preset_rock">Rock</string>
+    <string name="equalizer_preset_pop">Pop</string>
+    <string name="equalizer_preset_classical">ဂန္ထဝင်</string>
+    <string name="equalizer_preset_jazz">Jazz</string>
+
+    <!-- I2P status messages -->
+    <string name="i2p_status_checking">I2P ရရှိနိုင်မှုကို စစ်ဆေးနေသည်…</string>
+    <string name="i2p_status_available">I2P proxy %1$s:%2$d တွင် ရရှိနိုင်သည်</string>
+    <string name="i2p_status_unavailable">I2P မလုပ်ဆောင်နေပါ</string>
 </resources>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -634,4 +634,19 @@
     <string name="settings_color_classic">Clássico</string>
     <string name="settings_color_classic_default">Clássico (Padrão)</string>
     <string name="warning_socks4_dns_limitation">SOCKS4 não suporta resolução DNS remota. As consultas DNS podem ser resolvidas localmente, o que pode revelar os domínios que você acessa ao seu ISP. Considere usar SOCKS5 para melhor privacidade.</string>
+
+    <!-- Equalizer Preset Names -->
+    <string name="equalizer_preset_custom">Personalizado</string>
+    <string name="equalizer_preset_flat">Plano</string>
+    <string name="equalizer_preset_bass_boost">Reforço de Graves</string>
+    <string name="equalizer_preset_treble_boost">Reforço de Agudos</string>
+    <string name="equalizer_preset_rock">Rock</string>
+    <string name="equalizer_preset_pop">Pop</string>
+    <string name="equalizer_preset_classical">Clássica</string>
+    <string name="equalizer_preset_jazz">Jazz</string>
+
+    <!-- I2P Status Messages -->
+    <string name="i2p_status_checking">Verificando disponibilidade do I2P…</string>
+    <string name="i2p_status_available">Proxy I2P disponível em %1$s:%2$d</string>
+    <string name="i2p_status_unavailable">I2P não está em execução</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -633,4 +633,19 @@
     <string name="settings_color_classic">Классический</string>
     <string name="settings_color_classic_default">Классический (По умолчанию)</string>
     <string name="warning_socks4_dns_limitation">SOCKS4 не поддерживает удаленное разрешение DNS. DNS-запросы могут разрешаться локально, что может раскрыть домены, к которым вы обращаетесь, вашему интернет-провайдеру. Рассмотрите возможность использования SOCKS5 для лучшей конфиденциальности.</string>
+
+    <!-- Equalizer Preset Names -->
+    <string name="equalizer_preset_custom">Пользовательский</string>
+    <string name="equalizer_preset_flat">Плоский</string>
+    <string name="equalizer_preset_bass_boost">Усиление басов</string>
+    <string name="equalizer_preset_treble_boost">Усиление высоких</string>
+    <string name="equalizer_preset_rock">Рок</string>
+    <string name="equalizer_preset_pop">Поп</string>
+    <string name="equalizer_preset_classical">Классика</string>
+    <string name="equalizer_preset_jazz">Джаз</string>
+
+    <!-- I2P Status Messages -->
+    <string name="i2p_status_checking">Проверка доступности I2P…</string>
+    <string name="i2p_status_available">Прокси I2P доступен на %1$s:%2$d</string>
+    <string name="i2p_status_unavailable">I2P не запущен</string>
 </resources>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -634,4 +634,19 @@
     <string name="settings_color_classic">Klasik</string>
     <string name="settings_color_classic_default">Klasik (Varsayılan)</string>
     <string name="warning_socks4_dns_limitation">SOCKS4 uzak DNS çözümlemesini desteklemez. DNS sorguları yerel olarak çözümlenebilir, bu da eriştiğiniz alan adlarını İSS\'nize açığa çıkarabilir. Daha iyi gizlilik için SOCKS5 kullanmayı düşünün.</string>
+
+    <!-- Equalizer Preset Names -->
+    <string name="equalizer_preset_custom">Özel</string>
+    <string name="equalizer_preset_flat">Düz</string>
+    <string name="equalizer_preset_bass_boost">Bas Güçlendirme</string>
+    <string name="equalizer_preset_treble_boost">Tiz Güçlendirme</string>
+    <string name="equalizer_preset_rock">Rock</string>
+    <string name="equalizer_preset_pop">Pop</string>
+    <string name="equalizer_preset_classical">Klasik</string>
+    <string name="equalizer_preset_jazz">Caz</string>
+
+    <!-- I2P Status Messages -->
+    <string name="i2p_status_checking">I2P kullanılabilirliği kontrol ediliyor…</string>
+    <string name="i2p_status_available">I2P proxy %1$s:%2$d adresinde mevcut</string>
+    <string name="i2p_status_unavailable">I2P çalışmıyor</string>
 </resources>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -634,4 +634,19 @@
     <string name="settings_color_classic">Класичний</string>
     <string name="settings_color_classic_default">Класичний (За замовчуванням)</string>
     <string name="warning_socks4_dns_limitation">SOCKS4 не підтримує віддалене розв\'язання DNS. DNS-запити можуть розв\'язуватися локально, що може розкрити домени, до яких ви звертаєтеся, вашому інтернет-провайдеру. Розгляньте можливість використання SOCKS5 для кращої конфіденційності.</string>
+
+    <!-- Equalizer Preset Names -->
+    <string name="equalizer_preset_custom">Власний</string>
+    <string name="equalizer_preset_flat">Плоский</string>
+    <string name="equalizer_preset_bass_boost">Підсилення басів</string>
+    <string name="equalizer_preset_treble_boost">Підсилення високих</string>
+    <string name="equalizer_preset_rock">Рок</string>
+    <string name="equalizer_preset_pop">Поп</string>
+    <string name="equalizer_preset_classical">Класика</string>
+    <string name="equalizer_preset_jazz">Джаз</string>
+
+    <!-- I2P Status Messages -->
+    <string name="i2p_status_checking">Перевірка доступності I2P…</string>
+    <string name="i2p_status_available">Проксі I2P доступний на %1$s:%2$d</string>
+    <string name="i2p_status_unavailable">I2P не запущено</string>
 </resources>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -634,4 +634,19 @@
     <string name="settings_color_classic">Cổ điển</string>
     <string name="settings_color_classic_default">Cổ điển (Mặc định)</string>
     <string name="warning_socks4_dns_limitation">SOCKS4 không hỗ trợ phân giải DNS từ xa. Các truy vấn DNS có thể được phân giải cục bộ, điều này có thể tiết lộ các tên miền bạn truy cập cho ISP của bạn. Hãy xem xét sử dụng SOCKS5 để có quyền riêng tư tốt hơn.</string>
+
+    <!-- Equalizer Preset Names -->
+    <string name="equalizer_preset_custom">Tùy chỉnh</string>
+    <string name="equalizer_preset_flat">Phẳng</string>
+    <string name="equalizer_preset_bass_boost">Tăng Bass</string>
+    <string name="equalizer_preset_treble_boost">Tăng Treble</string>
+    <string name="equalizer_preset_rock">Rock</string>
+    <string name="equalizer_preset_pop">Pop</string>
+    <string name="equalizer_preset_classical">Cổ điển</string>
+    <string name="equalizer_preset_jazz">Jazz</string>
+
+    <!-- I2P Status Messages -->
+    <string name="i2p_status_checking">Đang kiểm tra tính khả dụng của I2P…</string>
+    <string name="i2p_status_available">Proxy I2P khả dụng tại %1$s:%2$d</string>
+    <string name="i2p_status_unavailable">I2P không chạy</string>
 </resources>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -634,4 +634,19 @@
     <string name="settings_color_classic">经典</string>
     <string name="settings_color_classic_default">经典（默认）</string>
     <string name="warning_socks4_dns_limitation">SOCKS4 不支持远程 DNS 解析。DNS 查询可能在本地解析，这可能会向您的 ISP 透露您访问的域名。考虑使用 SOCKS5 以获得更好的隐私保护。</string>
+
+    <!-- Equalizer Preset Names -->
+    <string name="equalizer_preset_custom">自定义</string>
+    <string name="equalizer_preset_flat">平坦</string>
+    <string name="equalizer_preset_bass_boost">低音增强</string>
+    <string name="equalizer_preset_treble_boost">高音增强</string>
+    <string name="equalizer_preset_rock">摇滚</string>
+    <string name="equalizer_preset_pop">流行</string>
+    <string name="equalizer_preset_classical">古典</string>
+    <string name="equalizer_preset_jazz">爵士</string>
+
+    <!-- I2P Status Messages -->
+    <string name="i2p_status_checking">正在检查 I2P 可用性…</string>
+    <string name="i2p_status_available">I2P 代理可用于 %1$s:%2$d</string>
+    <string name="i2p_status_unavailable">I2P 未运行</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -14,6 +14,19 @@
     <string name="equalizer_init_failed">Could not initialize equalizer</string>
     <string name="equalizer_bass_boost">Bass Booster</string>
     <string name="equalizer_surround_sound">Surround Sound</string>
+    <string name="equalizer_preset_custom">Custom</string>
+    <string name="equalizer_preset_flat">Flat</string>
+    <string name="equalizer_preset_bass_boost">Bass Boost</string>
+    <string name="equalizer_preset_treble_boost">Treble Boost</string>
+    <string name="equalizer_preset_rock">Rock</string>
+    <string name="equalizer_preset_pop">Pop</string>
+    <string name="equalizer_preset_classical">Classical</string>
+    <string name="equalizer_preset_jazz">Jazz</string>
+
+    <!-- I2P Status Messages -->
+    <string name="i2p_status_checking">Checking I2P availability…</string>
+    <string name="i2p_status_available">I2P proxy available at %1$s:%2$d</string>
+    <string name="i2p_status_unavailable">I2P is not running</string>
 
     <!-- Sort options -->
     <string name="sort_default">Default</string>


### PR DESCRIPTION
- Extract hardcoded I2P status messages to string resources
- Extract hardcoded equalizer preset names to string resources
- Add translations for all 16 supported languages (ar, de, es, fa, fr, hi, it, ja, ko, my, pt, ru, tr, uk, vi, zh)
- Update I2PManager.kt and EqualizerManager.kt to use Context.getString()