### PR TITLE
Fix header colors: use colorPrimary for AppBarLayout background

### DIFF
--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -10,7 +10,8 @@
         android:id="@+id/appBarLayout"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:background="?attr/colorSurface"
+        android:fitsSystemWindows="true"
+        android:background="?attr/colorPrimary"
         app:elevation="0dp">
 
         <com.google.android.material.appbar.MaterialToolbar
@@ -18,7 +19,7 @@
             android:layout_width="match_parent"
             android:layout_height="?attr/actionBarSize"
             app:title="@string/app_name"
-            app:titleTextColor="?attr/colorOnSurface">
+            app:titleTextColor="?attr/colorOnPrimary">
 
             <!-- Tor Status Indicator in Toolbar -->
             <com.opensource.i2pradio.ui.TorStatusView
@@ -46,9 +47,9 @@
             app:tabMode="fixed"
             app:tabGravity="fill"
             app:tabIndicatorFullWidth="false"
-            app:tabIndicatorColor="?attr/colorPrimary"
-            app:tabSelectedTextColor="?attr/colorPrimary"
-            app:tabTextColor="?attr/colorOnSurfaceVariant" />
+            app:tabIndicatorColor="?attr/colorOnPrimary"
+            app:tabSelectedTextColor="?attr/colorOnPrimary"
+            app:tabTextColor="?attr/colorOnPrimary" />
 
     </com.google.android.material.appbar.AppBarLayout>
 


### PR DESCRIPTION
The AppBarLayout was using colorSurface (dark) instead of colorPrimary for its background, causing the header (toolbar + tabs + status bar area) to blend with the content area instead of showing the theme's primary color.

Changes:
- AppBarLayout background: colorSurface -> colorPrimary
- AppBarLayout: add fitsSystemWindows so it extends behind status bar and its colored background shows through the transparent status bar
- Toolbar title: colorOnSurface -> colorOnPrimary
- Tab text/indicator: use colorOnPrimary for contrast on colored header
