### PR TITLE
Revert compileSdk/targetSdk to 34 and undo SDK 35 UI fixes

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -9,12 +9,12 @@ plugins {
 
 android {
     namespace = "com.opensource.i2pradio"
-    compileSdk = 35
+    compileSdk = 34
 
     defaultConfig {
         applicationId = "com.opensource.i2pradio"
         minSdk = 24
-        targetSdk = 35
+        targetSdk = 34
         versionCode = 10604
         versionName = "1.6.4"
     }

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -3,15 +3,13 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:fitsSystemWindows="true"
     android:background="?attr/colorSurface">
 
     <com.google.android.material.appbar.AppBarLayout
         android:id="@+id/appBarLayout"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:fitsSystemWindows="true"
-        android:background="?attr/colorPrimary"
+        android:background="?attr/colorSurface"
         app:elevation="0dp">
 
         <com.google.android.material.appbar.MaterialToolbar
@@ -19,7 +17,7 @@
             android:layout_width="match_parent"
             android:layout_height="?attr/actionBarSize"
             app:title="@string/app_name"
-            app:titleTextColor="?attr/colorOnPrimary">
+            app:titleTextColor="?attr/colorOnSurface">
 
             <!-- Tor Status Indicator in Toolbar -->
             <com.opensource.i2pradio.ui.TorStatusView
@@ -47,9 +45,9 @@
             app:tabMode="fixed"
             app:tabGravity="fill"
             app:tabIndicatorFullWidth="false"
-            app:tabIndicatorColor="?attr/colorOnPrimary"
-            app:tabSelectedTextColor="?attr/colorOnPrimary"
-            app:tabTextColor="?attr/colorOnPrimary" />
+            app:tabIndicatorColor="?attr/colorPrimary"
+            app:tabSelectedTextColor="?attr/colorPrimary"
+            app:tabTextColor="?attr/colorOnSurfaceVariant" />
 
     </com.google.android.material.appbar.AppBarLayout>
 


### PR DESCRIPTION
The bump to SDK 35 enforced Android 15 edge-to-edge mode which broke the header layout and theme colors. Rather than patching around those issues, revert to SDK 34 where the UI works correctly out of the box.

- compileSdk/targetSdk: 35 -> 34
- activity_main.xml: remove fitsSystemWindows, restore original colorSurface/colorOnSurface header colors and tab styling

The Tor API .onion-to-clearnet fallback is preserved as-is.

https://claude.ai/code/session_01TD3J1NGKteqDRX76ex6dVb