### PR TITLE
Fix privacy stations saving with wrong proxy type

### DIFF
--- a/app/src/main/java/com/opensource/i2pradio/ui/StationActionHelper.kt
+++ b/app/src/main/java/com/opensource/i2pradio/ui/StationActionHelper.kt
@@ -261,7 +261,11 @@ object StationActionHelper {
             clicktrend = 0,
             sslError = false,
             geoLat = null,
-            geoLong = null
+            geoLong = null,
+            useProxy = station.useProxy,
+            proxyType = station.proxyType,
+            proxyHost = station.proxyHost,
+            proxyPort = station.proxyPort
         )
     }
 


### PR DESCRIPTION
When saving Tor/I2P privacy stations from browse fragments to the local library, the proxy type was incorrectly saved as "NONE" instead of preserving the original "TOR" or "I2P" type.

The issue was in StationActionHelper.convertToRadioBrowserStation() which converts RadioStation back to RadioBrowserStation for saving. This method was missing the proxy-related fields (useProxy, proxyType, proxyHost, proxyPort), so they defaulted to false/"NONE"/""/ 0.

Added the four proxy fields to the conversion to preserve the original proxy settings when saving privacy stations.