### PR TITLE
Localize privacy and network settings messages

### DIFF
--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -648,4 +648,28 @@
     <string name="i2p_status_checking">جارٍ التحقق من توفر I2P…</string>
     <string name="i2p_status_available">وكيل I2P متاح على %1$s:%2$d</string>
     <string name="i2p_status_unavailable">I2P لا يعمل</string>
+
+    <!-- Settings - Network & API -->
+    <string name="settings_network_api">الشبكة والواجهة البرمجية</string>
+    <string name="settings_disable_radiobrowser_api">تعطيل واجهة RadioBrowser</string>
+    <string name="settings_disable_radiobrowser_api_description">إيقاف جلب محطات الإنترنت العادي من RadioBrowser</string>
+    <string name="settings_disable_radio_registry_api">تعطيل واجهة Radio Registry</string>
+    <string name="settings_disable_radio_registry_api_description">إيقاف جلب محطات Tor/I2P من Radio Registry</string>
+    <string name="settings_disable_cover_art">تعطيل صور الغلاف</string>
+    <string name="settings_disable_cover_art_description">منع تحميل صور المحطات من الخوادم الخارجية</string>
+    <string name="settings_network_api_info">يتصل التطبيق فقط بـ: واجهة RadioBrowser لمحطات الإنترنت العادي، وواجهة Radio Registry لمحطات Tor/I2P، والخوادم الخارجية لصور الغلاف، والبث المباشر عند التشغيل.</string>
+    <string name="settings_offline_mode_note">كلتا الواجهتين معطلتان: يعرض تبويب التصفح المكتبة المحلية فقط. يمكنك الاستمرار في تشغيل المحطات المحفوظة واستيراد محطات من الملفات.</string>
+
+    <!-- Browse - Offline Mode -->
+    <string name="browse_offline_mode_title">وضع عدم الاتصال</string>
+    <string name="browse_offline_mode_message">الواجهات الخارجية معطلة في الإعدادات. انتقل إلى مكتبتك للوصول إلى المحطات المحفوظة، أو قم بتفعيل الواجهات في الإعدادات لتصفح المحطات عبر الإنترنت.</string>
+    <string name="browse_radiobrowser_disabled">واجهة RadioBrowser معطلة</string>
+    <string name="browse_radioregistry_disabled">واجهة محطات الخصوصية معطلة</string>
+    <string name="browse_disabled_title">التصفح معطل</string>
+    <string name="browse_disabled_message">كلتا واجهتي RadioBrowser وRadio Registry معطلتان في الإعدادات. قم بتفعيل واجهة واحدة على الأقل لتصفح المحطات عبر الإنترنت.</string>
+    <string name="browse_disabled_tip_title">محطاتك المحفوظة تعمل</string>
+    <string name="browse_disabled_tip_message">انتقل إلى تبويب المكتبة لتشغيل المحطات التي حفظتها، أو استورد محطات من ملف.</string>
+    <string name="browse_privacy_only_title">راديو الخصوصية</string>
+    <string name="browse_privacy_only_message">واجهة RadioBrowser معطلة. يتم عرض محطات Tor وI2P فقط.</string>
+    <string name="station_already_in_library">المحطة موجودة بالفعل في مكتبتك</string>
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -649,4 +649,28 @@
     <string name="i2p_status_checking">Überprüfe I2P-Verfügbarkeit…</string>
     <string name="i2p_status_available">I2P-Proxy verfügbar unter %1$s:%2$d</string>
     <string name="i2p_status_unavailable">I2P läuft nicht</string>
+
+    <!-- Settings - Network & API -->
+    <string name="settings_network_api">Netzwerk &amp; API</string>
+    <string name="settings_disable_radiobrowser_api">RadioBrowser-API deaktivieren</string>
+    <string name="settings_disable_radiobrowser_api_description">Abruf von Clearnet-Sendern von RadioBrowser stoppen</string>
+    <string name="settings_disable_radio_registry_api">Radio Registry-API deaktivieren</string>
+    <string name="settings_disable_radio_registry_api_description">Abruf von Tor/I2P-Sendern von Radio Registry stoppen</string>
+    <string name="settings_disable_cover_art">Cover-Art deaktivieren</string>
+    <string name="settings_disable_cover_art_description">Laden von Sender-Artwork von externen Servern verhindern</string>
+    <string name="settings_network_api_info">Die App verbindet sich nur mit: RadioBrowser-API für Clearnet-Sender, Radio Registry-API für Tor/I2P-Sender, externen Servern für Sender-Cover-Art und Radiostreams beim Abspielen.</string>
+    <string name="settings_offline_mode_note">Beide APIs deaktiviert: Der Durchsuchen-Tab zeigt nur die lokale Bibliothek. Sie können weiterhin gespeicherte Sender abspielen und Sender aus Dateien importieren.</string>
+
+    <!-- Browse - Offline Mode -->
+    <string name="browse_offline_mode_title">Offline-Modus</string>
+    <string name="browse_offline_mode_message">Externe APIs sind in den Einstellungen deaktiviert. Gehen Sie zu Ihrer Bibliothek, um gespeicherte Sender zu nutzen, oder aktivieren Sie APIs in den Einstellungen, um Online-Sender zu durchsuchen.</string>
+    <string name="browse_radiobrowser_disabled">RadioBrowser-API deaktiviert</string>
+    <string name="browse_radioregistry_disabled">Datenschutz-Sender-API deaktiviert</string>
+    <string name="browse_disabled_title">Durchsuchen deaktiviert</string>
+    <string name="browse_disabled_message">Sowohl RadioBrowser- als auch Radio Registry-APIs sind in den Einstellungen deaktiviert. Aktivieren Sie mindestens eine API, um Online-Sender zu durchsuchen.</string>
+    <string name="browse_disabled_tip_title">Ihre gespeicherten Sender funktionieren weiterhin</string>
+    <string name="browse_disabled_tip_message">Gehen Sie zum Bibliothek-Tab, um Sender abzuspielen, die Sie bereits gespeichert haben, oder importieren Sie Sender aus einer Datei.</string>
+    <string name="browse_privacy_only_title">Datenschutz-Radio</string>
+    <string name="browse_privacy_only_message">RadioBrowser-API ist deaktiviert. Es werden nur Tor- und I2P-Sender angezeigt.</string>
+    <string name="station_already_in_library">Sender ist bereits in Ihrer Bibliothek</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -649,4 +649,28 @@
     <string name="i2p_status_checking">Comprobando disponibilidad de I2P…</string>
     <string name="i2p_status_available">Proxy I2P disponible en %1$s:%2$d</string>
     <string name="i2p_status_unavailable">I2P no está en ejecución</string>
+
+    <!-- Settings - Network & API -->
+    <string name="settings_network_api">Red y API</string>
+    <string name="settings_disable_radiobrowser_api">Desactivar API de RadioBrowser</string>
+    <string name="settings_disable_radiobrowser_api_description">Dejar de obtener emisoras de clearnet desde RadioBrowser</string>
+    <string name="settings_disable_radio_registry_api">Desactivar API de Radio Registry</string>
+    <string name="settings_disable_radio_registry_api_description">Dejar de obtener emisoras Tor/I2P desde Radio Registry</string>
+    <string name="settings_disable_cover_art">Desactivar carátulas</string>
+    <string name="settings_disable_cover_art_description">Evitar cargar imágenes de emisoras desde servidores externos</string>
+    <string name="settings_network_api_info">La aplicación solo se conecta a: API de RadioBrowser para emisoras de clearnet, API de Radio Registry para emisoras Tor/I2P, servidores externos para carátulas y transmisiones de radio al reproducir.</string>
+    <string name="settings_offline_mode_note">Ambas APIs desactivadas: La pestaña Explorar muestra solo la biblioteca local. Puedes seguir reproduciendo emisoras guardadas e importar emisoras desde archivos.</string>
+
+    <!-- Browse - Offline Mode -->
+    <string name="browse_offline_mode_title">Modo sin conexión</string>
+    <string name="browse_offline_mode_message">Las APIs externas están desactivadas en los ajustes. Ve a tu Biblioteca para acceder a emisoras guardadas, o activa las APIs en Ajustes para explorar emisoras en línea.</string>
+    <string name="browse_radiobrowser_disabled">API de RadioBrowser desactivada</string>
+    <string name="browse_radioregistry_disabled">API de emisoras de privacidad desactivada</string>
+    <string name="browse_disabled_title">Exploración desactivada</string>
+    <string name="browse_disabled_message">Tanto RadioBrowser como Radio Registry APIs están desactivadas en los ajustes. Activa al menos una API para explorar emisoras en línea.</string>
+    <string name="browse_disabled_tip_title">Tus emisoras guardadas aún funcionan</string>
+    <string name="browse_disabled_tip_message">Ve a la pestaña Biblioteca para reproducir emisoras que ya has guardado, o importa emisoras desde un archivo.</string>
+    <string name="browse_privacy_only_title">Radio de Privacidad</string>
+    <string name="browse_privacy_only_message">La API de RadioBrowser está desactivada. Mostrando solo emisoras Tor e I2P.</string>
+    <string name="station_already_in_library">La emisora ya está en tu biblioteca</string>
 </resources>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -649,4 +649,28 @@
     <string name="i2p_status_checking">در حال بررسی دسترسی I2P…</string>
     <string name="i2p_status_available">پروکسی I2P در %1$s:%2$d موجود است</string>
     <string name="i2p_status_unavailable">I2P در حال اجرا نیست</string>
+
+    <!-- Settings - Network & API -->
+    <string name="settings_network_api">شبکه و API</string>
+    <string name="settings_disable_radiobrowser_api">غیرفعال کردن API رادیو براوزر</string>
+    <string name="settings_disable_radiobrowser_api_description">توقف دریافت ایستگاه‌های کلیرنت از رادیو براوزر</string>
+    <string name="settings_disable_radio_registry_api">غیرفعال کردن API رجیستری رادیو</string>
+    <string name="settings_disable_radio_registry_api_description">توقف دریافت ایستگاه‌های Tor/I2P از رجیستری رادیو</string>
+    <string name="settings_disable_cover_art">غیرفعال کردن تصویر جلد</string>
+    <string name="settings_disable_cover_art_description">جلوگیری از بارگذاری تصاویر ایستگاه از سرورهای خارجی</string>
+    <string name="settings_network_api_info">برنامه فقط به این موارد متصل می‌شود: API رادیو براوزر برای ایستگاه‌های کلیرنت، API رجیستری رادیو برای ایستگاه‌های Tor/I2P، سرورهای خارجی برای تصاویر جلد، و پخش رادیو در هنگام پخش.</string>
+    <string name="settings_offline_mode_note">هر دو API غیرفعال: زبانه مرور فقط کتابخانه محلی را نشان می‌دهد. می‌توانید همچنان ایستگاه‌های ذخیره شده را پخش کنید و ایستگاه‌ها را از فایل‌ها وارد کنید.</string>
+
+    <!-- Browse - Offline Mode -->
+    <string name="browse_offline_mode_title">حالت آفلاین</string>
+    <string name="browse_offline_mode_message">APIهای خارجی در تنظیمات غیرفعال هستند. به کتابخانه خود بروید تا به ایستگاه‌های ذخیره شده دسترسی پیدا کنید، یا APIها را در تنظیمات فعال کنید تا ایستگاه‌های آنلاین را مرور کنید.</string>
+    <string name="browse_radiobrowser_disabled">API رادیو براوزر غیرفعال است</string>
+    <string name="browse_radioregistry_disabled">API ایستگاه‌های حریم خصوصی غیرفعال است</string>
+    <string name="browse_disabled_title">مرور غیرفعال است</string>
+    <string name="browse_disabled_message">هر دو API رادیو براوزر و رجیستری رادیو در تنظیمات غیرفعال هستند. حداقل یک API را فعال کنید تا ایستگاه‌های آنلاین را مرور کنید.</string>
+    <string name="browse_disabled_tip_title">ایستگاه‌های ذخیره شده شما همچنان کار می‌کنند</string>
+    <string name="browse_disabled_tip_message">به زبانه کتابخانه بروید تا ایستگاه‌هایی که قبلاً ذخیره کرده‌اید را پخش کنید، یا ایستگاه‌ها را از یک فایل وارد کنید.</string>
+    <string name="browse_privacy_only_title">رادیو حریم خصوصی</string>
+    <string name="browse_privacy_only_message">API رادیو براوزر غیرفعال است. فقط ایستگاه‌های Tor و I2P نمایش داده می‌شوند.</string>
+    <string name="station_already_in_library">ایستگاه از قبل در کتابخانه شما موجود است</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -648,4 +648,28 @@
     <string name="i2p_status_checking">Vérification de la disponibilité I2P…</string>
     <string name="i2p_status_available">Proxy I2P disponible sur %1$s:%2$d</string>
     <string name="i2p_status_unavailable">I2P n\'est pas en cours d\'exécution</string>
+
+    <!-- Settings - Network & API -->
+    <string name="settings_network_api">Réseau et API</string>
+    <string name="settings_disable_radiobrowser_api">Désactiver l\'API RadioBrowser</string>
+    <string name="settings_disable_radiobrowser_api_description">Arrêter de récupérer les stations clearnet depuis RadioBrowser</string>
+    <string name="settings_disable_radio_registry_api">Désactiver l\'API Radio Registry</string>
+    <string name="settings_disable_radio_registry_api_description">Arrêter de récupérer les stations Tor/I2P depuis Radio Registry</string>
+    <string name="settings_disable_cover_art">Désactiver les pochettes</string>
+    <string name="settings_disable_cover_art_description">Empêcher le chargement des images de stations depuis des serveurs externes</string>
+    <string name="settings_network_api_info">L\'application se connecte uniquement à : l\'API RadioBrowser pour les stations clearnet, l\'API Radio Registry pour les stations Tor/I2P, les serveurs externes pour les pochettes et les flux radio lors de la lecture.</string>
+    <string name="settings_offline_mode_note">Les deux APIs désactivées : l\'onglet Parcourir affiche uniquement la bibliothèque locale. Vous pouvez toujours lire les stations enregistrées et importer des stations depuis des fichiers.</string>
+
+    <!-- Browse - Offline Mode -->
+    <string name="browse_offline_mode_title">Mode hors ligne</string>
+    <string name="browse_offline_mode_message">Les APIs externes sont désactivées dans les paramètres. Accédez à votre Bibliothèque pour les stations enregistrées, ou activez les APIs dans Paramètres pour parcourir les stations en ligne.</string>
+    <string name="browse_radiobrowser_disabled">API RadioBrowser désactivée</string>
+    <string name="browse_radioregistry_disabled">API des stations de confidentialité désactivée</string>
+    <string name="browse_disabled_title">Parcourir désactivé</string>
+    <string name="browse_disabled_message">Les APIs RadioBrowser et Radio Registry sont toutes deux désactivées dans les paramètres. Activez au moins une API pour parcourir les stations en ligne.</string>
+    <string name="browse_disabled_tip_title">Vos stations enregistrées fonctionnent toujours</string>
+    <string name="browse_disabled_tip_message">Accédez à l\'onglet Bibliothèque pour lire les stations que vous avez déjà enregistrées, ou importez des stations depuis un fichier.</string>
+    <string name="browse_privacy_only_title">Radio Confidentialité</string>
+    <string name="browse_privacy_only_message">L\'API RadioBrowser est désactivée. Affichage des stations Tor et I2P uniquement.</string>
+    <string name="station_already_in_library">La station est déjà dans votre bibliothèque</string>
 </resources>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -648,4 +648,28 @@
     <string name="i2p_status_checking">I2P उपलब्धता की जाँच हो रही है…</string>
     <string name="i2p_status_available">I2P प्रॉक्सी %1$s:%2$d पर उपलब्ध</string>
     <string name="i2p_status_unavailable">I2P चल नहीं रहा है</string>
+
+    <!-- Settings - Network & API -->
+    <string name="settings_network_api">नेटवर्क और API</string>
+    <string name="settings_disable_radiobrowser_api">RadioBrowser API अक्षम करें</string>
+    <string name="settings_disable_radiobrowser_api_description">RadioBrowser से क्लियरनेट स्टेशन प्राप्त करना बंद करें</string>
+    <string name="settings_disable_radio_registry_api">Radio Registry API अक्षम करें</string>
+    <string name="settings_disable_radio_registry_api_description">Radio Registry से Tor/I2P स्टेशन प्राप्त करना बंद करें</string>
+    <string name="settings_disable_cover_art">कवर आर्ट अक्षम करें</string>
+    <string name="settings_disable_cover_art_description">बाहरी सर्वरों से स्टेशन आर्टवर्क लोड होने से रोकें</string>
+    <string name="settings_network_api_info">ऐप केवल इनसे कनेक्ट होता है: क्लियरनेट स्टेशनों के लिए RadioBrowser API, Tor/I2P स्टेशनों के लिए Radio Registry API, कवर आर्ट के लिए बाहरी सर्वर, और चलाते समय रेडियो स्ट्रीम।</string>
+    <string name="settings_offline_mode_note">दोनों APIs अक्षम: ब्राउज़ टैब केवल स्थानीय लाइब्रेरी दिखाता है। आप अभी भी सहेजे गए स्टेशन चला सकते हैं और फ़ाइलों से स्टेशन आयात कर सकते हैं।</string>
+
+    <!-- Browse - Offline Mode -->
+    <string name="browse_offline_mode_title">ऑफ़लाइन मोड</string>
+    <string name="browse_offline_mode_message">बाहरी APIs सेटिंग्स में अक्षम हैं। सहेजे गए स्टेशनों तक पहुंचने के लिए अपनी लाइब्रेरी पर जाएं, या ऑनलाइन स्टेशन ब्राउज़ करने के लिए सेटिंग्स में APIs सक्षम करें।</string>
+    <string name="browse_radiobrowser_disabled">RadioBrowser API अक्षम है</string>
+    <string name="browse_radioregistry_disabled">गोपनीयता स्टेशन API अक्षम है</string>
+    <string name="browse_disabled_title">ब्राउज़िंग अक्षम</string>
+    <string name="browse_disabled_message">RadioBrowser और Radio Registry दोनों APIs सेटिंग्स में अक्षम हैं। ऑनलाइन स्टेशन ब्राउज़ करने के लिए कम से कम एक API सक्षम करें।</string>
+    <string name="browse_disabled_tip_title">आपके सहेजे गए स्टेशन अभी भी काम करते हैं</string>
+    <string name="browse_disabled_tip_message">पहले से सहेजे गए स्टेशन चलाने के लिए लाइब्रेरी टैब पर जाएं, या किसी फ़ाइल से स्टेशन आयात करें।</string>
+    <string name="browse_privacy_only_title">प्राइवेसी रेडियो</string>
+    <string name="browse_privacy_only_message">RadioBrowser API अक्षम है। केवल Tor और I2P स्टेशन दिखाए जा रहे हैं।</string>
+    <string name="station_already_in_library">स्टेशन पहले से आपकी लाइब्रेरी में है</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -648,4 +648,28 @@
     <string name="i2p_status_checking">Verifica disponibilità I2P…</string>
     <string name="i2p_status_available">Proxy I2P disponibile su %1$s:%2$d</string>
     <string name="i2p_status_unavailable">I2P non è in esecuzione</string>
+
+    <!-- Settings - Network & API -->
+    <string name="settings_network_api">Rete e API</string>
+    <string name="settings_disable_radiobrowser_api">Disabilita API RadioBrowser</string>
+    <string name="settings_disable_radiobrowser_api_description">Interrompi il recupero delle stazioni clearnet da RadioBrowser</string>
+    <string name="settings_disable_radio_registry_api">Disabilita API Radio Registry</string>
+    <string name="settings_disable_radio_registry_api_description">Interrompi il recupero delle stazioni Tor/I2P da Radio Registry</string>
+    <string name="settings_disable_cover_art">Disabilita copertine</string>
+    <string name="settings_disable_cover_art_description">Impedisci il caricamento delle immagini delle stazioni da server esterni</string>
+    <string name="settings_network_api_info">L\'app si connette solo a: API RadioBrowser per stazioni clearnet, API Radio Registry per stazioni Tor/I2P, server esterni per copertine e streaming radio durante la riproduzione.</string>
+    <string name="settings_offline_mode_note">Entrambe le API disabilitate: la scheda Sfoglia mostra solo la libreria locale. Puoi comunque riprodurre stazioni salvate e importare stazioni da file.</string>
+
+    <!-- Browse - Offline Mode -->
+    <string name="browse_offline_mode_title">Modalità offline</string>
+    <string name="browse_offline_mode_message">Le API esterne sono disabilitate nelle impostazioni. Vai alla tua Libreria per accedere alle stazioni salvate, o abilita le API nelle Impostazioni per sfogliare le stazioni online.</string>
+    <string name="browse_radiobrowser_disabled">API RadioBrowser disabilitata</string>
+    <string name="browse_radioregistry_disabled">API stazioni privacy disabilitata</string>
+    <string name="browse_disabled_title">Sfoglia disabilitato</string>
+    <string name="browse_disabled_message">Sia RadioBrowser che Radio Registry API sono disabilitate nelle impostazioni. Abilita almeno un\'API per sfogliare le stazioni online.</string>
+    <string name="browse_disabled_tip_title">Le tue stazioni salvate funzionano ancora</string>
+    <string name="browse_disabled_tip_message">Vai alla scheda Libreria per riprodurre le stazioni che hai già salvato, o importa stazioni da un file.</string>
+    <string name="browse_privacy_only_title">Radio Privacy</string>
+    <string name="browse_privacy_only_message">L\'API RadioBrowser è disabilitata. Vengono mostrate solo le stazioni Tor e I2P.</string>
+    <string name="station_already_in_library">La stazione è già nella tua libreria</string>
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -648,4 +648,28 @@
     <string name="i2p_status_checking">I2Pの可用性を確認中…</string>
     <string name="i2p_status_available">I2Pプロキシが%1$s:%2$dで利用可能</string>
     <string name="i2p_status_unavailable">I2Pが実行されていません</string>
+
+    <!-- Settings - Network & API -->
+    <string name="settings_network_api">ネットワークとAPI</string>
+    <string name="settings_disable_radiobrowser_api">RadioBrowser APIを無効にする</string>
+    <string name="settings_disable_radiobrowser_api_description">RadioBrowserからクリアネットステーションの取得を停止</string>
+    <string name="settings_disable_radio_registry_api">Radio Registry APIを無効にする</string>
+    <string name="settings_disable_radio_registry_api_description">Radio RegistryからTor/I2Pステーションの取得を停止</string>
+    <string name="settings_disable_cover_art">カバーアートを無効にする</string>
+    <string name="settings_disable_cover_art_description">外部サーバーからのステーションアートワークの読み込みを防止</string>
+    <string name="settings_network_api_info">アプリは次にのみ接続します: クリアネットステーション用のRadioBrowser API、Tor/I2Pステーション用のRadio Registry API、カバーアート用の外部サーバー、再生時のラジオストリーム。</string>
+    <string name="settings_offline_mode_note">両方のAPIが無効: 参照タブはローカルライブラリのみを表示します。保存されたステーションの再生やファイルからのステーションのインポートは引き続き可能です。</string>
+
+    <!-- Browse - Offline Mode -->
+    <string name="browse_offline_mode_title">オフラインモード</string>
+    <string name="browse_offline_mode_message">外部APIは設定で無効になっています。保存されたステーションにアクセスするにはライブラリに移動するか、オンラインステーションを参照するには設定でAPIを有効にしてください。</string>
+    <string name="browse_radiobrowser_disabled">RadioBrowser APIが無効</string>
+    <string name="browse_radioregistry_disabled">プライバシーステーションAPIが無効</string>
+    <string name="browse_disabled_title">参照が無効</string>
+    <string name="browse_disabled_message">RadioBrowserとRadio Registryの両方のAPIが設定で無効になっています。オンラインステーションを参照するには、少なくとも1つのAPIを有効にしてください。</string>
+    <string name="browse_disabled_tip_title">保存されたステーションは引き続き動作します</string>
+    <string name="browse_disabled_tip_message">既に保存したステーションを再生するにはライブラリタブに移動するか、ファイルからステーションをインポートしてください。</string>
+    <string name="browse_privacy_only_title">プライバシーラジオ</string>
+    <string name="browse_privacy_only_message">RadioBrowser APIが無効です。TorとI2Pステーションのみを表示しています。</string>
+    <string name="station_already_in_library">ステーションは既にライブラリにあります</string>
 </resources>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -648,4 +648,28 @@
     <string name="i2p_status_checking">I2P 가용성 확인 중…</string>
     <string name="i2p_status_available">I2P 프록시가 %1$s:%2$d에서 사용 가능</string>
     <string name="i2p_status_unavailable">I2P가 실행되고 있지 않습니다</string>
+
+    <!-- Settings - Network & API -->
+    <string name="settings_network_api">네트워크 및 API</string>
+    <string name="settings_disable_radiobrowser_api">RadioBrowser API 비활성화</string>
+    <string name="settings_disable_radiobrowser_api_description">RadioBrowser에서 클리어넷 방송국 가져오기 중지</string>
+    <string name="settings_disable_radio_registry_api">Radio Registry API 비활성화</string>
+    <string name="settings_disable_radio_registry_api_description">Radio Registry에서 Tor/I2P 방송국 가져오기 중지</string>
+    <string name="settings_disable_cover_art">커버 아트 비활성화</string>
+    <string name="settings_disable_cover_art_description">외부 서버에서 방송국 아트워크 로드 방지</string>
+    <string name="settings_network_api_info">앱은 다음에만 연결됩니다: 클리어넷 방송국용 RadioBrowser API, Tor/I2P 방송국용 Radio Registry API, 커버 아트용 외부 서버, 재생 시 라디오 스트림.</string>
+    <string name="settings_offline_mode_note">두 API 모두 비활성화됨: 탐색 탭에 로컬 라이브러리만 표시됩니다. 저장된 방송국을 재생하고 파일에서 방송국을 가져올 수 있습니다.</string>
+
+    <!-- Browse - Offline Mode -->
+    <string name="browse_offline_mode_title">오프라인 모드</string>
+    <string name="browse_offline_mode_message">외부 API가 설정에서 비활성화되어 있습니다. 저장된 방송국에 액세스하려면 라이브러리로 이동하거나 설정에서 API를 활성화하여 온라인 방송국을 탐색하세요.</string>
+    <string name="browse_radiobrowser_disabled">RadioBrowser API 비활성화됨</string>
+    <string name="browse_radioregistry_disabled">프라이버시 방송국 API 비활성화됨</string>
+    <string name="browse_disabled_title">탐색 비활성화됨</string>
+    <string name="browse_disabled_message">RadioBrowser와 Radio Registry API가 모두 설정에서 비활성화되어 있습니다. 온라인 방송국을 탐색하려면 최소 하나의 API를 활성화하세요.</string>
+    <string name="browse_disabled_tip_title">저장된 방송국은 여전히 작동합니다</string>
+    <string name="browse_disabled_tip_message">이미 저장한 방송국을 재생하려면 라이브러리 탭으로 이동하거나 파일에서 방송국을 가져오세요.</string>
+    <string name="browse_privacy_only_title">프라이버시 라디오</string>
+    <string name="browse_privacy_only_message">RadioBrowser API가 비활성화되어 있습니다. Tor 및 I2P 방송국만 표시됩니다.</string>
+    <string name="station_already_in_library">방송국이 이미 라이브러리에 있습니다</string>
 </resources>

--- a/app/src/main/res/values-my/strings.xml
+++ b/app/src/main/res/values-my/strings.xml
@@ -649,4 +649,28 @@
     <string name="i2p_status_checking">I2P ရရှိနိုင်မှုကို စစ်ဆေးနေသည်…</string>
     <string name="i2p_status_available">I2P proxy %1$s:%2$d တွင် ရရှိနိုင်သည်</string>
     <string name="i2p_status_unavailable">I2P မလုပ်ဆောင်နေပါ</string>
+
+    <!-- Settings - Network & API -->
+    <string name="settings_network_api">ကွန်ရက်နှင့် API</string>
+    <string name="settings_disable_radiobrowser_api">RadioBrowser API ပိတ်ရန်</string>
+    <string name="settings_disable_radiobrowser_api_description">RadioBrowser မှ clearnet စတေးရှင်းများ ရယူခြင်း ရပ်တန့်ရန်</string>
+    <string name="settings_disable_radio_registry_api">Radio Registry API ပိတ်ရန်</string>
+    <string name="settings_disable_radio_registry_api_description">Radio Registry မှ Tor/I2P စတေးရှင်းများ ရယူခြင်း ရပ်တန့်ရန်</string>
+    <string name="settings_disable_cover_art">Cover Art ပိတ်ရန်</string>
+    <string name="settings_disable_cover_art_description">ပြင်ပဆာဗာများမှ စတေးရှင်းပုံများ တင်ခြင်း တားဆီးရန်</string>
+    <string name="settings_network_api_info">အက်ပ်သည် ဤအရာများနှင့်သာ ချိတ်ဆက်သည်: clearnet စတေးရှင်းများအတွက် RadioBrowser API၊ Tor/I2P စတေးရှင်းများအတွက် Radio Registry API၊ cover art အတွက် ပြင်ပဆာဗာများနှင့် ဖွင့်သည့်အခါ ရေဒီယိုစတရိမ်များ။</string>
+    <string name="settings_offline_mode_note">API နှစ်ခုလုံး ပိတ်ထားသည်: Browse တက်ဘ်တွင် ဒေသတွင်း စာကြည့်တိုက်သာ ပြသသည်။ သိမ်းဆည်းထားသော စတေးရှင်းများကို ဖွင့်နိုင်ပြီး ဖိုင်များမှ တင်သွင်းနိုင်ပါသည်။</string>
+
+    <!-- Browse - Offline Mode -->
+    <string name="browse_offline_mode_title">အော့ဖ်လိုင်းမုဒ်</string>
+    <string name="browse_offline_mode_message">ပြင်ပ API များကို ဆက်တင်များတွင် ပိတ်ထားသည်။ သိမ်းဆည်းထားသော စတေးရှင်းများကို ကြည့်ရန် Library သို့သွားပါ သို့မဟုတ် အွန်လိုင်းစတေးရှင်းများ ကြည့်ရန် ဆက်တင်များတွင် API များကို ဖွင့်ပါ။</string>
+    <string name="browse_radiobrowser_disabled">RadioBrowser API ပိတ်ထားသည်</string>
+    <string name="browse_radioregistry_disabled">ကိုယ်ရေးလုံခြုံရေး စတေးရှင်း API ပိတ်ထားသည်</string>
+    <string name="browse_disabled_title">Browse ပိတ်ထားသည်</string>
+    <string name="browse_disabled_message">RadioBrowser နှင့် Radio Registry API နှစ်ခုလုံးကို ဆက်တင်များတွင် ပိတ်ထားသည်။ အွန်လိုင်းစတေးရှင်းများ ကြည့်ရန် အနည်းဆုံး API တစ်ခု ဖွင့်ပါ။</string>
+    <string name="browse_disabled_tip_title">သင့်သိမ်းဆည်းထားသော စတေးရှင်းများ ဆက်အလုပ်လုပ်သည်</string>
+    <string name="browse_disabled_tip_message">သိမ်းဆည်းထားသော စတေးရှင်းများ ဖွင့်ရန် Library တက်ဘ်သို့သွားပါ သို့မဟုတ် ဖိုင်မှ တင်သွင်းပါ။</string>
+    <string name="browse_privacy_only_title">ကိုယ်ရေးလုံခြုံရေး ရေဒီယို</string>
+    <string name="browse_privacy_only_message">RadioBrowser API ပိတ်ထားသည်။ Tor နှင့် I2P စတေးရှင်းများသာ ပြသနေသည်။</string>
+    <string name="station_already_in_library">စတေးရှင်းသည် သင့် library တွင် ရှိပြီးသားဖြစ်သည်</string>
 </resources>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -649,4 +649,28 @@
     <string name="i2p_status_checking">Verificando disponibilidade do I2P…</string>
     <string name="i2p_status_available">Proxy I2P disponível em %1$s:%2$d</string>
     <string name="i2p_status_unavailable">I2P não está em execução</string>
+
+    <!-- Settings - Network & API -->
+    <string name="settings_network_api">Rede e API</string>
+    <string name="settings_disable_radiobrowser_api">Desativar API RadioBrowser</string>
+    <string name="settings_disable_radiobrowser_api_description">Parar de buscar estações clearnet do RadioBrowser</string>
+    <string name="settings_disable_radio_registry_api">Desativar API Radio Registry</string>
+    <string name="settings_disable_radio_registry_api_description">Parar de buscar estações Tor/I2P do Radio Registry</string>
+    <string name="settings_disable_cover_art">Desativar capas</string>
+    <string name="settings_disable_cover_art_description">Impedir carregamento de imagens de estações de servidores externos</string>
+    <string name="settings_network_api_info">O aplicativo conecta-se apenas a: API RadioBrowser para estações clearnet, API Radio Registry para estações Tor/I2P, servidores externos para capas e streams de rádio ao reproduzir.</string>
+    <string name="settings_offline_mode_note">Ambas APIs desativadas: A aba Explorar mostra apenas a biblioteca local. Você ainda pode reproduzir estações salvas e importar estações de arquivos.</string>
+
+    <!-- Browse - Offline Mode -->
+    <string name="browse_offline_mode_title">Modo offline</string>
+    <string name="browse_offline_mode_message">As APIs externas estão desativadas nas configurações. Vá para sua Biblioteca para acessar estações salvas, ou ative as APIs nas Configurações para explorar estações online.</string>
+    <string name="browse_radiobrowser_disabled">API RadioBrowser desativada</string>
+    <string name="browse_radioregistry_disabled">API de estações de privacidade desativada</string>
+    <string name="browse_disabled_title">Explorar desativado</string>
+    <string name="browse_disabled_message">Tanto RadioBrowser quanto Radio Registry APIs estão desativadas nas configurações. Ative pelo menos uma API para explorar estações online.</string>
+    <string name="browse_disabled_tip_title">Suas estações salvas ainda funcionam</string>
+    <string name="browse_disabled_tip_message">Vá para a aba Biblioteca para reproduzir estações que você já salvou, ou importe estações de um arquivo.</string>
+    <string name="browse_privacy_only_title">Rádio de Privacidade</string>
+    <string name="browse_privacy_only_message">A API RadioBrowser está desativada. Mostrando apenas estações Tor e I2P.</string>
+    <string name="station_already_in_library">A estação já está na sua biblioteca</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -648,4 +648,28 @@
     <string name="i2p_status_checking">Проверка доступности I2P…</string>
     <string name="i2p_status_available">Прокси I2P доступен на %1$s:%2$d</string>
     <string name="i2p_status_unavailable">I2P не запущен</string>
+
+    <!-- Settings - Network & API -->
+    <string name="settings_network_api">Сеть и API</string>
+    <string name="settings_disable_radiobrowser_api">Отключить API RadioBrowser</string>
+    <string name="settings_disable_radiobrowser_api_description">Прекратить получение clearnet-станций из RadioBrowser</string>
+    <string name="settings_disable_radio_registry_api">Отключить API Radio Registry</string>
+    <string name="settings_disable_radio_registry_api_description">Прекратить получение Tor/I2P-станций из Radio Registry</string>
+    <string name="settings_disable_cover_art">Отключить обложки</string>
+    <string name="settings_disable_cover_art_description">Запретить загрузку изображений станций с внешних серверов</string>
+    <string name="settings_network_api_info">Приложение подключается только к: API RadioBrowser для clearnet-станций, API Radio Registry для Tor/I2P-станций, внешним серверам для обложек и радиопотокам при воспроизведении.</string>
+    <string name="settings_offline_mode_note">Оба API отключены: вкладка «Обзор» показывает только локальную библиотеку. Вы по-прежнему можете воспроизводить сохранённые станции и импортировать станции из файлов.</string>
+
+    <!-- Browse - Offline Mode -->
+    <string name="browse_offline_mode_title">Автономный режим</string>
+    <string name="browse_offline_mode_message">Внешние API отключены в настройках. Перейдите в Библиотеку для доступа к сохранённым станциям или включите API в Настройках для просмотра онлайн-станций.</string>
+    <string name="browse_radiobrowser_disabled">API RadioBrowser отключён</string>
+    <string name="browse_radioregistry_disabled">API станций конфиденциальности отключён</string>
+    <string name="browse_disabled_title">Обзор отключён</string>
+    <string name="browse_disabled_message">API RadioBrowser и Radio Registry отключены в настройках. Включите хотя бы один API для просмотра онлайн-станций.</string>
+    <string name="browse_disabled_tip_title">Сохранённые станции по-прежнему работают</string>
+    <string name="browse_disabled_tip_message">Перейдите на вкладку «Библиотека» для воспроизведения уже сохранённых станций или импортируйте станции из файла.</string>
+    <string name="browse_privacy_only_title">Приватное радио</string>
+    <string name="browse_privacy_only_message">API RadioBrowser отключён. Отображаются только Tor и I2P станции.</string>
+    <string name="station_already_in_library">Станция уже в вашей библиотеке</string>
 </resources>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -649,4 +649,28 @@
     <string name="i2p_status_checking">I2P kullanılabilirliği kontrol ediliyor…</string>
     <string name="i2p_status_available">I2P proxy %1$s:%2$d adresinde mevcut</string>
     <string name="i2p_status_unavailable">I2P çalışmıyor</string>
+
+    <!-- Settings - Network & API -->
+    <string name="settings_network_api">Ağ ve API</string>
+    <string name="settings_disable_radiobrowser_api">RadioBrowser API\'yi Devre Dışı Bırak</string>
+    <string name="settings_disable_radiobrowser_api_description">RadioBrowser\'dan clearnet istasyonları almayı durdur</string>
+    <string name="settings_disable_radio_registry_api">Radio Registry API\'yi Devre Dışı Bırak</string>
+    <string name="settings_disable_radio_registry_api_description">Radio Registry\'den Tor/I2P istasyonları almayı durdur</string>
+    <string name="settings_disable_cover_art">Kapak Resmini Devre Dışı Bırak</string>
+    <string name="settings_disable_cover_art_description">Harici sunuculardan istasyon görsellerinin yüklenmesini engelle</string>
+    <string name="settings_network_api_info">Uygulama yalnızca şunlara bağlanır: clearnet istasyonları için RadioBrowser API, Tor/I2P istasyonları için Radio Registry API, kapak resimleri için harici sunucular ve oynatırken radyo akışları.</string>
+    <string name="settings_offline_mode_note">Her iki API de devre dışı: Gözat sekmesi yalnızca yerel kütüphaneyi gösterir. Kayıtlı istasyonları çalmaya ve dosyalardan istasyon içe aktarmaya devam edebilirsiniz.</string>
+
+    <!-- Browse - Offline Mode -->
+    <string name="browse_offline_mode_title">Çevrimdışı Mod</string>
+    <string name="browse_offline_mode_message">Harici API\'ler ayarlarda devre dışı. Kayıtlı istasyonlara erişmek için Kütüphane\'ye gidin veya çevrimiçi istasyonlara göz atmak için Ayarlar\'da API\'leri etkinleştirin.</string>
+    <string name="browse_radiobrowser_disabled">RadioBrowser API devre dışı</string>
+    <string name="browse_radioregistry_disabled">Gizlilik istasyonları API devre dışı</string>
+    <string name="browse_disabled_title">Gözat Devre Dışı</string>
+    <string name="browse_disabled_message">Hem RadioBrowser hem de Radio Registry API\'leri ayarlarda devre dışı. Çevrimiçi istasyonlara göz atmak için en az bir API\'yi etkinleştirin.</string>
+    <string name="browse_disabled_tip_title">Kayıtlı istasyonlarınız hâlâ çalışıyor</string>
+    <string name="browse_disabled_tip_message">Zaten kaydettiğiniz istasyonları çalmak için Kütüphane sekmesine gidin veya bir dosyadan istasyon içe aktarın.</string>
+    <string name="browse_privacy_only_title">Gizlilik Radyosu</string>
+    <string name="browse_privacy_only_message">RadioBrowser API devre dışı. Yalnızca Tor ve I2P istasyonları gösteriliyor.</string>
+    <string name="station_already_in_library">İstasyon zaten kütüphanenizde</string>
 </resources>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -649,4 +649,28 @@
     <string name="i2p_status_checking">Перевірка доступності I2P…</string>
     <string name="i2p_status_available">Проксі I2P доступний на %1$s:%2$d</string>
     <string name="i2p_status_unavailable">I2P не запущено</string>
+
+    <!-- Settings - Network & API -->
+    <string name="settings_network_api">Мережа та API</string>
+    <string name="settings_disable_radiobrowser_api">Вимкнути API RadioBrowser</string>
+    <string name="settings_disable_radiobrowser_api_description">Припинити отримання clearnet-станцій з RadioBrowser</string>
+    <string name="settings_disable_radio_registry_api">Вимкнути API Radio Registry</string>
+    <string name="settings_disable_radio_registry_api_description">Припинити отримання Tor/I2P-станцій з Radio Registry</string>
+    <string name="settings_disable_cover_art">Вимкнути обкладинки</string>
+    <string name="settings_disable_cover_art_description">Заборонити завантаження зображень станцій із зовнішніх серверів</string>
+    <string name="settings_network_api_info">Додаток підключається лише до: API RadioBrowser для clearnet-станцій, API Radio Registry для Tor/I2P-станцій, зовнішніх серверів для обкладинок та радіопотоків під час відтворення.</string>
+    <string name="settings_offline_mode_note">Обидва API вимкнено: вкладка «Огляд» показує лише локальну бібліотеку. Ви можете відтворювати збережені станції та імпортувати станції з файлів.</string>
+
+    <!-- Browse - Offline Mode -->
+    <string name="browse_offline_mode_title">Автономний режим</string>
+    <string name="browse_offline_mode_message">Зовнішні API вимкнено в налаштуваннях. Перейдіть до Бібліотеки для доступу до збережених станцій або увімкніть API в Налаштуваннях для перегляду онлайн-станцій.</string>
+    <string name="browse_radiobrowser_disabled">API RadioBrowser вимкнено</string>
+    <string name="browse_radioregistry_disabled">API станцій конфіденційності вимкнено</string>
+    <string name="browse_disabled_title">Огляд вимкнено</string>
+    <string name="browse_disabled_message">API RadioBrowser та Radio Registry вимкнено в налаштуваннях. Увімкніть хоча б один API для перегляду онлайн-станцій.</string>
+    <string name="browse_disabled_tip_title">Збережені станції все ще працюють</string>
+    <string name="browse_disabled_tip_message">Перейдіть на вкладку «Бібліотека» для відтворення вже збережених станцій або імпортуйте станції з файлу.</string>
+    <string name="browse_privacy_only_title">Приватне радіо</string>
+    <string name="browse_privacy_only_message">API RadioBrowser вимкнено. Відображаються лише Tor та I2P станції.</string>
+    <string name="station_already_in_library">Станція вже у вашій бібліотеці</string>
 </resources>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -649,4 +649,28 @@
     <string name="i2p_status_checking">Đang kiểm tra tính khả dụng của I2P…</string>
     <string name="i2p_status_available">Proxy I2P khả dụng tại %1$s:%2$d</string>
     <string name="i2p_status_unavailable">I2P không chạy</string>
+
+    <!-- Settings - Network & API -->
+    <string name="settings_network_api">Mạng và API</string>
+    <string name="settings_disable_radiobrowser_api">Tắt API RadioBrowser</string>
+    <string name="settings_disable_radiobrowser_api_description">Ngừng lấy các đài clearnet từ RadioBrowser</string>
+    <string name="settings_disable_radio_registry_api">Tắt API Radio Registry</string>
+    <string name="settings_disable_radio_registry_api_description">Ngừng lấy các đài Tor/I2P từ Radio Registry</string>
+    <string name="settings_disable_cover_art">Tắt ảnh bìa</string>
+    <string name="settings_disable_cover_art_description">Ngăn tải hình ảnh đài từ máy chủ bên ngoài</string>
+    <string name="settings_network_api_info">Ứng dụng chỉ kết nối với: API RadioBrowser cho các đài clearnet, API Radio Registry cho các đài Tor/I2P, máy chủ bên ngoài cho ảnh bìa và luồng radio khi phát.</string>
+    <string name="settings_offline_mode_note">Cả hai API đã tắt: Tab Duyệt chỉ hiển thị thư viện cục bộ. Bạn vẫn có thể phát các đài đã lưu và nhập đài từ tệp.</string>
+
+    <!-- Browse - Offline Mode -->
+    <string name="browse_offline_mode_title">Chế độ ngoại tuyến</string>
+    <string name="browse_offline_mode_message">Các API bên ngoài đã bị tắt trong cài đặt. Vào Thư viện để truy cập các đài đã lưu, hoặc bật API trong Cài đặt để duyệt các đài trực tuyến.</string>
+    <string name="browse_radiobrowser_disabled">API RadioBrowser đã tắt</string>
+    <string name="browse_radioregistry_disabled">API đài riêng tư đã tắt</string>
+    <string name="browse_disabled_title">Duyệt đã tắt</string>
+    <string name="browse_disabled_message">Cả API RadioBrowser và Radio Registry đều bị tắt trong cài đặt. Bật ít nhất một API để duyệt các đài trực tuyến.</string>
+    <string name="browse_disabled_tip_title">Các đài đã lưu vẫn hoạt động</string>
+    <string name="browse_disabled_tip_message">Vào tab Thư viện để phát các đài bạn đã lưu, hoặc nhập đài từ tệp.</string>
+    <string name="browse_privacy_only_title">Radio riêng tư</string>
+    <string name="browse_privacy_only_message">API RadioBrowser đã tắt. Chỉ hiển thị các đài Tor và I2P.</string>
+    <string name="station_already_in_library">Đài đã có trong thư viện của bạn</string>
 </resources>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -649,4 +649,28 @@
     <string name="i2p_status_checking">正在检查 I2P 可用性…</string>
     <string name="i2p_status_available">I2P 代理可用于 %1$s:%2$d</string>
     <string name="i2p_status_unavailable">I2P 未运行</string>
+
+    <!-- Settings - Network & API -->
+    <string name="settings_network_api">网络和 API</string>
+    <string name="settings_disable_radiobrowser_api">禁用 RadioBrowser API</string>
+    <string name="settings_disable_radiobrowser_api_description">停止从 RadioBrowser 获取明网电台</string>
+    <string name="settings_disable_radio_registry_api">禁用 Radio Registry API</string>
+    <string name="settings_disable_radio_registry_api_description">停止从 Radio Registry 获取 Tor/I2P 电台</string>
+    <string name="settings_disable_cover_art">禁用封面图片</string>
+    <string name="settings_disable_cover_art_description">阻止从外部服务器加载电台图片</string>
+    <string name="settings_network_api_info">应用仅连接到：用于明网电台的 RadioBrowser API、用于 Tor/I2P 电台的 Radio Registry API、用于封面的外部服务器以及播放时的广播流。</string>
+    <string name="settings_offline_mode_note">两个 API 均已禁用：浏览标签页仅显示本地库。您仍可以播放已保存的电台并从文件导入电台。</string>
+
+    <!-- Browse - Offline Mode -->
+    <string name="browse_offline_mode_title">离线模式</string>
+    <string name="browse_offline_mode_message">外部 API 已在设置中禁用。前往您的媒体库访问已保存的电台，或在设置中启用 API 以浏览在线电台。</string>
+    <string name="browse_radiobrowser_disabled">RadioBrowser API 已禁用</string>
+    <string name="browse_radioregistry_disabled">隐私电台 API 已禁用</string>
+    <string name="browse_disabled_title">浏览已禁用</string>
+    <string name="browse_disabled_message">RadioBrowser 和 Radio Registry API 均已在设置中禁用。请启用至少一个 API 以浏览在线电台。</string>
+    <string name="browse_disabled_tip_title">您保存的电台仍然有效</string>
+    <string name="browse_disabled_tip_message">前往媒体库标签页播放已保存的电台，或从文件导入电台。</string>
+    <string name="browse_privacy_only_title">隐私广播</string>
+    <string name="browse_privacy_only_message">RadioBrowser API 已禁用。仅显示 Tor 和 I2P 电台。</string>
+    <string name="station_already_in_library">电台已在您的媒体库中</string>
 </resources>


### PR DESCRIPTION
Add translations for Network & API section and browse offline mode strings across all 16 language files (ar, de, es, fa, fr, hi, it, ja, ko, my, pt, ru, tr, uk, vi, zh).

Strings added:
- Settings Network & API section (settings_network_api, settings_disable_radiobrowser_api, settings_disable_radio_registry_api, settings_disable_cover_art and descriptions)
- Browse offline mode messages (browse_offline_mode_title/message, browse_disabled_title/message, browse_privacy_only_title/message)
- station_already_in_library