### PR TITLE
Fix placeholder cover art icon appearing small in mini player and now…

### DIFF
--- a/app/src/main/java/com/opensource/i2pradio/ui/MiniPlayerView.kt
+++ b/app/src/main/java/com/opensource/i2pradio/ui/MiniPlayerView.kt
@@ -116,8 +116,8 @@ class MiniPlayerView @JvmOverloads constructor(
      */
     fun updateCoverArt(coverArtUri: String?) {
         if (coverArtUri != null) {
-            // Start with centerInside for placeholder, switch to centerCrop only on successful load
-            coverImage.scaleType = ImageView.ScaleType.CENTER_INSIDE
+            // Start with fitCenter for placeholder (scales vector up to fill container), switch to centerCrop on successful load
+            coverImage.scaleType = ImageView.ScaleType.FIT_CENTER
             // Use privacy loader for Tor/I2P stations to route cover art through Tor
             val isPrivacyStation = currentStation?.getProxyTypeEnum().let {
                 it == ProxyType.TOR || it == ProxyType.I2P
@@ -131,16 +131,16 @@ class MiniPlayerView @JvmOverloads constructor(
                 error(R.drawable.ic_radio)
                 listener(
                     onStart = {
-                        // Ensure centerInside during placeholder phase
-                        coverImage.scaleType = ImageView.ScaleType.CENTER_INSIDE
+                        // Ensure fitCenter during placeholder phase so vector icon fills container
+                        coverImage.scaleType = ImageView.ScaleType.FIT_CENTER
                     },
                     onSuccess = { _, _ ->
                         // Real bitmap loaded - use centerCrop for best appearance
                         coverImage.scaleType = ImageView.ScaleType.CENTER_CROP
                     },
                     onError = { _, _ ->
-                        // Error loading - keep centerInside for vector placeholder
-                        coverImage.scaleType = ImageView.ScaleType.CENTER_INSIDE
+                        // Error loading - use fitCenter so vector placeholder fills container
+                        coverImage.scaleType = ImageView.ScaleType.FIT_CENTER
                     }
                 )
             }
@@ -150,8 +150,8 @@ class MiniPlayerView @JvmOverloads constructor(
                 coverImage.loadSecure(coverArtUri, imageLoadBuilder)
             }
         } else {
-            // No cover art - use centerInside for vector placeholder
-            coverImage.scaleType = ImageView.ScaleType.CENTER_INSIDE
+            // No cover art - use fitCenter so vector placeholder fills container
+            coverImage.scaleType = ImageView.ScaleType.FIT_CENTER
             // Force reload to get fresh drawable with current theme colors (Material You)
             coverImage.setImageDrawable(null)
             coverImage.load(R.drawable.ic_radio) {
@@ -215,8 +215,8 @@ class MiniPlayerView @JvmOverloads constructor(
         // Use loadSecure to route remote URLs through Tor when Force Tor is enabled
         // For privacy stations (Tor/I2P), use loadSecurePrivacy to route through Tor when available
         if (station.coverArtUri != null) {
-            // Start with centerInside for placeholder, switch to centerCrop only on successful load
-            coverImage.scaleType = ImageView.ScaleType.CENTER_INSIDE
+            // Start with fitCenter for placeholder (scales vector up to fill container), switch to centerCrop on successful load
+            coverImage.scaleType = ImageView.ScaleType.FIT_CENTER
             val isPrivacyStation = station.getProxyTypeEnum().let {
                 it == ProxyType.TOR || it == ProxyType.I2P
             }
@@ -226,16 +226,16 @@ class MiniPlayerView @JvmOverloads constructor(
                 error(R.drawable.ic_radio)
                 listener(
                     onStart = {
-                        // Ensure centerInside during placeholder phase
-                        coverImage.scaleType = ImageView.ScaleType.CENTER_INSIDE
+                        // Ensure fitCenter during placeholder phase so vector icon fills container
+                        coverImage.scaleType = ImageView.ScaleType.FIT_CENTER
                     },
                     onSuccess = { _, _ ->
                         // Real bitmap loaded - use centerCrop for best appearance
                         coverImage.scaleType = ImageView.ScaleType.CENTER_CROP
                     },
                     onError = { _, _ ->
-                        // Error loading - keep centerInside for vector placeholder
-                        coverImage.scaleType = ImageView.ScaleType.CENTER_INSIDE
+                        // Error loading - use fitCenter so vector placeholder fills container
+                        coverImage.scaleType = ImageView.ScaleType.FIT_CENTER
                     }
                 )
             }
@@ -245,8 +245,8 @@ class MiniPlayerView @JvmOverloads constructor(
                 coverImage.loadSecure(station.coverArtUri, imageLoadBuilder)
             }
         } else {
-            // No cover art - use centerInside for vector placeholder
-            coverImage.scaleType = ImageView.ScaleType.CENTER_INSIDE
+            // No cover art - use fitCenter so vector placeholder fills container
+            coverImage.scaleType = ImageView.ScaleType.FIT_CENTER
             // Explicitly clear any cached/loading state and set default drawable
             // Force reload to get fresh drawable with current theme colors (Material You)
             coverImage.setImageDrawable(null)

--- a/app/src/main/java/com/opensource/i2pradio/ui/NowPlayingFragment.kt
+++ b/app/src/main/java/com/opensource/i2pradio/ui/NowPlayingFragment.kt
@@ -647,8 +647,8 @@ class NowPlayingFragment : Fragment() {
                 // Use loadSecure to route remote URLs through Tor when Force Tor is enabled
                 // For privacy stations (Tor/I2P), use loadSecurePrivacy to route through Tor when available
                 if (station.coverArtUri != null) {
-                    // Start with centerInside for placeholder, switch to centerCrop only on successful load
-                    coverArt.scaleType = ImageView.ScaleType.CENTER_INSIDE
+                    // Start with fitCenter for placeholder (scales vector up to fill container), switch to centerCrop on successful load
+                    coverArt.scaleType = ImageView.ScaleType.FIT_CENTER
                     val isPrivacyStation = station.getProxyTypeEnum().let {
                         it == ProxyType.TOR || it == ProxyType.I2P
                     }
@@ -659,16 +659,16 @@ class NowPlayingFragment : Fragment() {
                         error(R.drawable.ic_radio)
                         listener(
                             onStart = {
-                                // Ensure centerInside during placeholder phase
-                                coverArt.scaleType = ImageView.ScaleType.CENTER_INSIDE
+                                // Ensure fitCenter during placeholder phase so vector icon fills container
+                                coverArt.scaleType = ImageView.ScaleType.FIT_CENTER
                             },
                             onSuccess = { _, _ ->
                                 // Real bitmap loaded - use centerCrop for best appearance
                                 coverArt.scaleType = ImageView.ScaleType.CENTER_CROP
                             },
                             onError = { _, _ ->
-                                // Error loading - keep centerInside for vector placeholder
-                                coverArt.scaleType = ImageView.ScaleType.CENTER_INSIDE
+                                // Error loading - use fitCenter so vector placeholder fills container
+                                coverArt.scaleType = ImageView.ScaleType.FIT_CENTER
                             }
                         )
                     }
@@ -678,8 +678,8 @@ class NowPlayingFragment : Fragment() {
                         coverArt.loadSecure(station.coverArtUri, imageLoadBuilder)
                     }
                 } else {
-                    // No cover art - use centerInside for vector placeholder and force reload
-                    coverArt.scaleType = ImageView.ScaleType.CENTER_INSIDE
+                    // No cover art - use fitCenter so vector placeholder fills container
+                    coverArt.scaleType = ImageView.ScaleType.FIT_CENTER
                     // Force reload to get fresh drawable with current theme colors (Material You)
                     coverArt.setImageDrawable(null)
                     coverArt.load(R.drawable.ic_radio) {
@@ -1137,8 +1137,8 @@ class NowPlayingFragment : Fragment() {
      */
     private fun updateCoverArt(coverArtUri: String?) {
         if (coverArtUri != null) {
-            // Start with centerInside for placeholder, switch to centerCrop only on successful load
-            coverArt.scaleType = ImageView.ScaleType.CENTER_INSIDE
+            // Start with fitCenter for placeholder (scales vector up to fill container), switch to centerCrop on successful load
+            coverArt.scaleType = ImageView.ScaleType.FIT_CENTER
             // Check if current station is a privacy station (Tor/I2P)
             val isPrivacyStation = viewModel.currentStation.value?.getProxyTypeEnum().let {
                 it == ProxyType.TOR || it == ProxyType.I2P
@@ -1152,16 +1152,16 @@ class NowPlayingFragment : Fragment() {
                 error(R.drawable.ic_radio)
                 listener(
                     onStart = {
-                        // Ensure centerInside during placeholder phase
-                        coverArt.scaleType = ImageView.ScaleType.CENTER_INSIDE
+                        // Ensure fitCenter during placeholder phase so vector icon fills container
+                        coverArt.scaleType = ImageView.ScaleType.FIT_CENTER
                     },
                     onSuccess = { _, _ ->
                         // Real bitmap loaded - use centerCrop for best appearance
                         coverArt.scaleType = ImageView.ScaleType.CENTER_CROP
                     },
                     onError = { _, _ ->
-                        // Error loading - keep centerInside for vector placeholder
-                        coverArt.scaleType = ImageView.ScaleType.CENTER_INSIDE
+                        // Error loading - use fitCenter so vector placeholder fills container
+                        coverArt.scaleType = ImageView.ScaleType.FIT_CENTER
                     }
                 )
             }
@@ -1171,7 +1171,7 @@ class NowPlayingFragment : Fragment() {
                 coverArt.loadSecure(coverArtUri, imageLoadBuilder)
             }
         } else {
-            coverArt.scaleType = ImageView.ScaleType.CENTER_INSIDE
+            coverArt.scaleType = ImageView.ScaleType.FIT_CENTER
             coverArt.load(R.drawable.ic_radio) {
                 crossfade(true)
             }


### PR DESCRIPTION
… playing

The ic_radio vector (24dp) was rendered at native size inside larger containers (52dp mini player, up to 320dp now playing) because CENTER_INSIDE doesn't scale up. Changed to FIT_CENTER which scales vectors up to fill the container cleanly.

https://claude.ai/code/session_01SnhysNHfWpD56PtaKBgdkS