### PR TITLE
Fix toolbar drawing behind status bar on Android 15 (targetSdk 35)

### DIFF
--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -3,6 +3,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:fitsSystemWindows="true"
     android:background="?attr/colorSurface">
 
     <com.google.android.material.appbar.AppBarLayout


### PR DESCRIPTION
The compileSdk/targetSdk bump to 35 enabled Android 15's enforced edge-to-edge mode, causing the toolbar and tor status button to render behind the system status bar. Add fitsSystemWindows="true" to the root CoordinatorLayout so it properly pads below the status bar.
