### PR TITLE
show default radio icon when cover art is disabled

### DIFF
--- a/app/src/main/java/com/opensource/i2pradio/ui/MiniPlayerView.kt
+++ b/app/src/main/java/com/opensource/i2pradio/ui/MiniPlayerView.kt
@@ -115,7 +115,9 @@ class MiniPlayerView @JvmOverloads constructor(
      * For privacy stations (Tor/I2P), uses loadSecurePrivacy to route through Tor when available.
      */
     fun updateCoverArt(coverArtUri: String?) {
-        if (coverArtUri != null) {
+        // When cover art is disabled, always show the default radio icon
+        // instead of attempting to load remote cover art (or leaving it empty).
+        if (coverArtUri != null && !PreferencesHelper.isCoverArtDisabled(context)) {
             // Start with fitCenter for placeholder (scales vector up to fill container), switch to centerCrop on successful load
             coverImage.scaleType = ImageView.ScaleType.FIT_CENTER
             // Use privacy loader for Tor/I2P stations to route cover art through Tor
@@ -150,7 +152,7 @@ class MiniPlayerView @JvmOverloads constructor(
                 coverImage.loadSecure(coverArtUri, imageLoadBuilder)
             }
         } else {
-            // No cover art - use fitCenter so vector placeholder fills container
+            // No cover art (or cover art disabled) - use fitCenter so vector placeholder fills container
             coverImage.scaleType = ImageView.ScaleType.FIT_CENTER
             // Force reload to get fresh drawable with current theme colors (Material You)
             coverImage.setImageDrawable(null)
@@ -214,7 +216,9 @@ class MiniPlayerView @JvmOverloads constructor(
         // Handle cover art update properly - clear old image when switching stations
         // Use loadSecure to route remote URLs through Tor when Force Tor is enabled
         // For privacy stations (Tor/I2P), use loadSecurePrivacy to route through Tor when available
-        if (station.coverArtUri != null) {
+        // When cover art is disabled, always show the default radio icon
+        // instead of attempting to load remote cover art (or leaving it empty).
+        if (station.coverArtUri != null && !PreferencesHelper.isCoverArtDisabled(context)) {
             // Start with fitCenter for placeholder (scales vector up to fill container), switch to centerCrop on successful load
             coverImage.scaleType = ImageView.ScaleType.FIT_CENTER
             val isPrivacyStation = station.getProxyTypeEnum().let {
@@ -245,7 +249,7 @@ class MiniPlayerView @JvmOverloads constructor(
                 coverImage.loadSecure(station.coverArtUri, imageLoadBuilder)
             }
         } else {
-            // No cover art - use fitCenter so vector placeholder fills container
+            // No cover art (or cover art disabled) - use fitCenter so vector placeholder fills container
             coverImage.scaleType = ImageView.ScaleType.FIT_CENTER
             // Explicitly clear any cached/loading state and set default drawable
             // Force reload to get fresh drawable with current theme colors (Material You)

--- a/app/src/main/java/com/opensource/i2pradio/ui/NowPlayingFragment.kt
+++ b/app/src/main/java/com/opensource/i2pradio/ui/NowPlayingFragment.kt
@@ -646,7 +646,9 @@ class NowPlayingFragment : Fragment() {
                 // Handle cover art update properly - switch scaleType based on content
                 // Use loadSecure to route remote URLs through Tor when Force Tor is enabled
                 // For privacy stations (Tor/I2P), use loadSecurePrivacy to route through Tor when available
-                if (station.coverArtUri != null) {
+                // When cover art is disabled, always show the default radio icon
+                // instead of attempting to load remote cover art (or leaving it empty).
+                if (station.coverArtUri != null && !PreferencesHelper.isCoverArtDisabled(requireContext())) {
                     // Start with fitCenter for placeholder (scales vector up to fill container), switch to centerCrop on successful load
                     coverArt.scaleType = ImageView.ScaleType.FIT_CENTER
                     val isPrivacyStation = station.getProxyTypeEnum().let {
@@ -678,7 +680,7 @@ class NowPlayingFragment : Fragment() {
                         coverArt.loadSecure(station.coverArtUri, imageLoadBuilder)
                     }
                 } else {
-                    // No cover art - use fitCenter so vector placeholder fills container
+                    // No cover art (or cover art disabled) - use fitCenter so vector placeholder fills container
                     coverArt.scaleType = ImageView.ScaleType.FIT_CENTER
                     // Force reload to get fresh drawable with current theme colors (Material You)
                     coverArt.setImageDrawable(null)
@@ -1136,7 +1138,9 @@ class NowPlayingFragment : Fragment() {
      * For privacy stations (Tor/I2P), uses loadSecurePrivacy to route through Tor when available.
      */
     private fun updateCoverArt(coverArtUri: String?) {
-        if (coverArtUri != null) {
+        // When cover art is disabled, always show the default radio icon
+        // instead of attempting to load remote cover art (or leaving it empty).
+        if (coverArtUri != null && !PreferencesHelper.isCoverArtDisabled(requireContext())) {
             // Start with fitCenter for placeholder (scales vector up to fill container), switch to centerCrop on successful load
             coverArt.scaleType = ImageView.ScaleType.FIT_CENTER
             // Check if current station is a privacy station (Tor/I2P)
@@ -1171,6 +1175,7 @@ class NowPlayingFragment : Fragment() {
                 coverArt.loadSecure(coverArtUri, imageLoadBuilder)
             }
         } else {
+            // No cover art (or cover art disabled) - use fitCenter so vector placeholder fills container
             coverArt.scaleType = ImageView.ScaleType.FIT_CENTER
             coverArt.load(R.drawable.ic_radio) {
                 crossfade(true)


### PR DESCRIPTION
When cover art disable mode is on, the mini player and now playing screen were showing empty cover art instead of the default radio icon. Explicitly treat the disabled setting like a null coverArtUri in updateCoverArt/setStation so the placeholder ic_radio drawable is always loaded in that case.

https://claude.ai/code/session_01T5xijYX4jYsDzHNotiv1a1