### PR TITLE
Add sleep timer translations to all 16 languages

### DIFF
--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -238,6 +238,11 @@
     <string name="settings_sleep_timer_45min">45 دقيقة</string>
     <string name="settings_sleep_timer_60min">60 دقيقة</string>
     <string name="settings_sleep_timer_90min">90 دقيقة</string>
+    <string name="settings_sleep_timer_enable">تفعيل مؤقت النوم</string>
+    <string name="settings_sleep_timer_min">1 دقيقة</string>
+    <string name="settings_sleep_timer_max">12 ساعة</string>
+    <string name="settings_sleep_timer_presets">إعدادات سريعة</string>
+    <string name="settings_sleep_timer_precision_hint">اضغط مطولاً على شريط التمرير للتكبير</string>
     <string name="settings_equalizer_description">ضبط نطاقات تردد الصوت والتأثيرات</string>
     <string name="settings_recording_directory">دليل التسجيل</string>
     <string name="settings_recording_directory_default">افتراضي (Music/deutsia_radio)</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -238,6 +238,11 @@
     <string name="settings_sleep_timer_45min">45 Minuten</string>
     <string name="settings_sleep_timer_60min">60 Minuten</string>
     <string name="settings_sleep_timer_90min">90 Minuten</string>
+    <string name="settings_sleep_timer_enable">Sleep-Timer aktivieren</string>
+    <string name="settings_sleep_timer_min">1 Min.</string>
+    <string name="settings_sleep_timer_max">12 Stunden</string>
+    <string name="settings_sleep_timer_presets">Schnellauswahl</string>
+    <string name="settings_sleep_timer_precision_hint">Schieberegler halten zum Zoomen</string>
     <string name="settings_equalizer_description">Audiofrequenzbänder und Effekte anpassen</string>
     <string name="settings_recording_directory">Aufnahmeverzeichnis</string>
     <string name="settings_recording_directory_default">Standard (Music/deutsia_radio)</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -242,6 +242,11 @@
     <string name="settings_sleep_timer_45min">45 minutos</string>
     <string name="settings_sleep_timer_60min">60 minutos</string>
     <string name="settings_sleep_timer_90min">90 minutos</string>
+    <string name="settings_sleep_timer_enable">Activar temporizador de sueño</string>
+    <string name="settings_sleep_timer_min">1 min</string>
+    <string name="settings_sleep_timer_max">12 horas</string>
+    <string name="settings_sleep_timer_presets">Ajustes rápidos</string>
+    <string name="settings_sleep_timer_precision_hint">Mantén presionado el control para ampliar</string>
     <string name="settings_equalizer_description">Ajustar bandas de frecuencia de audio y efectos</string>
     <string name="settings_recording_directory">Directorio de grabación</string>
     <string name="settings_recording_directory_default">Predeterminado (Music/deutsia_radio)</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -238,6 +238,11 @@
     <string name="settings_sleep_timer_45min">۴۵ دقیقه</string>
     <string name="settings_sleep_timer_60min">۶۰ دقیقه</string>
     <string name="settings_sleep_timer_90min">۹۰ دقیقه</string>
+    <string name="settings_sleep_timer_enable">فعال کردن تایمر خواب</string>
+    <string name="settings_sleep_timer_min">۱ دقیقه</string>
+    <string name="settings_sleep_timer_max">۱۲ ساعت</string>
+    <string name="settings_sleep_timer_presets">تنظیمات سریع</string>
+    <string name="settings_sleep_timer_precision_hint">نوار لغزنده را نگه دارید تا بزرگنمایی شود</string>
     <string name="settings_equalizer_description">تنظیم باندهای فرکانس صدا و جلوه‌ها</string>
     <string name="settings_recording_directory">پوشه ضبط</string>
     <string name="settings_recording_directory_default">پیش‌فرض (Music/deutsia_radio)</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -238,6 +238,11 @@
     <string name="settings_sleep_timer_45min">45 minutes</string>
     <string name="settings_sleep_timer_60min">60 minutes</string>
     <string name="settings_sleep_timer_90min">90 minutes</string>
+    <string name="settings_sleep_timer_enable">Activer la minuterie de sommeil</string>
+    <string name="settings_sleep_timer_min">1 min</string>
+    <string name="settings_sleep_timer_max">12 heures</string>
+    <string name="settings_sleep_timer_presets">Préréglages rapides</string>
+    <string name="settings_sleep_timer_precision_hint">Maintenir le curseur pour zoomer</string>
     <string name="settings_equalizer_description">Ajuster les bandes de fréquence audio et les effets</string>
     <string name="settings_recording_directory">Répertoire d\'enregistrement</string>
     <string name="settings_recording_directory_default">Par défaut (Musique/deutsia_radio)</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -238,6 +238,11 @@
     <string name="settings_sleep_timer_45min">45 मिनट</string>
     <string name="settings_sleep_timer_60min">60 मिनट</string>
     <string name="settings_sleep_timer_90min">90 मिनट</string>
+    <string name="settings_sleep_timer_enable">स्लीप टाइमर सक्षम करें</string>
+    <string name="settings_sleep_timer_min">1 मिनट</string>
+    <string name="settings_sleep_timer_max">12 घंटे</string>
+    <string name="settings_sleep_timer_presets">त्वरित प्रीसेट</string>
+    <string name="settings_sleep_timer_precision_hint">ज़ूम करने के लिए स्लाइडर को दबाए रखें</string>
     <string name="settings_equalizer_description">ऑडियो फ़्रीक्वेंसी बैंड और प्रभाव समायोजित करें</string>
     <string name="settings_recording_directory">रिकॉर्डिंग निर्देशिका</string>
     <string name="settings_recording_directory_default">डिफ़ॉल्ट (संगीत/deutsia_radio)</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -238,6 +238,11 @@
     <string name="settings_sleep_timer_45min">45 minuti</string>
     <string name="settings_sleep_timer_60min">60 minuti</string>
     <string name="settings_sleep_timer_90min">90 minuti</string>
+    <string name="settings_sleep_timer_enable">Attiva timer di spegnimento</string>
+    <string name="settings_sleep_timer_min">1 min</string>
+    <string name="settings_sleep_timer_max">12 ore</string>
+    <string name="settings_sleep_timer_presets">Preimpostazioni rapide</string>
+    <string name="settings_sleep_timer_precision_hint">Tieni premuto il cursore per ingrandire</string>
     <string name="settings_equalizer_description">Regola bande di frequenza audio ed effetti</string>
     <string name="settings_recording_directory">Directory di registrazione</string>
     <string name="settings_recording_directory_default">Predefinita (Musica/deutsia_radio)</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -238,6 +238,11 @@
     <string name="settings_sleep_timer_45min">45分</string>
     <string name="settings_sleep_timer_60min">60分</string>
     <string name="settings_sleep_timer_90min">90分</string>
+    <string name="settings_sleep_timer_enable">スリープタイマーを有効化</string>
+    <string name="settings_sleep_timer_min">1分</string>
+    <string name="settings_sleep_timer_max">12時間</string>
+    <string name="settings_sleep_timer_presets">クイックプリセット</string>
+    <string name="settings_sleep_timer_precision_hint">拡大するにはスライダーを長押し</string>
     <string name="settings_equalizer_description">オーディオ周波数帯とエフェクトを調整</string>
     <string name="settings_recording_directory">録音ディレクトリ</string>
     <string name="settings_recording_directory_default">デフォルト（Music/deutsia_radio）</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -238,6 +238,11 @@
     <string name="settings_sleep_timer_45min">45분</string>
     <string name="settings_sleep_timer_60min">60분</string>
     <string name="settings_sleep_timer_90min">90분</string>
+    <string name="settings_sleep_timer_enable">취침 타이머 활성화</string>
+    <string name="settings_sleep_timer_min">1분</string>
+    <string name="settings_sleep_timer_max">12시간</string>
+    <string name="settings_sleep_timer_presets">빠른 프리셋</string>
+    <string name="settings_sleep_timer_precision_hint">확대하려면 슬라이더를 길게 누르세요</string>
     <string name="settings_equalizer_description">오디오 주파수 대역 및 효과 조정</string>
     <string name="settings_recording_directory">녹음 디렉토리</string>
     <string name="settings_recording_directory_default">기본값 (Music/deutsia_radio)</string>

--- a/app/src/main/res/values-my/strings.xml
+++ b/app/src/main/res/values-my/strings.xml
@@ -238,6 +238,11 @@
     <string name="settings_sleep_timer_45min">၄၅ မိနစ်</string>
     <string name="settings_sleep_timer_60min">၆၀ မိနစ်</string>
     <string name="settings_sleep_timer_90min">၉၀ မိနစ်</string>
+    <string name="settings_sleep_timer_enable">အိပ်စက်ချိန်သတ်မှတ်ခြင်း ဖွင့်ပါ</string>
+    <string name="settings_sleep_timer_min">၁ မိနစ်</string>
+    <string name="settings_sleep_timer_max">၁၂ နာရီ</string>
+    <string name="settings_sleep_timer_presets">အမြန်ကြိုတင်သတ်မှတ်မှုများ</string>
+    <string name="settings_sleep_timer_precision_hint">ချဲ့ရန် slider ကို ဖိထားပါ</string>
     <string name="settings_equalizer_description">အသံ ကြိမ်နှုန်း ဘန်းများနှင့် အကျိုးသက်ရောက်မှုများကို ညှိပါ</string>
     <string name="settings_recording_directory">ရိုက်ကူးမှု ဖိုင်တွဲ</string>
     <string name="settings_recording_directory_default">မူလ (Music/deutsia_radio)</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -238,6 +238,11 @@
     <string name="settings_sleep_timer_45min">45 minutos</string>
     <string name="settings_sleep_timer_60min">60 minutos</string>
     <string name="settings_sleep_timer_90min">90 minutos</string>
+    <string name="settings_sleep_timer_enable">Ativar temporizador de sono</string>
+    <string name="settings_sleep_timer_min">1 min</string>
+    <string name="settings_sleep_timer_max">12 horas</string>
+    <string name="settings_sleep_timer_presets">Predefinições rápidas</string>
+    <string name="settings_sleep_timer_precision_hint">Segure o controle para ampliar</string>
     <string name="settings_equalizer_description">Ajustar bandas de frequência de áudio e efeitos</string>
     <string name="settings_recording_directory">Diretório de gravação</string>
     <string name="settings_recording_directory_default">Padrão (Music/deutsia_radio)</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -238,6 +238,11 @@
     <string name="settings_sleep_timer_45min">45 минут</string>
     <string name="settings_sleep_timer_60min">60 минут</string>
     <string name="settings_sleep_timer_90min">90 минут</string>
+    <string name="settings_sleep_timer_enable">Включить таймер сна</string>
+    <string name="settings_sleep_timer_min">1 мин</string>
+    <string name="settings_sleep_timer_max">12 часов</string>
+    <string name="settings_sleep_timer_presets">Быстрые настройки</string>
+    <string name="settings_sleep_timer_precision_hint">Удерживайте ползунок для увеличения</string>
     <string name="settings_equalizer_description">Настройка частотных полос и эффектов</string>
     <string name="settings_recording_directory">Каталог записей</string>
     <string name="settings_recording_directory_default">По умолчанию (Music/deutsia_radio)</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -238,6 +238,11 @@
     <string name="settings_sleep_timer_45min">45 dakika</string>
     <string name="settings_sleep_timer_60min">60 dakika</string>
     <string name="settings_sleep_timer_90min">90 dakika</string>
+    <string name="settings_sleep_timer_enable">Uyku Zamanlayıcısını Etkinleştir</string>
+    <string name="settings_sleep_timer_min">1 dk</string>
+    <string name="settings_sleep_timer_max">12 saat</string>
+    <string name="settings_sleep_timer_presets">Hızlı ön ayarlar</string>
+    <string name="settings_sleep_timer_precision_hint">Yakınlaştırmak için kaydırıcıyı basılı tutun</string>
     <string name="settings_equalizer_description">Ses frekans bantlarını ve efektleri ayarla</string>
     <string name="settings_recording_directory">Kayıt Dizini</string>
     <string name="settings_recording_directory_default">Varsayılan (Music/deutsia_radio)</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -238,6 +238,11 @@
     <string name="settings_sleep_timer_45min">45 хвилин</string>
     <string name="settings_sleep_timer_60min">60 хвилин</string>
     <string name="settings_sleep_timer_90min">90 хвилин</string>
+    <string name="settings_sleep_timer_enable">Увімкнути таймер сну</string>
+    <string name="settings_sleep_timer_min">1 хв</string>
+    <string name="settings_sleep_timer_max">12 годин</string>
+    <string name="settings_sleep_timer_presets">Швидкі налаштування</string>
+    <string name="settings_sleep_timer_precision_hint">Утримуйте повзунок для збільшення</string>
     <string name="settings_equalizer_description">Налаштування частотних смуг та ефектів</string>
     <string name="settings_recording_directory">Каталог записів</string>
     <string name="settings_recording_directory_default">За замовчуванням (Music/deutsia_radio)</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -238,6 +238,11 @@
     <string name="settings_sleep_timer_45min">45 phút</string>
     <string name="settings_sleep_timer_60min">60 phút</string>
     <string name="settings_sleep_timer_90min">90 phút</string>
+    <string name="settings_sleep_timer_enable">Bật hẹn giờ ngủ</string>
+    <string name="settings_sleep_timer_min">1 phút</string>
+    <string name="settings_sleep_timer_max">12 giờ</string>
+    <string name="settings_sleep_timer_presets">Cài đặt nhanh</string>
+    <string name="settings_sleep_timer_precision_hint">Giữ thanh trượt để phóng to</string>
     <string name="settings_equalizer_description">Điều chỉnh dải tần âm thanh và hiệu ứng</string>
     <string name="settings_recording_directory">Thư mục ghi</string>
     <string name="settings_recording_directory_default">Mặc định (Music/deutsia_radio)</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -238,6 +238,11 @@
     <string name="settings_sleep_timer_45min">45分钟</string>
     <string name="settings_sleep_timer_60min">60分钟</string>
     <string name="settings_sleep_timer_90min">90分钟</string>
+    <string name="settings_sleep_timer_enable">启用睡眠定时器</string>
+    <string name="settings_sleep_timer_min">1 分钟</string>
+    <string name="settings_sleep_timer_max">12 小时</string>
+    <string name="settings_sleep_timer_presets">快速预设</string>
+    <string name="settings_sleep_timer_precision_hint">长按滑块以放大</string>
     <string name="settings_equalizer_description">调整音频频段和效果</string>
     <string name="settings_recording_directory">录制目录</string>
     <string name="settings_recording_directory_default">默认（Music/deutsia_radio）</string>


### PR DESCRIPTION
Adds 5 missing sleep timer strings to all localized strings.xml files:
- settings_sleep_timer_enable
- settings_sleep_timer_min
- settings_sleep_timer_max
- settings_sleep_timer_presets
- settings_sleep_timer_precision_hint
