### PR TITLE
i18n: translate 15 missing strings across all locales, bump to 1.7

### DIFF
--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -140,6 +140,8 @@
     <string name="dialog_sort_stations">ترتيب المحطات</string>
     <string name="dialog_delete_stations">حذف المحطات</string>
     <string name="button_save">حفظ</string>
+    <string name="button_edit">تعديل</string>
+    <string name="button_select_all">تحديد الكل</string>
     <string name="button_cancel">إلغاء</string>
     <string name="button_import">استيراد</string>
     <string name="button_export">تصدير</string>
@@ -268,7 +270,7 @@
 
     
     <string name="settings_about">حول</string>
-    <string name="settings_version">الإصدار 1.5</string>
+    <string name="settings_version">الإصدار 1.7</string>
     <string name="settings_view_github">عرض على GitHub</string>
     <string name="settings_donate">تبرع</string>
     <string name="settings_donate_description">إذا ساعدك هذا التطبيق، فكر في التبرع</string>
@@ -327,7 +329,9 @@
     <string name="tor_control_button_cancel">إلغاء</string>
     <string name="tor_control_button_retry">إعادة المحاولة</string>
     <string name="tor_control_button_install">تثبيت InviZible Pro</string>
+    <string name="tor_control_button_install_lite">تثبيت InviZible Lite</string>
     <string name="tor_control_button_open_invizible">فتح InviZible Pro</string>
+    <string name="tor_control_button_open_app">فتح %s</string>
 
     
     <string name="add_edit_tor_info">استخدام Tor المضمن - لا حاجة لتكوين الوكيل</string>
@@ -374,6 +378,7 @@
     <string name="toast_custom_proxy_saved">تم حفظ إعدادات الوكيل المخصص</string>
     <string name="toast_custom_proxy_cleared">تم مسح إعدادات الوكيل المخصص</string>
     <string name="toast_address_copied">تم نسخ العنوان إلى الحافظة</string>
+    <string name="toast_metadata_copied">تم نسخ معلومات الأغنية إلى الحافظة</string>
     <string name="toast_using_default_directory">استخدام الدليل الافتراضي</string>
 
     
@@ -560,6 +565,9 @@
     <string name="recording_error_connection_refused">تم رفض الاتصال</string>
     <string name="recording_error_io">خطأ إدخال/إخراج: %s</string>
     <string name="recording_error_generic">خطأ: %s</string>
+    <string name="recording_error_hls_playlist">تعذر جلب قائمة تشغيل HLS</string>
+    <string name="recording_error_rtsp_unsupported">التسجيل غير مدعوم لبث RTSP</string>
+    <string name="recording_error_proxy_blocked">تم حظر التسجيل: البروكسي المطلوب (Tor/مخصص) غير متاح</string>
 
     
     <string name="custom_proxy_not_configured_notification">البروكسي المخصص غير مهيأ</string>
@@ -601,6 +609,13 @@
     <string name="error_i2p_not_connected">I2P لا يعمل. قم بتشغيل I2P (مثل InviZible Pro) لتشغيل هذا البث.</string>
     <string name="error_tor_required_for_clearnet">Tor غير متصل. وضع إجبار Tor يتطلب Tor للبث العادي.</string>
     <string name="error_custom_proxy_not_configured">البروكسي المخصص غير مهيأ. قم بتهيئته في الإعدادات.</string>
+    <string name="error_unsupported_codec">بث %1$s غير مدعوم</string>
+    <string name="error_playlist_unreadable">تعذر قراءة قائمة التشغيل — قد تكون المحطة غير متصلة</string>
+    <string name="error_station_geoblocked">المحطة محظورة في منطقتك (أو من عقدة الخروج هذه)</string>
+    <string name="error_station_gone">المحطة لم تعد موجودة على هذا الرابط</string>
+    <string name="error_station_auth_required">المحطة تتطلب مصادقة</string>
+    <string name="notification_unsupported_codec">بث %1$s غير مدعوم</string>
+    <string name="notification_playlist_unreadable">تعذر قراءة قائمة التشغيل</string>
 
     
     <string name="cd_add_radio_station">إضافة محطة راديو</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -140,6 +140,8 @@
     <string name="dialog_sort_stations">Sender sortieren</string>
     <string name="dialog_delete_stations">Sender löschen</string>
     <string name="button_save">Speichern</string>
+    <string name="button_edit">Bearbeiten</string>
+    <string name="button_select_all">Alle auswählen</string>
     <string name="button_cancel">Abbrechen</string>
     <string name="button_import">Importieren</string>
     <string name="button_export">Exportieren</string>
@@ -268,7 +270,7 @@
 
     
     <string name="settings_about">Über</string>
-    <string name="settings_version">Version 1.5</string>
+    <string name="settings_version">Version 1.7</string>
     <string name="settings_view_github">Auf GitHub ansehen</string>
     <string name="settings_donate">Spenden</string>
     <string name="settings_donate_description">Wenn Ihnen diese App geholfen hat, ziehen Sie eine Spende in Betracht</string>
@@ -327,7 +329,9 @@
     <string name="tor_control_button_cancel">Abbrechen</string>
     <string name="tor_control_button_retry">Verbindung wiederholen</string>
     <string name="tor_control_button_install">InviZible Pro installieren</string>
+    <string name="tor_control_button_install_lite">InviZible Lite installieren</string>
     <string name="tor_control_button_open_invizible">InviZible Pro öffnen</string>
+    <string name="tor_control_button_open_app">%s öffnen</string>
 
 
     
@@ -375,6 +379,7 @@
     <string name="toast_custom_proxy_saved">Benutzerdefinierte Proxy-Einstellungen gespeichert</string>
     <string name="toast_custom_proxy_cleared">Benutzerdefinierte Proxy-Einstellungen gelöscht</string>
     <string name="toast_address_copied">Adresse in Zwischenablage kopiert</string>
+    <string name="toast_metadata_copied">Songinfo in Zwischenablage kopiert</string>
     <string name="toast_using_default_directory">Standardverzeichnis wird verwendet</string>
 
     
@@ -561,6 +566,9 @@
     <string name="recording_error_connection_refused">Verbindung abgelehnt</string>
     <string name="recording_error_io">E/A-Fehler: %s</string>
     <string name="recording_error_generic">Fehler: %s</string>
+    <string name="recording_error_hls_playlist">HLS-Playlist konnte nicht abgerufen werden</string>
+    <string name="recording_error_rtsp_unsupported">Aufnahme wird für RTSP-Streams nicht unterstützt</string>
+    <string name="recording_error_proxy_blocked">Aufnahme blockiert: Benötigter Proxy (Tor/Benutzerdefiniert) nicht verfügbar</string>
 
     
     <string name="custom_proxy_not_configured_notification">Benutzerdefinierter Proxy nicht konfiguriert</string>
@@ -594,6 +602,13 @@
     <string name="error_i2p_not_connected">I2P läuft nicht. Starten Sie I2P (z.B. InviZible Pro), um diesen Stream abzuspielen.</string>
     <string name="error_tor_required_for_clearnet">Tor ist nicht verbunden. Der Tor-Zwangsmodus erfordert Tor für Clearnet-Streams.</string>
     <string name="error_custom_proxy_not_configured">Benutzerdefinierter Proxy nicht konfiguriert. Konfigurieren Sie ihn in den Einstellungen.</string>
+    <string name="error_unsupported_codec">%1$s-Streams werden nicht unterstützt</string>
+    <string name="error_playlist_unreadable">Playlist konnte nicht gelesen werden – Sender möglicherweise offline</string>
+    <string name="error_station_geoblocked">Sender in Ihrer Region blockiert (oder von diesem Exit-Node)</string>
+    <string name="error_station_gone">Sender existiert unter dieser URL nicht mehr</string>
+    <string name="error_station_auth_required">Sender erfordert Authentifizierung</string>
+    <string name="notification_unsupported_codec">%1$s-Streams werden nicht unterstützt</string>
+    <string name="notification_playlist_unreadable">Playlist konnte nicht gelesen werden</string>
 
     
     <string name="password_change_rekey_failed">Passwort geändert, aber Datenbank-Neucodierung fehlgeschlagen: %s</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -142,6 +142,8 @@
     <string name="dialog_sort_stations">Ordenar estaciones</string>
     <string name="dialog_delete_stations">Eliminar estaciones</string>
     <string name="button_save">Guardar</string>
+    <string name="button_edit">Editar</string>
+    <string name="button_select_all">Seleccionar todo</string>
     <string name="button_cancel">Cancelar</string>
     <string name="button_import">Importar</string>
     <string name="button_export">Exportar</string>
@@ -272,7 +274,7 @@
 
     
     <string name="settings_about">Acerca de</string>
-    <string name="settings_version">Versión 1.5</string>
+    <string name="settings_version">Versión 1.7</string>
     <string name="settings_view_github">Ver en GitHub</string>
     <string name="settings_donate">Donar</string>
     <string name="settings_donate_description">Si esta aplicación te ayudó, considera hacer una donación</string>
@@ -331,7 +333,9 @@
     <string name="tor_control_button_cancel">Cancelar</string>
     <string name="tor_control_button_retry">Reintentar conexión</string>
     <string name="tor_control_button_install">Instalar InviZible Pro</string>
+    <string name="tor_control_button_install_lite">Instalar InviZible Lite</string>
     <string name="tor_control_button_open_invizible">Abrir InviZible Pro</string>
+    <string name="tor_control_button_open_app">Abrir %s</string>
 
 
     
@@ -379,6 +383,7 @@
     <string name="toast_custom_proxy_saved">Configuración de proxy personalizado guardada</string>
     <string name="toast_custom_proxy_cleared">Configuración de proxy personalizado eliminada</string>
     <string name="toast_address_copied">Dirección copiada al portapapeles</string>
+    <string name="toast_metadata_copied">Información de la canción copiada al portapapeles</string>
     <string name="toast_using_default_directory">Usando directorio predeterminado</string>
 
     
@@ -565,6 +570,9 @@
     <string name="recording_error_connection_refused">Conexión rechazada</string>
     <string name="recording_error_io">Error de E/S: %s</string>
     <string name="recording_error_generic">Error: %s</string>
+    <string name="recording_error_hls_playlist">No se pudo obtener la lista de reproducción HLS</string>
+    <string name="recording_error_rtsp_unsupported">La grabación no es compatible con flujos RTSP</string>
+    <string name="recording_error_proxy_blocked">Grabación bloqueada: el proxy requerido (Tor/personalizado) no está disponible</string>
 
     
     <string name="custom_proxy_not_configured_notification">Proxy personalizado no configurado</string>
@@ -606,6 +614,13 @@
     <string name="error_i2p_not_connected">I2P no está ejecutándose. Inicia I2P (ej. InviZible Pro) para reproducir esta transmisión.</string>
     <string name="error_tor_required_for_clearnet">Tor no está conectado. El modo forzar Tor requiere Tor para transmisiones clearnet.</string>
     <string name="error_custom_proxy_not_configured">Proxy personalizado no configurado. Configúralo en Ajustes.</string>
+    <string name="error_unsupported_codec">Los flujos %1$s no son compatibles</string>
+    <string name="error_playlist_unreadable">No se pudo leer la lista de reproducción — la emisora puede estar fuera de línea</string>
+    <string name="error_station_geoblocked">Emisora bloqueada en tu región (o desde este nodo de salida)</string>
+    <string name="error_station_gone">La emisora ya no existe en esa URL</string>
+    <string name="error_station_auth_required">La emisora requiere autenticación</string>
+    <string name="notification_unsupported_codec">Los flujos %1$s no son compatibles</string>
+    <string name="notification_playlist_unreadable">No se pudo leer la lista de reproducción</string>
 
     
     <string name="cd_add_radio_station">Añadir estación de radio</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -140,6 +140,8 @@
     <string name="dialog_sort_stations">مرتب‌سازی ایستگاه‌ها</string>
     <string name="dialog_delete_stations">حذف ایستگاه‌ها</string>
     <string name="button_save">ذخیره</string>
+    <string name="button_edit">ویرایش</string>
+    <string name="button_select_all">انتخاب همه</string>
     <string name="button_cancel">لغو</string>
     <string name="button_import">وارد کردن</string>
     <string name="button_export">خروجی گرفتن</string>
@@ -268,7 +270,7 @@
 
     
     <string name="settings_about">درباره</string>
-    <string name="settings_version">نسخه 1.5</string>
+    <string name="settings_version">نسخه 1.7</string>
     <string name="settings_view_github">مشاهده در GitHub</string>
     <string name="settings_donate">کمک مالی</string>
     <string name="settings_donate_description">اگر این برنامه به شما کمک کرد، کمک مالی را در نظر بگیرید</string>
@@ -327,7 +329,9 @@
     <string name="tor_control_button_cancel">لغو</string>
     <string name="tor_control_button_retry">تلاش مجدد</string>
     <string name="tor_control_button_install">نصب InviZible Pro</string>
+    <string name="tor_control_button_install_lite">نصب InviZible Lite</string>
     <string name="tor_control_button_open_invizible">باز کردن InviZible Pro</string>
+    <string name="tor_control_button_open_app">باز کردن %s</string>
 
 
     
@@ -375,6 +379,7 @@
     <string name="toast_custom_proxy_saved">تنظیمات پروکسی سفارشی ذخیره شد</string>
     <string name="toast_custom_proxy_cleared">تنظیمات پروکسی سفارشی پاک شد</string>
     <string name="toast_address_copied">آدرس به کلیپ‌بورد کپی شد</string>
+    <string name="toast_metadata_copied">اطلاعات آهنگ در کلیپ‌بورد کپی شد</string>
     <string name="toast_using_default_directory">در حال استفاده از پوشه پیش‌فرض</string>
 
     
@@ -561,6 +566,9 @@
     <string name="recording_error_connection_refused">اتصال رد شد</string>
     <string name="recording_error_io">خطای ورودی/خروجی: %s</string>
     <string name="recording_error_generic">خطا: %s</string>
+    <string name="recording_error_hls_playlist">دریافت پلی‌لیست HLS ممکن نشد</string>
+    <string name="recording_error_rtsp_unsupported">ضبط برای جریان‌های RTSP پشتیبانی نمی‌شود</string>
+    <string name="recording_error_proxy_blocked">ضبط مسدود شد: پروکسی موردنیاز (Tor/سفارشی) در دسترس نیست</string>
 
     
     <string name="custom_proxy_not_configured_notification">پروکسی سفارشی پیکربندی نشده است</string>
@@ -602,6 +610,13 @@
     <string name="error_i2p_not_connected">I2P در حال اجرا نیست. I2P را راه‌اندازی کنید (مثلاً InviZible Pro) تا این پخش را اجرا کنید.</string>
     <string name="error_tor_required_for_clearnet">Tor متصل نیست. حالت اجباری Tor نیاز به Tor برای پخش‌های clearnet دارد.</string>
     <string name="error_custom_proxy_not_configured">پروکسی سفارشی پیکربندی نشده است. آن را در تنظیمات پیکربندی کنید.</string>
+    <string name="error_unsupported_codec">جریان‌های %1$s پشتیبانی نمی‌شوند</string>
+    <string name="error_playlist_unreadable">خواندن پلی‌لیست ممکن نشد — ممکن است ایستگاه آفلاین باشد</string>
+    <string name="error_station_geoblocked">ایستگاه در منطقه شما (یا از این گره خروجی) مسدود است</string>
+    <string name="error_station_gone">ایستگاه دیگر در این آدرس وجود ندارد</string>
+    <string name="error_station_auth_required">ایستگاه نیاز به احراز هویت دارد</string>
+    <string name="notification_unsupported_codec">جریان‌های %1$s پشتیبانی نمی‌شوند</string>
+    <string name="notification_playlist_unreadable">خواندن پلی‌لیست ممکن نشد</string>
 
     
     <string name="cd_add_radio_station">افزودن ایستگاه رادیویی</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -140,6 +140,8 @@
     <string name="dialog_sort_stations">Trier les stations</string>
     <string name="dialog_delete_stations">Supprimer les stations</string>
     <string name="button_save">Enregistrer</string>
+    <string name="button_edit">Modifier</string>
+    <string name="button_select_all">Tout sélectionner</string>
     <string name="button_cancel">Annuler</string>
     <string name="button_import">Importer</string>
     <string name="button_export">Exporter</string>
@@ -268,7 +270,7 @@
 
     
     <string name="settings_about">À propos</string>
-    <string name="settings_version">Version 1.5</string>
+    <string name="settings_version">Version 1.7</string>
     <string name="settings_view_github">Voir sur GitHub</string>
     <string name="settings_donate">Faire un don</string>
     <string name="settings_donate_description">Si cette application vous a aidé, envisagez de faire un don</string>
@@ -327,7 +329,9 @@
     <string name="tor_control_button_cancel">Annuler</string>
     <string name="tor_control_button_retry">Réessayer la connexion</string>
     <string name="tor_control_button_install">Installer InviZible Pro</string>
+    <string name="tor_control_button_install_lite">Installer InviZible Lite</string>
     <string name="tor_control_button_open_invizible">Ouvrir InviZible Pro</string>
+    <string name="tor_control_button_open_app">Ouvrir %s</string>
 
     
     <string name="add_edit_tor_info">Utilisation de Tor intégré - aucune configuration de proxy nécessaire</string>
@@ -374,6 +378,7 @@
     <string name="toast_custom_proxy_saved">Paramètres du proxy personnalisé enregistrés</string>
     <string name="toast_custom_proxy_cleared">Paramètres du proxy personnalisé effacés</string>
     <string name="toast_address_copied">Adresse copiée dans le presse-papiers</string>
+    <string name="toast_metadata_copied">Informations de la chanson copiées dans le presse-papiers</string>
     <string name="toast_using_default_directory">Utilisation du répertoire par défaut</string>
 
     
@@ -560,6 +565,9 @@
     <string name="recording_error_connection_refused">Connexion refusée</string>
     <string name="recording_error_io">Erreur E/S : %s</string>
     <string name="recording_error_generic">Erreur : %s</string>
+    <string name="recording_error_hls_playlist">Impossible de récupérer la liste de lecture HLS</string>
+    <string name="recording_error_rtsp_unsupported">L\'enregistrement n\'est pas pris en charge pour les flux RTSP</string>
+    <string name="recording_error_proxy_blocked">Enregistrement bloqué : le proxy requis (Tor/personnalisé) n\'est pas disponible</string>
 
     
     <string name="custom_proxy_not_configured_notification">Proxy personnalisé non configuré</string>
@@ -601,6 +609,13 @@
     <string name="error_i2p_not_connected">I2P n\'est pas en cours d\'exécution. Démarrez I2P (ex. InviZible Pro) pour lire ce flux.</string>
     <string name="error_tor_required_for_clearnet">Tor n\'est pas connecté. Le mode Tor forcé nécessite Tor pour les flux clearnet.</string>
     <string name="error_custom_proxy_not_configured">Proxy personnalisé non configuré. Configurez-le dans les Paramètres.</string>
+    <string name="error_unsupported_codec">Les flux %1$s ne sont pas pris en charge</string>
+    <string name="error_playlist_unreadable">Impossible de lire la liste de lecture — la station est peut-être hors ligne</string>
+    <string name="error_station_geoblocked">Station bloquée dans votre région (ou depuis ce nœud de sortie)</string>
+    <string name="error_station_gone">La station n\'existe plus à cette URL</string>
+    <string name="error_station_auth_required">La station requiert une authentification</string>
+    <string name="notification_unsupported_codec">Les flux %1$s ne sont pas pris en charge</string>
+    <string name="notification_playlist_unreadable">Impossible de lire la liste de lecture</string>
 
     
     <string name="cd_add_radio_station">Ajouter une station de radio</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -140,6 +140,8 @@
     <string name="dialog_sort_stations">स्टेशन क्रमबद्ध करें</string>
     <string name="dialog_delete_stations">स्टेशन हटाएं</string>
     <string name="button_save">सहेजें</string>
+    <string name="button_edit">संपादित करें</string>
+    <string name="button_select_all">सभी चुनें</string>
     <string name="button_cancel">रद्द करें</string>
     <string name="button_import">आयात करें</string>
     <string name="button_export">निर्यात करें</string>
@@ -268,7 +270,7 @@
 
     
     <string name="settings_about">के बारे में</string>
-    <string name="settings_version">संस्करण 1.5</string>
+    <string name="settings_version">संस्करण 1.7</string>
     <string name="settings_view_github">GitHub पर देखें</string>
     <string name="settings_donate">दान करें</string>
     <string name="settings_donate_description">यदि इस ऐप ने आपकी मदद की, तो दान करने पर विचार करें</string>
@@ -327,7 +329,9 @@
     <string name="tor_control_button_cancel">रद्द करें</string>
     <string name="tor_control_button_retry">कनेक्शन पुनः प्रयास करें</string>
     <string name="tor_control_button_install">InviZible Pro इंस्टॉल करें</string>
+    <string name="tor_control_button_install_lite">InviZible Lite इंस्टॉल करें</string>
     <string name="tor_control_button_open_invizible">InviZible Pro खोलें</string>
+    <string name="tor_control_button_open_app">%s खोलें</string>
 
     
     <string name="add_edit_tor_info">एम्बेडेड Tor का उपयोग - कोई प्रॉक्सी कॉन्फ़िगरेशन आवश्यक नहीं</string>
@@ -374,6 +378,7 @@
     <string name="toast_custom_proxy_saved">कस्टम प्रॉक्सी सेटिंग्स सहेजी गईं</string>
     <string name="toast_custom_proxy_cleared">कस्टम प्रॉक्सी सेटिंग्स साफ़ हुईं</string>
     <string name="toast_address_copied">पता क्लिपबोर्ड पर कॉपी किया गया</string>
+    <string name="toast_metadata_copied">गाने की जानकारी क्लिपबोर्ड पर कॉपी की गई</string>
     <string name="toast_using_default_directory">डिफ़ॉल्ट निर्देशिका का उपयोग किया जा रहा है</string>
 
     
@@ -560,6 +565,9 @@
     <string name="recording_error_connection_refused">कनेक्शन अस्वीकृत</string>
     <string name="recording_error_io">I/O त्रुटि: %s</string>
     <string name="recording_error_generic">त्रुटि: %s</string>
+    <string name="recording_error_hls_playlist">HLS प्लेलिस्ट प्राप्त करने में असमर्थ</string>
+    <string name="recording_error_rtsp_unsupported">RTSP स्ट्रीम के लिए रिकॉर्डिंग समर्थित नहीं है</string>
+    <string name="recording_error_proxy_blocked">रिकॉर्डिंग अवरुद्ध: आवश्यक प्रॉक्सी (Tor/कस्टम) उपलब्ध नहीं है</string>
 
     
     <string name="custom_proxy_not_configured_notification">कस्टम प्रॉक्सी कॉन्फ़िगर नहीं है</string>
@@ -601,6 +609,13 @@
     <string name="error_i2p_not_connected">I2P नहीं चल रहा है। इस स्ट्रीम को चलाने के लिए I2P शुरू करें (जैसे InviZible Pro)।</string>
     <string name="error_tor_required_for_clearnet">Tor कनेक्ट नहीं है। फोर्स Tor मोड के लिए क्लियरनेट स्ट्रीम में Tor आवश्यक है।</string>
     <string name="error_custom_proxy_not_configured">कस्टम प्रॉक्सी कॉन्फ़िगर नहीं है। सेटिंग्स में कॉन्फ़िगर करें।</string>
+    <string name="error_unsupported_codec">%1$s स्ट्रीम समर्थित नहीं हैं</string>
+    <string name="error_playlist_unreadable">प्लेलिस्ट नहीं पढ़ी जा सकी — स्टेशन ऑफ़लाइन हो सकता है</string>
+    <string name="error_station_geoblocked">आपके क्षेत्र में स्टेशन अवरुद्ध है (या इस एग्ज़िट नोड से)</string>
+    <string name="error_station_gone">स्टेशन अब उस URL पर मौजूद नहीं है</string>
+    <string name="error_station_auth_required">स्टेशन को प्रमाणीकरण की आवश्यकता है</string>
+    <string name="notification_unsupported_codec">%1$s स्ट्रीम समर्थित नहीं हैं</string>
+    <string name="notification_playlist_unreadable">प्लेलिस्ट नहीं पढ़ी जा सकी</string>
 
     
     <string name="cd_add_radio_station">रेडियो स्टेशन जोड़ें</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -140,6 +140,8 @@
     <string name="dialog_sort_stations">Ordina stazioni</string>
     <string name="dialog_delete_stations">Elimina stazioni</string>
     <string name="button_save">Salva</string>
+    <string name="button_edit">Modifica</string>
+    <string name="button_select_all">Seleziona tutto</string>
     <string name="button_cancel">Annulla</string>
     <string name="button_import">Importa</string>
     <string name="button_export">Esporta</string>
@@ -268,7 +270,7 @@
 
     
     <string name="settings_about">Informazioni</string>
-    <string name="settings_version">Versione 1.5</string>
+    <string name="settings_version">Versione 1.7</string>
     <string name="settings_view_github">Visualizza su GitHub</string>
     <string name="settings_donate">Dona</string>
     <string name="settings_donate_description">Se questa app ti ha aiutato, considera di donare</string>
@@ -327,7 +329,9 @@
     <string name="tor_control_button_cancel">Annulla</string>
     <string name="tor_control_button_retry">Riprova connessione</string>
     <string name="tor_control_button_install">Installa InviZible Pro</string>
+    <string name="tor_control_button_install_lite">Installa InviZible Lite</string>
     <string name="tor_control_button_open_invizible">Apri InviZible Pro</string>
+    <string name="tor_control_button_open_app">Apri %s</string>
 
     
     <string name="add_edit_tor_info">Utilizzo di Tor integrato - nessuna configurazione proxy necessaria</string>
@@ -374,6 +378,7 @@
     <string name="toast_custom_proxy_saved">Impostazioni proxy personalizzato salvate</string>
     <string name="toast_custom_proxy_cleared">Impostazioni proxy personalizzato cancellate</string>
     <string name="toast_address_copied">Indirizzo copiato negli appunti</string>
+    <string name="toast_metadata_copied">Informazioni del brano copiate negli appunti</string>
     <string name="toast_using_default_directory">Utilizzo directory predefinita</string>
 
     
@@ -560,6 +565,9 @@
     <string name="recording_error_connection_refused">Connessione rifiutata</string>
     <string name="recording_error_io">Errore I/O: %s</string>
     <string name="recording_error_generic">Errore: %s</string>
+    <string name="recording_error_hls_playlist">Impossibile recuperare la playlist HLS</string>
+    <string name="recording_error_rtsp_unsupported">La registrazione non è supportata per i flussi RTSP</string>
+    <string name="recording_error_proxy_blocked">Registrazione bloccata: il proxy richiesto (Tor/personalizzato) non è disponibile</string>
 
     
     <string name="custom_proxy_not_configured_notification">Proxy personalizzato non configurato</string>
@@ -601,6 +609,13 @@
     <string name="error_i2p_not_connected">I2P non è in esecuzione. Avvia I2P (es. InviZible Pro) per riprodurre questo stream.</string>
     <string name="error_tor_required_for_clearnet">Tor non è connesso. La modalità Tor forzato richiede Tor per gli stream clearnet.</string>
     <string name="error_custom_proxy_not_configured">Proxy personalizzato non configurato. Configuralo nelle Impostazioni.</string>
+    <string name="error_unsupported_codec">I flussi %1$s non sono supportati</string>
+    <string name="error_playlist_unreadable">Impossibile leggere la playlist — la stazione potrebbe essere offline</string>
+    <string name="error_station_geoblocked">Stazione bloccata nella tua regione (o da questo nodo di uscita)</string>
+    <string name="error_station_gone">La stazione non esiste più a questo URL</string>
+    <string name="error_station_auth_required">La stazione richiede l\'autenticazione</string>
+    <string name="notification_unsupported_codec">I flussi %1$s non sono supportati</string>
+    <string name="notification_playlist_unreadable">Impossibile leggere la playlist</string>
 
     
     <string name="cd_add_radio_station">Aggiungi stazione radio</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -140,6 +140,8 @@
     <string name="dialog_sort_stations">ステーションを並べ替え</string>
     <string name="dialog_delete_stations">ステーションを削除</string>
     <string name="button_save">保存</string>
+    <string name="button_edit">編集</string>
+    <string name="button_select_all">すべて選択</string>
     <string name="button_cancel">キャンセル</string>
     <string name="button_import">インポート</string>
     <string name="button_export">エクスポート</string>
@@ -268,7 +270,7 @@
 
     
     <string name="settings_about">このアプリについて</string>
-    <string name="settings_version">バージョン 1.5</string>
+    <string name="settings_version">バージョン 1.7</string>
     <string name="settings_view_github">GitHubで見る</string>
     <string name="settings_donate">寄付</string>
     <string name="settings_donate_description">このアプリが役に立った場合は、寄付をご検討ください</string>
@@ -327,7 +329,9 @@
     <string name="tor_control_button_cancel">キャンセル</string>
     <string name="tor_control_button_retry">再接続</string>
     <string name="tor_control_button_install">InviZible Proをインストール</string>
+    <string name="tor_control_button_install_lite">InviZible Liteをインストール</string>
     <string name="tor_control_button_open_invizible">InviZible Proを開く</string>
+    <string name="tor_control_button_open_app">%sを開く</string>
 
     
     <string name="add_edit_tor_info">埋め込みTorを使用 - プロキシ設定は不要</string>
@@ -374,6 +378,7 @@
     <string name="toast_custom_proxy_saved">カスタムプロキシ設定を保存しました</string>
     <string name="toast_custom_proxy_cleared">カスタムプロキシ設定をクリアしました</string>
     <string name="toast_address_copied">アドレスをクリップボードにコピーしました</string>
+    <string name="toast_metadata_copied">曲情報をクリップボードにコピーしました</string>
     <string name="toast_using_default_directory">デフォルトディレクトリを使用しています</string>
 
     
@@ -560,6 +565,9 @@
     <string name="recording_error_connection_refused">接続が拒否されました</string>
     <string name="recording_error_io">I/Oエラー: %s</string>
     <string name="recording_error_generic">エラー: %s</string>
+    <string name="recording_error_hls_playlist">HLSプレイリストを取得できません</string>
+    <string name="recording_error_rtsp_unsupported">RTSPストリームの録音はサポートされていません</string>
+    <string name="recording_error_proxy_blocked">録音がブロックされました: 必要なプロキシ (Tor/カスタム) が利用できません</string>
 
     
     <string name="custom_proxy_not_configured_notification">カスタムプロキシが設定されていません</string>
@@ -601,6 +609,13 @@
     <string name="error_i2p_not_connected">I2Pが実行されていません。このストリームを再生するにはI2P（例：InviZible Pro）を起動してください。</string>
     <string name="error_tor_required_for_clearnet">Torが接続されていません。Tor強制モードではクリアネットストリームにTorが必要です。</string>
     <string name="error_custom_proxy_not_configured">カスタムプロキシが設定されていません。設定で構成してください。</string>
+    <string name="error_unsupported_codec">%1$sストリームはサポートされていません</string>
+    <string name="error_playlist_unreadable">プレイリストを読み取れません — ステーションがオフラインの可能性があります</string>
+    <string name="error_station_geoblocked">このステーションはお住まいの地域 (またはこの出口ノード) ではブロックされています</string>
+    <string name="error_station_gone">このURLにステーションは存在しません</string>
+    <string name="error_station_auth_required">ステーションには認証が必要です</string>
+    <string name="notification_unsupported_codec">%1$sストリームはサポートされていません</string>
+    <string name="notification_playlist_unreadable">プレイリストを読み取れません</string>
 
     
     <string name="cd_add_radio_station">ラジオ局を追加</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -140,6 +140,8 @@
     <string name="dialog_sort_stations">방송국 정렬</string>
     <string name="dialog_delete_stations">방송국 삭제</string>
     <string name="button_save">저장</string>
+    <string name="button_edit">편집</string>
+    <string name="button_select_all">모두 선택</string>
     <string name="button_cancel">취소</string>
     <string name="button_import">가져오기</string>
     <string name="button_export">내보내기</string>
@@ -268,7 +270,7 @@
 
     
     <string name="settings_about">정보</string>
-    <string name="settings_version">버전 1.5</string>
+    <string name="settings_version">버전 1.7</string>
     <string name="settings_view_github">GitHub에서 보기</string>
     <string name="settings_donate">기부</string>
     <string name="settings_donate_description">이 앱이 도움이 되었다면 기부를 고려해주세요</string>
@@ -327,7 +329,9 @@
     <string name="tor_control_button_cancel">취소</string>
     <string name="tor_control_button_retry">재연결</string>
     <string name="tor_control_button_install">InviZible Pro 설치</string>
+    <string name="tor_control_button_install_lite">InviZible Lite 설치</string>
     <string name="tor_control_button_open_invizible">InviZible Pro 열기</string>
+    <string name="tor_control_button_open_app">%s 열기</string>
 
     
     <string name="add_edit_tor_info">내장 Tor 사용 - 프록시 구성 불필요</string>
@@ -374,6 +378,7 @@
     <string name="toast_custom_proxy_saved">사용자 지정 프록시 설정 저장됨</string>
     <string name="toast_custom_proxy_cleared">사용자 지정 프록시 설정 지워짐</string>
     <string name="toast_address_copied">주소가 클립보드에 복사됨</string>
+    <string name="toast_metadata_copied">노래 정보가 클립보드에 복사됨</string>
     <string name="toast_using_default_directory">기본 디렉토리 사용 중</string>
 
     
@@ -560,6 +565,9 @@
     <string name="recording_error_connection_refused">연결이 거부되었습니다</string>
     <string name="recording_error_io">I/O 오류: %s</string>
     <string name="recording_error_generic">오류: %s</string>
+    <string name="recording_error_hls_playlist">HLS 재생목록을 가져올 수 없음</string>
+    <string name="recording_error_rtsp_unsupported">RTSP 스트림에는 녹음이 지원되지 않습니다</string>
+    <string name="recording_error_proxy_blocked">녹음 차단됨: 필요한 프록시 (Tor/사용자 지정)를 사용할 수 없음</string>
 
     
     <string name="custom_proxy_not_configured_notification">사용자 지정 프록시가 구성되지 않음</string>
@@ -601,6 +609,13 @@
     <string name="error_i2p_not_connected">I2P가 실행되지 않습니다. 이 스트림을 재생하려면 I2P(예: InviZible Pro)를 시작하세요.</string>
     <string name="error_tor_required_for_clearnet">Tor가 연결되지 않았습니다. Tor 강제 모드에서는 클리어넷 스트림에 Tor가 필요합니다.</string>
     <string name="error_custom_proxy_not_configured">사용자 지정 프록시가 구성되지 않았습니다. 설정에서 구성하세요.</string>
+    <string name="error_unsupported_codec">%1$s 스트림은 지원되지 않습니다</string>
+    <string name="error_playlist_unreadable">재생목록을 읽을 수 없음 — 스테이션이 오프라인일 수 있음</string>
+    <string name="error_station_geoblocked">해당 지역에서 스테이션이 차단됨 (또는 이 출구 노드에서)</string>
+    <string name="error_station_gone">해당 URL에 스테이션이 더 이상 존재하지 않음</string>
+    <string name="error_station_auth_required">스테이션에 인증이 필요함</string>
+    <string name="notification_unsupported_codec">%1$s 스트림은 지원되지 않습니다</string>
+    <string name="notification_playlist_unreadable">재생목록을 읽을 수 없음</string>
 
     
     <string name="cd_add_radio_station">라디오 방송국 추가</string>

--- a/app/src/main/res/values-my/strings.xml
+++ b/app/src/main/res/values-my/strings.xml
@@ -140,6 +140,8 @@
     <string name="dialog_sort_stations">စတေးရှင်းများကို စီရန်</string>
     <string name="dialog_delete_stations">စတေးရှင်းများကို ဖျက်ရန်</string>
     <string name="button_save">သိမ်းဆည်းရန်</string>
+    <string name="button_edit">ပြင်ဆင်ရန်</string>
+    <string name="button_select_all">အားလုံး ရွေးပါ</string>
     <string name="button_cancel">ပယ်ဖျက်ရန်</string>
     <string name="button_import">တင်သွင်းရန်</string>
     <string name="button_export">ထုတ်ယူရန်</string>
@@ -268,7 +270,7 @@
 
     
     <string name="settings_about">အကြောင်း</string>
-    <string name="settings_version">ဗားရှင်း 1.5</string>
+    <string name="settings_version">ဗားရှင်း 1.7</string>
     <string name="settings_view_github">GitHub တွင် ကြည့်ရန်</string>
     <string name="settings_donate">လှူဒါန်းရန်</string>
     <string name="settings_donate_description">ဒီအက်ပ်က သင့်ကို ကူညီခဲ့ရင် လှူဒါန်းရန် စဉ်းစားပါ</string>
@@ -327,7 +329,9 @@
     <string name="tor_control_button_cancel">ပယ်ဖျက်ပါ</string>
     <string name="tor_control_button_retry">ချိတ်ဆက်မှုကို ပြန်လည်ကြိုးစားပါ</string>
     <string name="tor_control_button_install">InviZible Pro ကို တပ်ဆင်ပါ</string>
+    <string name="tor_control_button_install_lite">InviZible Lite ကို တပ်ဆင်ပါ</string>
     <string name="tor_control_button_open_invizible">InviZible Pro ကို ဖွင့်ပါ</string>
+    <string name="tor_control_button_open_app">%s ကို ဖွင့်ပါ</string>
 
 
     
@@ -375,6 +379,7 @@
     <string name="toast_custom_proxy_saved">စိတ်ကြိုက် proxy ဆက်တင်များကို သိမ်းဆည်းပြီးပါပြီ</string>
     <string name="toast_custom_proxy_cleared">စိတ်ကြိုက် proxy ဆက်တင်များကို ရှင်းလင်းပြီးပါပြီ</string>
     <string name="toast_address_copied">လိပ်စာကို clipboard သို့ ကူးယူပြီးပါပြီ</string>
+    <string name="toast_metadata_copied">သီချင်းအချက်အလက်ကို clipboard သို့ ကူးယူပြီးပါပြီ</string>
     <string name="toast_using_default_directory">မူလ ဖိုင်တွဲကို သုံးနေသည်</string>
 
     
@@ -561,6 +566,9 @@
     <string name="recording_error_connection_refused">ချိတ်ဆက်မှု ငြင်းပယ်ခံရသည်</string>
     <string name="recording_error_io">I/O အမှား: %s</string>
     <string name="recording_error_generic">အမှား: %s</string>
+    <string name="recording_error_hls_playlist">HLS ပလေးလစ်ကို ရယူ၍မရပါ</string>
+    <string name="recording_error_rtsp_unsupported">RTSP streams အတွက် အသံသွင်းခြင်းကို မပံ့ပိုးပါ</string>
+    <string name="recording_error_proxy_blocked">အသံသွင်းခြင်း ပိတ်ဆို့ထားသည်- လိုအပ်သော ပရောက်ဆီ (Tor/စိတ်ကြိုက်) မရနိုင်ပါ</string>
 
     
     <string name="custom_proxy_not_configured_notification">စိတ်ကြိုက် ပရောက်ဆီ ပြင်ဆင်မထားပါ</string>
@@ -602,6 +610,13 @@
     <string name="error_i2p_not_connected">I2P မလည်ပတ်ပါ။ ဤထုတ်လွှင့်မှုကို ဖွင့်ရန် I2P (ဥပမာ InviZible Pro) ကို စတင်ပါ။</string>
     <string name="error_tor_required_for_clearnet">Tor ချိတ်ဆက်မထားပါ။ Force Tor မုဒ်တွင် clearnet ထုတ်လွှင့်မှုများအတွက် Tor လိုအပ်သည်။</string>
     <string name="error_custom_proxy_not_configured">စိတ်ကြိုက် ပရောက်ဆီ စီစဉ်မထားပါ။ ဆက်တင်များတွင် စီစဉ်ပါ။</string>
+    <string name="error_unsupported_codec">%1$s streams ကို မပံ့ပိုးပါ</string>
+    <string name="error_playlist_unreadable">ပလေးလစ်ကို ဖတ်၍မရပါ — ဌာနသည် အော့ဖ်လိုင်းဖြစ်နိုင်သည်</string>
+    <string name="error_station_geoblocked">သင့်ဒေသတွင် (သို့မဟုတ် ဤထွက်ပေါက် node မှ) ဌာနကို ပိတ်ဆို့ထားသည်</string>
+    <string name="error_station_gone">ဤ URL တွင် ဌာနမရှိတော့ပါ</string>
+    <string name="error_station_auth_required">ဌာနသည် အထောက်အထား စိစစ်ခြင်း လိုအပ်သည်</string>
+    <string name="notification_unsupported_codec">%1$s streams ကို မပံ့ပိုးပါ</string>
+    <string name="notification_playlist_unreadable">ပလေးလစ်ကို ဖတ်၍မရပါ</string>
 
     
     <string name="cd_add_radio_station">ရေဒီယို ဘူတာရုံ ထည့်ပါ</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -140,6 +140,8 @@
     <string name="dialog_sort_stations">Ordenar estações</string>
     <string name="dialog_delete_stations">Excluir estações</string>
     <string name="button_save">Salvar</string>
+    <string name="button_edit">Editar</string>
+    <string name="button_select_all">Selecionar tudo</string>
     <string name="button_cancel">Cancelar</string>
     <string name="button_import">Importar</string>
     <string name="button_export">Exportar</string>
@@ -268,7 +270,7 @@
 
     
     <string name="settings_about">Sobre</string>
-    <string name="settings_version">Versão 1.5</string>
+    <string name="settings_version">Versão 1.7</string>
     <string name="settings_view_github">Ver no GitHub</string>
     <string name="settings_donate">Doar</string>
     <string name="settings_donate_description">Se este aplicativo ajudou você, considere fazer uma doação</string>
@@ -327,7 +329,9 @@
     <string name="tor_control_button_cancel">Cancelar</string>
     <string name="tor_control_button_retry">Tentar novamente</string>
     <string name="tor_control_button_install">Instalar InviZible Pro</string>
+    <string name="tor_control_button_install_lite">Instalar InviZible Lite</string>
     <string name="tor_control_button_open_invizible">Abrir InviZible Pro</string>
+    <string name="tor_control_button_open_app">Abrir %s</string>
 
 
     
@@ -375,6 +379,7 @@
     <string name="toast_custom_proxy_saved">Configurações de proxy personalizado salvas</string>
     <string name="toast_custom_proxy_cleared">Configurações de proxy personalizado limpas</string>
     <string name="toast_address_copied">Endereço copiado para área de transferência</string>
+    <string name="toast_metadata_copied">Informações da música copiadas para área de transferência</string>
     <string name="toast_using_default_directory">Usando diretório padrão</string>
 
     
@@ -561,6 +566,9 @@
     <string name="recording_error_connection_refused">Conexão recusada</string>
     <string name="recording_error_io">Erro de E/S: %s</string>
     <string name="recording_error_generic">Erro: %s</string>
+    <string name="recording_error_hls_playlist">Não foi possível obter a lista de reprodução HLS</string>
+    <string name="recording_error_rtsp_unsupported">A gravação não é compatível com streams RTSP</string>
+    <string name="recording_error_proxy_blocked">Gravação bloqueada: o proxy necessário (Tor/personalizado) não está disponível</string>
 
     
     <string name="custom_proxy_not_configured_notification">Proxy personalizado não configurado</string>
@@ -602,6 +610,13 @@
     <string name="error_i2p_not_connected">I2P não está em execução. Inicie o I2P (ex. InviZible Pro) para reproduzir este stream.</string>
     <string name="error_tor_required_for_clearnet">Tor não está conectado. O modo Tor forçado requer Tor para streams clearnet.</string>
     <string name="error_custom_proxy_not_configured">Proxy personalizado não configurado. Configure-o nas Configurações.</string>
+    <string name="error_unsupported_codec">Streams %1$s não são suportados</string>
+    <string name="error_playlist_unreadable">Não foi possível ler a lista de reprodução — a estação pode estar offline</string>
+    <string name="error_station_geoblocked">Estação bloqueada na sua região (ou a partir deste nó de saída)</string>
+    <string name="error_station_gone">A estação não existe mais nesta URL</string>
+    <string name="error_station_auth_required">A estação requer autenticação</string>
+    <string name="notification_unsupported_codec">Streams %1$s não são suportados</string>
+    <string name="notification_playlist_unreadable">Não foi possível ler a lista de reprodução</string>
 
     
     <string name="cd_add_radio_station">Adicionar estação de rádio</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -140,6 +140,8 @@
     <string name="dialog_sort_stations">Сортировка станций</string>
     <string name="dialog_delete_stations">Удалить станции</string>
     <string name="button_save">Сохранить</string>
+    <string name="button_edit">Изменить</string>
+    <string name="button_select_all">Выбрать все</string>
     <string name="button_cancel">Отмена</string>
     <string name="button_import">Импорт</string>
     <string name="button_export">Экспорт</string>
@@ -268,7 +270,7 @@
 
     
     <string name="settings_about">О программе</string>
-    <string name="settings_version">Версия 1.5</string>
+    <string name="settings_version">Версия 1.7</string>
     <string name="settings_view_github">Посмотреть на GitHub</string>
     <string name="settings_donate">Поддержать</string>
     <string name="settings_donate_description">Если это приложение вам помогло, рассмотрите возможность поддержки</string>
@@ -327,7 +329,9 @@
     <string name="tor_control_button_cancel">Отмена</string>
     <string name="tor_control_button_retry">Повторить подключение</string>
     <string name="tor_control_button_install">Установить InviZible Pro</string>
+    <string name="tor_control_button_install_lite">Установить InviZible Lite</string>
     <string name="tor_control_button_open_invizible">Открыть InviZible Pro</string>
+    <string name="tor_control_button_open_app">Открыть %s</string>
 
     
     <string name="add_edit_tor_info">Используется встроенный Tor - настройка прокси не требуется</string>
@@ -374,6 +378,7 @@
     <string name="toast_custom_proxy_saved">Настройки пользовательского прокси сохранены</string>
     <string name="toast_custom_proxy_cleared">Настройки пользовательского прокси очищены</string>
     <string name="toast_address_copied">Адрес скопирован в буфер обмена</string>
+    <string name="toast_metadata_copied">Информация о песне скопирована в буфер обмена</string>
     <string name="toast_using_default_directory">Используется каталог по умолчанию</string>
 
     
@@ -560,6 +565,9 @@
     <string name="recording_error_connection_refused">Подключение отклонено</string>
     <string name="recording_error_io">Ошибка ввода/вывода: %s</string>
     <string name="recording_error_generic">Ошибка: %s</string>
+    <string name="recording_error_hls_playlist">Не удалось получить плейлист HLS</string>
+    <string name="recording_error_rtsp_unsupported">Запись не поддерживается для потоков RTSP</string>
+    <string name="recording_error_proxy_blocked">Запись заблокирована: требуемый прокси (Tor/пользовательский) недоступен</string>
 
     
     <string name="custom_proxy_not_configured_notification">Пользовательский прокси не настроен</string>
@@ -601,6 +609,13 @@
     <string name="error_i2p_not_connected">I2P не запущен. Запустите I2P (напр. InviZible Pro) для воспроизведения этого потока.</string>
     <string name="error_tor_required_for_clearnet">Tor не подключён. Режим принудительного Tor требует Tor для обычных потоков.</string>
     <string name="error_custom_proxy_not_configured">Пользовательский прокси не настроен. Настройте его в Настройках.</string>
+    <string name="error_unsupported_codec">Потоки %1$s не поддерживаются</string>
+    <string name="error_playlist_unreadable">Не удалось прочитать плейлист — станция может быть недоступна</string>
+    <string name="error_station_geoblocked">Станция заблокирована в вашем регионе (или с этой выходной ноды)</string>
+    <string name="error_station_gone">Станция больше не существует по этому URL</string>
+    <string name="error_station_auth_required">Станция требует аутентификации</string>
+    <string name="notification_unsupported_codec">Потоки %1$s не поддерживаются</string>
+    <string name="notification_playlist_unreadable">Не удалось прочитать плейлист</string>
 
     
     <string name="cd_add_radio_station">Добавить радиостанцию</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -140,6 +140,8 @@
     <string name="dialog_sort_stations">İstasyonları Sırala</string>
     <string name="dialog_delete_stations">İstasyonları sil</string>
     <string name="button_save">Kaydet</string>
+    <string name="button_edit">Düzenle</string>
+    <string name="button_select_all">Tümünü Seç</string>
     <string name="button_cancel">İptal</string>
     <string name="button_import">İçe Aktar</string>
     <string name="button_export">Dışa Aktar</string>
@@ -268,7 +270,7 @@
 
     
     <string name="settings_about">Hakkında</string>
-    <string name="settings_version">Sürüm 1.5</string>
+    <string name="settings_version">Sürüm 1.7</string>
     <string name="settings_view_github">GitHub\'da Görüntüle</string>
     <string name="settings_donate">Bağış Yap</string>
     <string name="settings_donate_description">Bu uygulama işinize yaradıysa bağış yapmayı düşünün</string>
@@ -327,7 +329,9 @@
     <string name="tor_control_button_cancel">İptal</string>
     <string name="tor_control_button_retry">Bağlantıyı Yeniden Dene</string>
     <string name="tor_control_button_install">InviZible Pro\'yu Yükle</string>
+    <string name="tor_control_button_install_lite">InviZible Lite\'ı Yükle</string>
     <string name="tor_control_button_open_invizible">InviZible Pro\'yu Aç</string>
+    <string name="tor_control_button_open_app">%s\'i Aç</string>
 
 
     
@@ -375,6 +379,7 @@
     <string name="toast_custom_proxy_saved">Özel vekil sunucu ayarları kaydedildi</string>
     <string name="toast_custom_proxy_cleared">Özel vekil sunucu ayarları temizlendi</string>
     <string name="toast_address_copied">Adres panoya kopyalandı</string>
+    <string name="toast_metadata_copied">Şarkı bilgisi panoya kopyalandı</string>
     <string name="toast_using_default_directory">Varsayılan dizin kullanılıyor</string>
 
     
@@ -561,6 +566,9 @@
     <string name="recording_error_connection_refused">Bağlantı reddedildi</string>
     <string name="recording_error_io">G/Ç hatası: %s</string>
     <string name="recording_error_generic">Hata: %s</string>
+    <string name="recording_error_hls_playlist">HLS çalma listesi alınamadı</string>
+    <string name="recording_error_rtsp_unsupported">RTSP akışları için kayıt desteklenmiyor</string>
+    <string name="recording_error_proxy_blocked">Kayıt engellendi: Gerekli proxy (Tor/özel) mevcut değil</string>
 
     
     <string name="custom_proxy_not_configured_notification">Özel proxy yapılandırılmamış</string>
@@ -602,6 +610,13 @@
     <string name="error_i2p_not_connected">I2P çalışmıyor. Bu yayını oynatmak için I2P\'yi başlatın (örn. InviZible Pro).</string>
     <string name="error_tor_required_for_clearnet">Tor bağlı değil. Zorla Tor modu clearnet yayınları için Tor gerektirir.</string>
     <string name="error_custom_proxy_not_configured">Özel proxy yapılandırılmamış. Ayarlar\'da yapılandırın.</string>
+    <string name="error_unsupported_codec">%1$s akışları desteklenmiyor</string>
+    <string name="error_playlist_unreadable">Çalma listesi okunamadı — istasyon çevrimdışı olabilir</string>
+    <string name="error_station_geoblocked">İstasyon bölgenizde engellendi (veya bu çıkış düğümünden)</string>
+    <string name="error_station_gone">İstasyon artık bu URL\'de mevcut değil</string>
+    <string name="error_station_auth_required">İstasyon kimlik doğrulama gerektiriyor</string>
+    <string name="notification_unsupported_codec">%1$s akışları desteklenmiyor</string>
+    <string name="notification_playlist_unreadable">Çalma listesi okunamadı</string>
 
     
     <string name="cd_add_radio_station">Radyo İstasyonu Ekle</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -140,6 +140,8 @@
     <string name="dialog_sort_stations">Сортування станцій</string>
     <string name="dialog_delete_stations">Видалити станції</string>
     <string name="button_save">Зберегти</string>
+    <string name="button_edit">Редагувати</string>
+    <string name="button_select_all">Вибрати все</string>
     <string name="button_cancel">Скасувати</string>
     <string name="button_import">Імпорт</string>
     <string name="button_export">Експорт</string>
@@ -268,7 +270,7 @@
 
     
     <string name="settings_about">Про програму</string>
-    <string name="settings_version">Версія 1.5</string>
+    <string name="settings_version">Версія 1.7</string>
     <string name="settings_view_github">Переглянути на GitHub</string>
     <string name="settings_donate">Підтримати</string>
     <string name="settings_donate_description">Якщо цей додаток вам допоміг, розгляньте можливість підтримки</string>
@@ -327,7 +329,9 @@
     <string name="tor_control_button_cancel">Скасувати</string>
     <string name="tor_control_button_retry">Повторити підключення</string>
     <string name="tor_control_button_install">Встановити InviZible Pro</string>
+    <string name="tor_control_button_install_lite">Встановити InviZible Lite</string>
     <string name="tor_control_button_open_invizible">Відкрити InviZible Pro</string>
+    <string name="tor_control_button_open_app">Відкрити %s</string>
 
 
     
@@ -375,6 +379,7 @@
     <string name="toast_custom_proxy_saved">Налаштування власного проксі збережено</string>
     <string name="toast_custom_proxy_cleared">Налаштування власного проксі очищено</string>
     <string name="toast_address_copied">Адресу скопійовано в буфер обміну</string>
+    <string name="toast_metadata_copied">Інформацію про пісню скопійовано в буфер обміну</string>
     <string name="toast_using_default_directory">Використовується каталог за замовчуванням</string>
 
     
@@ -561,6 +566,9 @@
     <string name="recording_error_connection_refused">Підключення відхилено</string>
     <string name="recording_error_io">Помилка вводу/виводу: %s</string>
     <string name="recording_error_generic">Помилка: %s</string>
+    <string name="recording_error_hls_playlist">Не вдалося отримати плейлист HLS</string>
+    <string name="recording_error_rtsp_unsupported">Запис не підтримується для потоків RTSP</string>
+    <string name="recording_error_proxy_blocked">Запис заблоковано: потрібний проксі (Tor/користувацький) недоступний</string>
 
     
     <string name="custom_proxy_not_configured_notification">Користувацький проксі не налаштовано</string>
@@ -602,6 +610,13 @@
     <string name="error_i2p_not_connected">I2P не запущено. Запустіть I2P (напр. InviZible Pro) для відтворення цього потоку.</string>
     <string name="error_tor_required_for_clearnet">Tor не підключено. Примусовий режим Tor вимагає Tor для звичайних потоків.</string>
     <string name="error_custom_proxy_not_configured">Користувацький проксі не налаштовано. Налаштуйте його в Налаштуваннях.</string>
+    <string name="error_unsupported_codec">Потоки %1$s не підтримуються</string>
+    <string name="error_playlist_unreadable">Не вдалося прочитати плейлист — станція може бути офлайн</string>
+    <string name="error_station_geoblocked">Станцію заблоковано у вашому регіоні (або з цього вихідного вузла)</string>
+    <string name="error_station_gone">Станція більше не існує за цією URL-адресою</string>
+    <string name="error_station_auth_required">Станція вимагає автентифікації</string>
+    <string name="notification_unsupported_codec">Потоки %1$s не підтримуються</string>
+    <string name="notification_playlist_unreadable">Не вдалося прочитати плейлист</string>
 
     
     <string name="cd_add_radio_station">Додати радіостанцію</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -140,6 +140,8 @@
     <string name="dialog_sort_stations">Sắp xếp trạm</string>
     <string name="dialog_delete_stations">Xóa trạm</string>
     <string name="button_save">Lưu</string>
+    <string name="button_edit">Chỉnh sửa</string>
+    <string name="button_select_all">Chọn tất cả</string>
     <string name="button_cancel">Hủy</string>
     <string name="button_import">Nhập</string>
     <string name="button_export">Xuất</string>
@@ -268,7 +270,7 @@
 
     
     <string name="settings_about">Giới thiệu</string>
-    <string name="settings_version">Phiên bản 1.5</string>
+    <string name="settings_version">Phiên bản 1.7</string>
     <string name="settings_view_github">Xem trên GitHub</string>
     <string name="settings_donate">Quyên góp</string>
     <string name="settings_donate_description">Nếu ứng dụng này hữu ích cho bạn, hãy xem xét quyên góp</string>
@@ -327,7 +329,9 @@
     <string name="tor_control_button_cancel">Hủy</string>
     <string name="tor_control_button_retry">Thử lại kết nối</string>
     <string name="tor_control_button_install">Cài đặt InviZible Pro</string>
+    <string name="tor_control_button_install_lite">Cài đặt InviZible Lite</string>
     <string name="tor_control_button_open_invizible">Mở InviZible Pro</string>
+    <string name="tor_control_button_open_app">Mở %s</string>
 
 
     
@@ -375,6 +379,7 @@
     <string name="toast_custom_proxy_saved">Đã lưu cài đặt proxy tùy chỉnh</string>
     <string name="toast_custom_proxy_cleared">Đã xóa cài đặt proxy tùy chỉnh</string>
     <string name="toast_address_copied">Đã sao chép địa chỉ vào clipboard</string>
+    <string name="toast_metadata_copied">Đã sao chép thông tin bài hát vào clipboard</string>
     <string name="toast_using_default_directory">Đang sử dụng thư mục mặc định</string>
 
     
@@ -561,6 +566,9 @@
     <string name="recording_error_connection_refused">Kết nối bị từ chối</string>
     <string name="recording_error_io">Lỗi I/O: %s</string>
     <string name="recording_error_generic">Lỗi: %s</string>
+    <string name="recording_error_hls_playlist">Không thể tải danh sách phát HLS</string>
+    <string name="recording_error_rtsp_unsupported">Ghi âm không được hỗ trợ cho luồng RTSP</string>
+    <string name="recording_error_proxy_blocked">Ghi âm bị chặn: proxy bắt buộc (Tor/tùy chỉnh) không khả dụng</string>
 
     
     <string name="custom_proxy_not_configured_notification">Proxy tùy chỉnh chưa được cấu hình</string>
@@ -602,6 +610,13 @@
     <string name="error_i2p_not_connected">I2P chưa chạy. Khởi động I2P (ví dụ: InviZible Pro) để phát luồng này.</string>
     <string name="error_tor_required_for_clearnet">Tor chưa được kết nối. Chế độ bắt buộc Tor yêu cầu Tor cho các luồng clearnet.</string>
     <string name="error_custom_proxy_not_configured">Proxy tùy chỉnh chưa được cấu hình. Cấu hình trong Cài đặt.</string>
+    <string name="error_unsupported_codec">Luồng %1$s không được hỗ trợ</string>
+    <string name="error_playlist_unreadable">Không thể đọc danh sách phát — đài có thể đang ngoại tuyến</string>
+    <string name="error_station_geoblocked">Đài bị chặn tại khu vực của bạn (hoặc từ nút thoát này)</string>
+    <string name="error_station_gone">Đài không còn tồn tại tại URL đó</string>
+    <string name="error_station_auth_required">Đài yêu cầu xác thực</string>
+    <string name="notification_unsupported_codec">Luồng %1$s không được hỗ trợ</string>
+    <string name="notification_playlist_unreadable">Không thể đọc danh sách phát</string>
 
     
     <string name="cd_add_radio_station">Thêm đài radio</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -140,6 +140,8 @@
     <string name="dialog_sort_stations">排序电台</string>
     <string name="dialog_delete_stations">删除电台</string>
     <string name="button_save">保存</string>
+    <string name="button_edit">编辑</string>
+    <string name="button_select_all">全选</string>
     <string name="button_cancel">取消</string>
     <string name="button_import">导入</string>
     <string name="button_export">导出</string>
@@ -268,7 +270,7 @@
 
     
     <string name="settings_about">关于</string>
-    <string name="settings_version">版本 1.5</string>
+    <string name="settings_version">版本 1.7</string>
     <string name="settings_view_github">在 GitHub 上查看</string>
     <string name="settings_donate">捐赠</string>
     <string name="settings_donate_description">如果此应用对您有帮助，请考虑捐赠</string>
@@ -327,7 +329,9 @@
     <string name="tor_control_button_cancel">取消</string>
     <string name="tor_control_button_retry">重试连接</string>
     <string name="tor_control_button_install">安装InviZible Pro</string>
+    <string name="tor_control_button_install_lite">安装InviZible Lite</string>
     <string name="tor_control_button_open_invizible">打开InviZible Pro</string>
+    <string name="tor_control_button_open_app">打开 %s</string>
 
 
     
@@ -375,6 +379,7 @@
     <string name="toast_custom_proxy_saved">自定义代理设置已保存</string>
     <string name="toast_custom_proxy_cleared">自定义代理设置已清除</string>
     <string name="toast_address_copied">地址已复制到剪贴板</string>
+    <string name="toast_metadata_copied">歌曲信息已复制到剪贴板</string>
     <string name="toast_using_default_directory">使用默认目录</string>
 
     
@@ -561,6 +566,9 @@
     <string name="recording_error_connection_refused">连接被拒绝</string>
     <string name="recording_error_io">I/O 错误：%s</string>
     <string name="recording_error_generic">错误：%s</string>
+    <string name="recording_error_hls_playlist">无法获取HLS播放列表</string>
+    <string name="recording_error_rtsp_unsupported">RTSP流不支持录制</string>
+    <string name="recording_error_proxy_blocked">录制被阻止：所需的代理（Tor/自定义）不可用</string>
 
     
     <string name="custom_proxy_not_configured_notification">自定义代理未配置</string>
@@ -602,6 +610,13 @@
     <string name="error_i2p_not_connected">I2P 未运行。启动 I2P（如 InviZible Pro）以播放此流。</string>
     <string name="error_tor_required_for_clearnet">Tor 未连接。强制 Tor 模式需要 Tor 来播放明网流。</string>
     <string name="error_custom_proxy_not_configured">自定义代理未配置。请在设置中配置。</string>
+    <string name="error_unsupported_codec">不支持%1$s流</string>
+    <string name="error_playlist_unreadable">无法读取播放列表 — 电台可能离线</string>
+    <string name="error_station_geoblocked">电台在您所在区域被阻止（或来自此出口节点）</string>
+    <string name="error_station_gone">该URL上的电台已不存在</string>
+    <string name="error_station_auth_required">电台需要身份验证</string>
+    <string name="notification_unsupported_codec">不支持%1$s流</string>
+    <string name="notification_playlist_unreadable">无法读取播放列表</string>
 
     
     <string name="cd_add_radio_station">添加电台</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -316,7 +316,7 @@
 
     <!-- Settings - About -->
     <string name="settings_about">About</string>
-    <string name="settings_version">Version 1.6</string>
+    <string name="settings_version">Version 1.7</string>
     <string name="settings_view_github">View on GitHub</string>
     <string name="settings_donate">Donate</string>
     <string name="settings_donate_description">If this app helped you out, consider donating</string>


### PR DESCRIPTION
Adds translations for button_edit, button_select_all, toast_metadata_copied, tor_control_button_install_lite, tor_control_button_open_app, recording_error_hls_playlist, recording_error_rtsp_unsupported, recording_error_proxy_blocked, error_unsupported_codec, error_playlist_unreadable, error_station_geoblocked, error_station_gone, error_station_auth_required, notification_unsupported_codec, and notification_playlist_unreadable in all 16 locales. Also bumps the settings_version string from 1.5/1.6 to 1.7 in every locale.