### PR TITLE
Fix genre display in radio registry browse showing network prefix

### DIFF
--- a/app/src/main/java/com/opensource/i2pradio/data/radioregistry/RadioRegistryStation.kt
+++ b/app/src/main/java/com/opensource/i2pradio/data/radioregistry/RadioRegistryStation.kt
@@ -108,7 +108,7 @@ data class RadioRegistryStation(
      * Get the genre string with network indicator suffix
      */
     fun getGenreWithNetwork(): String {
-        val genreText = genre ?: "Other"
+        val genreText = getPrimaryGenre()
         val networkIndicator = if (isTorStation) "Tor" else if (isI2pStation) "I2P" else null
         return if (networkIndicator != null && genreText.isNotEmpty() && genreText != "Other") {
             "$genreText · $networkIndicator"
@@ -120,9 +120,18 @@ data class RadioRegistryStation(
     }
 
     /**
-     * Get the primary genre (without network indicator)
+     * Get the primary genre (without network indicator).
+     * Strips network tags (I2P, Tor) from the genre string since the API
+     * may include them as a prefix (e.g., "I2P,Electronic").
      */
-    fun getPrimaryGenre(): String = genre ?: "Other"
+    fun getPrimaryGenre(): String {
+        val genreText = genre ?: return "Other"
+        val networkTags = setOf("i2p", "tor")
+        val parts = genreText.split(",")
+            .map { it.trim() }
+            .filter { it.isNotEmpty() && it.lowercase() !in networkTags }
+        return parts.firstOrNull() ?: "Other"
+    }
 
     /**
      * Get network indicator (Tor or I2P)


### PR DESCRIPTION
The Radio Registry API genre field contains the network name as a prefix (e.g., "I2P,Electronic"). getPrimaryGenre() returned this raw value and getGenreWithNetwork() also used the raw genre field, resulting in display like "I2P,Electronic · I2P" instead of "Electronic · I2P".

Fix by stripping network tags (I2P, Tor) in getPrimaryGenre() and using getPrimaryGenre() in getGenreWithNetwork(), matching RadioBrowserStation behavior.
