### PR TITLE
Fix HlsRecorder losing segments on transient network errors

### DIFF
--- a/app/src/main/java/com/opensource/i2pradio/HlsRecorder.kt
+++ b/app/src/main/java/com/opensource/i2pradio/HlsRecorder.kt
@@ -4,6 +4,7 @@ import okhttp3.Call
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import java.io.BufferedOutputStream
+import java.io.ByteArrayOutputStream
 import java.io.IOException
 import java.net.URI
 import java.util.concurrent.atomic.AtomicBoolean
@@ -131,9 +132,12 @@ class HlsRecorder(
 
                     val segmentUrl = resolveUrl(mediaPlaylistUrl, segmentUri)
                     try {
-                        val bytes = downloadSegment(client, segmentUrl, outputStream)
+                        val segmentBuffer = ByteArrayOutputStream()
+                        val bytes = downloadSegment(client, segmentUrl, segmentBuffer)
+                        segmentBuffer.writeTo(outputStream)
                         totalBytesWritten += bytes
                         newSegmentsDownloaded++
+                        downloadedSegmentKeys.add(key)
                         onProgress(totalBytesWritten)
 
                         if (totalBytesWritten - lastFlushBytes >= flushInterval) {
@@ -149,8 +153,6 @@ class HlsRecorder(
                             android.util.Log.w(TAG, "Segment download failed: ${e.message}")
                         }
                     }
-
-                    downloadedSegmentKeys.add(key)
                     if (downloadedSegmentKeys.size > MAX_DEDUP_CACHE_SIZE) {
                         val iter = downloadedSegmentKeys.iterator()
                         val toRemove = downloadedSegmentKeys.size - MAX_DEDUP_CACHE_SIZE
@@ -226,7 +228,7 @@ class HlsRecorder(
     private fun downloadSegment(
         client: OkHttpClient,
         url: String,
-        outputStream: BufferedOutputStream,
+        outputStream: java.io.OutputStream,
     ): Long {
         val request = Request.Builder()
             .url(url)


### PR DESCRIPTION
Two bugs fixed:

1. downloadedSegmentKeys.add(key) was outside the try block, so a failed segment download still marked the key as "downloaded". On the next playlist poll the segment was skipped permanently. Fix: move the add() inside the try block so it only runs on success.

2. downloadSegment() streamed directly to the output file. An IOException mid-transfer left partial bytes in the output, corrupting the container. Fix: buffer each segment into a ByteArrayOutputStream first, then write atomically to the output stream only on success.

https://claude.ai/code/session_01MmKHR4sb61FVtNAu5uZQJv