### PR TITLE
Add translations for search_privacy_stations string

### DIFF
--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -72,6 +72,7 @@
     
     <string name="tab_browse">تصفح</string>
     <string name="search_radio_browser">البحث عن آلاف المحطات…</string>
+    <string name="search_privacy_stations">البحث في محطات الخصوصية…</string>
     <string name="browse_top_voted">الأكثر تصويتاً</string>
     <string name="browse_popular">شائعة</string>
     <string name="browse_random">عشوائية</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -72,6 +72,7 @@
     
     <string name="tab_browse">Entdecken</string>
     <string name="search_radio_browser">Tausende von Sendern durchsuchen…</string>
+    <string name="search_privacy_stations">Datenschutzstationen durchsuchen…</string>
     <string name="browse_top_voted">Am besten bewertet</string>
     <string name="browse_popular">Beliebt</string>
     <string name="browse_random">Zufällig</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -74,6 +74,7 @@
     
     <string name="tab_browse">Explorar</string>
     <string name="search_radio_browser">Buscar entre miles de estaciones…</string>
+    <string name="search_privacy_stations">Buscar estaciones de privacidad…</string>
     <string name="browse_top_voted">Más votadas</string>
     <string name="browse_popular">Populares</string>
     <string name="browse_random">Aleatorias</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -72,6 +72,7 @@
     
     <string name="tab_browse">مرور</string>
     <string name="search_radio_browser">جستجو در هزاران ایستگاه…</string>
+    <string name="search_privacy_stations">جستجوی ایستگاه‌های حریم خصوصی…</string>
     <string name="browse_top_voted">پررأی‌ترین</string>
     <string name="browse_popular">محبوب</string>
     <string name="browse_random">تصادفی</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -72,6 +72,7 @@
     
     <string name="tab_browse">Parcourir</string>
     <string name="search_radio_browser">Rechercher parmi des milliers de stations…</string>
+    <string name="search_privacy_stations">Rechercher des stations privées…</string>
     <string name="browse_top_voted">Les mieux notées</string>
     <string name="browse_popular">Populaires</string>
     <string name="browse_random">Aléatoire</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -72,6 +72,7 @@
     
     <string name="tab_browse">ब्राउज़ करें</string>
     <string name="search_radio_browser">हजारों स्टेशनों को खोजें…</string>
+    <string name="search_privacy_stations">गोपनीयता स्टेशन खोजें…</string>
     <string name="browse_top_voted">सबसे अधिक वोट वाले</string>
     <string name="browse_popular">लोकप्रिय</string>
     <string name="browse_random">यादृच्छिक</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -72,6 +72,7 @@
     
     <string name="tab_browse">Sfoglia</string>
     <string name="search_radio_browser">Cerca tra migliaia di stazioni…</string>
+    <string name="search_privacy_stations">Cerca stazioni privacy…</string>
     <string name="browse_top_voted">Più votate</string>
     <string name="browse_popular">Popolari</string>
     <string name="browse_random">Casuali</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -72,6 +72,7 @@
     
     <string name="tab_browse">閲覧</string>
     <string name="search_radio_browser">数千のステーションを検索…</string>
+    <string name="search_privacy_stations">プライバシーステーション検索…</string>
     <string name="browse_top_voted">最も投票されたステーション</string>
     <string name="browse_popular">人気</string>
     <string name="browse_random">ランダム</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -72,6 +72,7 @@
     
     <string name="tab_browse">탐색</string>
     <string name="search_radio_browser">수천 개의 방송국 검색…</string>
+    <string name="search_privacy_stations">프라이버시 스테이션 검색…</string>
     <string name="browse_top_voted">최다 투표</string>
     <string name="browse_popular">인기</string>
     <string name="browse_random">랜덤</string>

--- a/app/src/main/res/values-my/strings.xml
+++ b/app/src/main/res/values-my/strings.xml
@@ -72,6 +72,7 @@
     
     <string name="tab_browse">ရှာဖွေရန်</string>
     <string name="search_radio_browser">စတေးရှင်းထောင်ပေါင်းများစွာကို ရှာပါ…</string>
+    <string name="search_privacy_stations">ကိုယ်ရေးကိုယ်တာ ဘေးကင်းရေးစခန်းများကို ရှာဖွေရန်…</string>
     <string name="browse_top_voted">အများဆုံး မဲရသော</string>
     <string name="browse_popular">လူကြိုက်များသော</string>
     <string name="browse_random">ကျပန်း</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -72,6 +72,7 @@
     
     <string name="tab_browse">Explorar</string>
     <string name="search_radio_browser">Pesquisar milhares de estações…</string>
+    <string name="search_privacy_stations">Pesquisar estações de privacidade…</string>
     <string name="browse_top_voted">Mais votadas</string>
     <string name="browse_popular">Populares</string>
     <string name="browse_random">Aleatórias</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -72,6 +72,7 @@
     
     <string name="tab_browse">Обзор</string>
     <string name="search_radio_browser">Поиск среди тысяч станций…</string>
+    <string name="search_privacy_stations">Поиск станций приватности…</string>
     <string name="browse_top_voted">Самые популярные</string>
     <string name="browse_popular">Популярные</string>
     <string name="browse_random">Случайные</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -72,6 +72,7 @@
     
     <string name="tab_browse">Göz At</string>
     <string name="search_radio_browser">Binlerce istasyon ara…</string>
+    <string name="search_privacy_stations">Gizlilik istasyonlarını ara…</string>
     <string name="browse_top_voted">En Çok Oylanan</string>
     <string name="browse_popular">Popüler</string>
     <string name="browse_random">Rastgele</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -72,6 +72,7 @@
     
     <string name="tab_browse">Огляд</string>
     <string name="search_radio_browser">Пошук серед тисяч станцій…</string>
+    <string name="search_privacy_stations">Шукати станції конфіденційності…</string>
     <string name="browse_top_voted">Найпопулярніші</string>
     <string name="browse_popular">Популярні</string>
     <string name="browse_random">Випадкові</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -72,6 +72,7 @@
     
     <string name="tab_browse">Duyệt</string>
     <string name="search_radio_browser">Tìm kiếm hàng nghìn trạm…</string>
+    <string name="search_privacy_stations">Tìm kiếm đài riêng tư…</string>
     <string name="browse_top_voted">Nhiều bình chọn nhất</string>
     <string name="browse_popular">Phổ biến</string>
     <string name="browse_random">Ngẫu nhiên</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -72,6 +72,7 @@
     
     <string name="tab_browse">浏览</string>
     <string name="search_radio_browser">搜索数千个电台…</string>
+    <string name="search_privacy_stations">搜索隐私电台…</string>
     <string name="browse_top_voted">最多投票</string>
     <string name="browse_popular">热门</string>
     <string name="browse_random">随机</string>


### PR DESCRIPTION
Translate "Search privacy stations…" to all supported languages:
- Arabic, German, Spanish, Persian, French, Hindi, Italian
- Japanese, Korean, Burmese, Portuguese, Russian, Turkish
- Ukrainian, Vietnamese, Chinese

This ensures the privacy stations search field is properly localized across all app languages.