### PR TITLE
remove rtsp support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,6 @@ All notable changes to deutsia radio will be documented in this file.
 ## [1.7.1]
 
 ### Added
-- **RTSP playback support**: Added support for RTSP streams
 - **Copy now playing metadata**: Long-press the now playing info to copy song/station metadata to clipboard, with a confirmation toast
 - **URL resolution**: Separated URL resolution from format detection 
 ### Security

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -77,7 +77,6 @@ dependencies {
     implementation("androidx.media3:media3-exoplayer:1.2.1")
     implementation("androidx.media3:media3-exoplayer-hls:1.2.1")
     implementation("androidx.media3:media3-exoplayer-dash:1.2.1")
-    implementation("androidx.media3:media3-exoplayer-rtsp:1.2.1")
     implementation("androidx.media3:media3-datasource-okhttp:1.2.1")
     implementation("androidx.media3:media3-session:1.2.1")
 

--- a/app/src/main/java/com/opensource/i2pradio/RadioService.kt
+++ b/app/src/main/java/com/opensource/i2pradio/RadioService.kt
@@ -35,7 +35,6 @@ import androidx.media3.exoplayer.DefaultLoadControl
 import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.exoplayer.dash.DashMediaSource
 import androidx.media3.exoplayer.hls.HlsMediaSource
-import androidx.media3.exoplayer.rtsp.RtspMediaSource
 import androidx.media3.exoplayer.source.MediaSource
 import androidx.media3.exoplayer.source.ProgressiveMediaSource
 import androidx.media3.extractor.metadata.icy.IcyInfo
@@ -567,16 +566,6 @@ class RadioService : Service() {
         val streamUrl = currentStreamUrl ?: run {
             android.util.Log.e("RadioService", "Cannot start recording: no stream URL")
             broadcastRecordingError(getString(R.string.recording_error_no_stream))
-            return
-        }
-
-        // Recording uses OkHttp / HlsRecorder / DashRecorder, all of which
-        // assume an HTTP response body. RTSP streams are RTP, so there's
-        // nothing sensible to write to disk from this path. Surface a clear
-        // error instead of silently producing an empty file.
-        if (isRtspStream(streamUrl)) {
-            android.util.Log.w("RadioService", "Recording not supported for RTSP streams")
-            broadcastRecordingError(getString(R.string.recording_error_rtsp_unsupported))
             return
         }
 
@@ -1648,19 +1637,6 @@ class RadioService : Service() {
         return path.endsWith(".mpd") || path.contains(".mpd")
     }
 
-    /**
-     * RTSP streams use their own transport (RTP over UDP/TCP) and bypass
-     * OkHttp entirely. That has two important consequences:
-     *  - Proxy settings (Tor/I2P/custom) don't apply, so force-proxy modes
-     *    must reject rtsp:// URLs up front rather than silently leaking.
-     *  - Recording via [buildRecordingHttpClient] won't work - RTSP needs
-     *    its own RTP receiver. We surface a clear error instead of silently
-     *    producing an empty file.
-     */
-    private fun isRtspStream(streamUrl: String): Boolean {
-        return streamUrl.startsWith("rtsp://", ignoreCase = true)
-    }
-
     private fun switchRecordingStream(
         newStreamUrl: String,
         newProxyHost: String,
@@ -1672,17 +1648,6 @@ class RadioService : Service() {
     ) {
         if (!isRecording) {
             android.util.Log.d("RadioService", "switchRecordingStream called but not recording")
-            return
-        }
-
-        // Switching to an RTSP station while recording can't continue the
-        // recording - there's no HTTP response body to tee. Stop recording
-        // cleanly rather than hand an RTSP URL to the recording thread,
-        // which would just spin on connection failures.
-        if (isRtspStream(newStreamUrl)) {
-            android.util.Log.w("RadioService", "New stream is RTSP - stopping recording (RTSP recording unsupported)")
-            broadcastRecordingError(getString(R.string.recording_error_rtsp_unsupported))
-            stopRecording()
             return
         }
 
@@ -2065,22 +2030,6 @@ class RadioService : Service() {
             val forceCustomProxyExceptTorI2P = PreferencesHelper.isForceCustomProxyExceptTorI2P(this)
             val isI2PStream = proxyType == ProxyType.I2P || streamUrl.contains(".i2p")
             val isTorStream = proxyType == ProxyType.TOR || streamUrl.contains(".onion")
-            val isRtsp = isRtspStream(streamUrl)
-
-            // RTSP uses its own transport (RTP over UDP/TCP) and bypasses
-            // OkHttp entirely - proxy settings, including the per-station
-            // proxy, don't apply. Reject rtsp:// whenever the user has
-            // asked for ANY kind of proxying (global force-* modes OR a
-            // per-station proxyType other than NONE) rather than silently
-            // leaking raw RTP to the clearnet.
-            val anyProxyRequired = forceTorAll || forceTorExceptI2P ||
-                forceCustomProxy || forceCustomProxyExceptTorI2P ||
-                proxyType != ProxyType.NONE
-            if (isRtsp && anyProxyRequired) {
-                android.util.Log.e("RadioService", "RTSP blocked: user has proxying configured but RTSP can't be proxied")
-                rejectUnsupportedCodec("RTSP (proxy mode)")
-                return
-            }
 
             android.util.Log.d("RadioService", "===== STREAM CONNECTION REQUEST =====")
             android.util.Log.d("RadioService", "Stream URL: $streamUrl")
@@ -2438,19 +2387,9 @@ class RadioService : Service() {
                 // Browser. This fixes streams with extensionless URLs (e.g.
                 // /listen?sid=1) that are actually HLS - the catalog tells us
                 // truthfully what they are even when the URL doesn't.
-                val useRtsp = isRtspStream(streamUrl)
-                val useHls = !useRtsp && (isHlsStream(streamUrl) || hlsHint)
-                val useDash = !useRtsp && isDashStream(streamUrl)
+                val useHls = isHlsStream(streamUrl) || hlsHint
+                val useDash = isDashStream(streamUrl)
                 val mediaSource: MediaSource = when {
-                    useRtsp -> {
-                        // RTSP bypasses OkHttp so it doesn't share our proxy /
-                        // bandwidth-tracking pipeline. The gate at the top of
-                        // playStream has already rejected rtsp:// URLs under
-                        // any proxy mode, so reaching here means the user has
-                        // no proxy configured and direct playback is OK.
-                        RtspMediaSource.Factory()
-                            .createMediaSource(MediaItem.fromUri(streamUrl))
-                    }
                     useHls -> {
                         HlsMediaSource.Factory(dataSourceFactory)
                             .createMediaSource(MediaItem.fromUri(streamUrl))

--- a/app/src/main/java/com/opensource/i2pradio/util/PlaylistResolver.kt
+++ b/app/src/main/java/com/opensource/i2pradio/util/PlaylistResolver.kt
@@ -74,10 +74,9 @@ object PlaylistResolver {
         }
 
         // Non-HTTP schemes can't be probed with OkHttp and never serve a
-        // playlist pointer in the first place - RTSP, MMS, and friends are
+        // playlist pointer in the first place - MMS, RTMP, and friends are
         // always direct transports. Short-circuit before any network work.
-        if (url.startsWith("rtsp://", ignoreCase = true) ||
-            url.startsWith("mms://", ignoreCase = true) ||
+        if (url.startsWith("mms://", ignoreCase = true) ||
             url.startsWith("rtmp://", ignoreCase = true) ||
             url.startsWith("rtmps://", ignoreCase = true)) {
             return Result.Resolved(url)
@@ -299,8 +298,7 @@ object PlaylistResolver {
             if (line.startsWith("#")) return@forEach
             if (line.startsWith("http://", ignoreCase = true) ||
                 line.startsWith("https://", ignoreCase = true) ||
-                line.startsWith("mms://", ignoreCase = true) ||
-                line.startsWith("rtsp://", ignoreCase = true)) {
+                line.startsWith("mms://", ignoreCase = true)) {
                 return line
             }
         }
@@ -364,8 +362,7 @@ object PlaylistResolver {
     private fun absolutise(baseUrl: String, resolved: String): String {
         if (resolved.startsWith("http://", ignoreCase = true) ||
             resolved.startsWith("https://", ignoreCase = true) ||
-            resolved.startsWith("mms://", ignoreCase = true) ||
-            resolved.startsWith("rtsp://", ignoreCase = true)) {
+            resolved.startsWith("mms://", ignoreCase = true)) {
             return resolved
         }
         return try {

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -566,7 +566,6 @@
     <string name="recording_error_io">خطأ إدخال/إخراج: %s</string>
     <string name="recording_error_generic">خطأ: %s</string>
     <string name="recording_error_hls_playlist">تعذر جلب قائمة تشغيل HLS</string>
-    <string name="recording_error_rtsp_unsupported">التسجيل غير مدعوم لبث RTSP</string>
     <string name="recording_error_proxy_blocked">تم حظر التسجيل: البروكسي المطلوب (Tor/مخصص) غير متاح</string>
 
     

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -567,7 +567,6 @@
     <string name="recording_error_io">E/A-Fehler: %s</string>
     <string name="recording_error_generic">Fehler: %s</string>
     <string name="recording_error_hls_playlist">HLS-Playlist konnte nicht abgerufen werden</string>
-    <string name="recording_error_rtsp_unsupported">Aufnahme wird für RTSP-Streams nicht unterstützt</string>
     <string name="recording_error_proxy_blocked">Aufnahme blockiert: Benötigter Proxy (Tor/Benutzerdefiniert) nicht verfügbar</string>
 
     

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -571,7 +571,6 @@
     <string name="recording_error_io">Error de E/S: %s</string>
     <string name="recording_error_generic">Error: %s</string>
     <string name="recording_error_hls_playlist">No se pudo obtener la lista de reproducción HLS</string>
-    <string name="recording_error_rtsp_unsupported">La grabación no es compatible con flujos RTSP</string>
     <string name="recording_error_proxy_blocked">Grabación bloqueada: el proxy requerido (Tor/personalizado) no está disponible</string>
 
     

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -567,7 +567,6 @@
     <string name="recording_error_io">خطای ورودی/خروجی: %s</string>
     <string name="recording_error_generic">خطا: %s</string>
     <string name="recording_error_hls_playlist">دریافت پلی‌لیست HLS ممکن نشد</string>
-    <string name="recording_error_rtsp_unsupported">ضبط برای جریان‌های RTSP پشتیبانی نمی‌شود</string>
     <string name="recording_error_proxy_blocked">ضبط مسدود شد: پروکسی موردنیاز (Tor/سفارشی) در دسترس نیست</string>
 
     

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -566,7 +566,6 @@
     <string name="recording_error_io">Erreur E/S : %s</string>
     <string name="recording_error_generic">Erreur : %s</string>
     <string name="recording_error_hls_playlist">Impossible de récupérer la liste de lecture HLS</string>
-    <string name="recording_error_rtsp_unsupported">L\'enregistrement n\'est pas pris en charge pour les flux RTSP</string>
     <string name="recording_error_proxy_blocked">Enregistrement bloqué : le proxy requis (Tor/personnalisé) n\'est pas disponible</string>
 
     

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -566,7 +566,6 @@
     <string name="recording_error_io">I/O त्रुटि: %s</string>
     <string name="recording_error_generic">त्रुटि: %s</string>
     <string name="recording_error_hls_playlist">HLS प्लेलिस्ट प्राप्त करने में असमर्थ</string>
-    <string name="recording_error_rtsp_unsupported">RTSP स्ट्रीम के लिए रिकॉर्डिंग समर्थित नहीं है</string>
     <string name="recording_error_proxy_blocked">रिकॉर्डिंग अवरुद्ध: आवश्यक प्रॉक्सी (Tor/कस्टम) उपलब्ध नहीं है</string>
 
     

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -566,7 +566,6 @@
     <string name="recording_error_io">Errore I/O: %s</string>
     <string name="recording_error_generic">Errore: %s</string>
     <string name="recording_error_hls_playlist">Impossibile recuperare la playlist HLS</string>
-    <string name="recording_error_rtsp_unsupported">La registrazione non è supportata per i flussi RTSP</string>
     <string name="recording_error_proxy_blocked">Registrazione bloccata: il proxy richiesto (Tor/personalizzato) non è disponibile</string>
 
     

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -566,7 +566,6 @@
     <string name="recording_error_io">I/Oエラー: %s</string>
     <string name="recording_error_generic">エラー: %s</string>
     <string name="recording_error_hls_playlist">HLSプレイリストを取得できません</string>
-    <string name="recording_error_rtsp_unsupported">RTSPストリームの録音はサポートされていません</string>
     <string name="recording_error_proxy_blocked">録音がブロックされました: 必要なプロキシ (Tor/カスタム) が利用できません</string>
 
     

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -566,7 +566,6 @@
     <string name="recording_error_io">I/O 오류: %s</string>
     <string name="recording_error_generic">오류: %s</string>
     <string name="recording_error_hls_playlist">HLS 재생목록을 가져올 수 없음</string>
-    <string name="recording_error_rtsp_unsupported">RTSP 스트림에는 녹음이 지원되지 않습니다</string>
     <string name="recording_error_proxy_blocked">녹음 차단됨: 필요한 프록시 (Tor/사용자 지정)를 사용할 수 없음</string>
 
     

--- a/app/src/main/res/values-my/strings.xml
+++ b/app/src/main/res/values-my/strings.xml
@@ -567,7 +567,6 @@
     <string name="recording_error_io">I/O အမှား: %s</string>
     <string name="recording_error_generic">အမှား: %s</string>
     <string name="recording_error_hls_playlist">HLS ပလေးလစ်ကို ရယူ၍မရပါ</string>
-    <string name="recording_error_rtsp_unsupported">RTSP streams အတွက် အသံသွင်းခြင်းကို မပံ့ပိုးပါ</string>
     <string name="recording_error_proxy_blocked">အသံသွင်းခြင်း ပိတ်ဆို့ထားသည်- လိုအပ်သော ပရောက်ဆီ (Tor/စိတ်ကြိုက်) မရနိုင်ပါ</string>
 
     

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -567,7 +567,6 @@
     <string name="recording_error_io">Erro de E/S: %s</string>
     <string name="recording_error_generic">Erro: %s</string>
     <string name="recording_error_hls_playlist">Não foi possível obter a lista de reprodução HLS</string>
-    <string name="recording_error_rtsp_unsupported">A gravação não é compatível com streams RTSP</string>
     <string name="recording_error_proxy_blocked">Gravação bloqueada: o proxy necessário (Tor/personalizado) não está disponível</string>
 
     

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -566,7 +566,6 @@
     <string name="recording_error_io">Ошибка ввода/вывода: %s</string>
     <string name="recording_error_generic">Ошибка: %s</string>
     <string name="recording_error_hls_playlist">Не удалось получить плейлист HLS</string>
-    <string name="recording_error_rtsp_unsupported">Запись не поддерживается для потоков RTSP</string>
     <string name="recording_error_proxy_blocked">Запись заблокирована: требуемый прокси (Tor/пользовательский) недоступен</string>
 
     

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -567,7 +567,6 @@
     <string name="recording_error_io">G/Ç hatası: %s</string>
     <string name="recording_error_generic">Hata: %s</string>
     <string name="recording_error_hls_playlist">HLS çalma listesi alınamadı</string>
-    <string name="recording_error_rtsp_unsupported">RTSP akışları için kayıt desteklenmiyor</string>
     <string name="recording_error_proxy_blocked">Kayıt engellendi: Gerekli proxy (Tor/özel) mevcut değil</string>
 
     

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -567,7 +567,6 @@
     <string name="recording_error_io">Помилка вводу/виводу: %s</string>
     <string name="recording_error_generic">Помилка: %s</string>
     <string name="recording_error_hls_playlist">Не вдалося отримати плейлист HLS</string>
-    <string name="recording_error_rtsp_unsupported">Запис не підтримується для потоків RTSP</string>
     <string name="recording_error_proxy_blocked">Запис заблоковано: потрібний проксі (Tor/користувацький) недоступний</string>
 
     

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -567,7 +567,6 @@
     <string name="recording_error_io">Lỗi I/O: %s</string>
     <string name="recording_error_generic">Lỗi: %s</string>
     <string name="recording_error_hls_playlist">Không thể tải danh sách phát HLS</string>
-    <string name="recording_error_rtsp_unsupported">Ghi âm không được hỗ trợ cho luồng RTSP</string>
     <string name="recording_error_proxy_blocked">Ghi âm bị chặn: proxy bắt buộc (Tor/tùy chỉnh) không khả dụng</string>
 
     

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -567,7 +567,6 @@
     <string name="recording_error_io">I/O 错误：%s</string>
     <string name="recording_error_generic">错误：%s</string>
     <string name="recording_error_hls_playlist">无法获取HLS播放列表</string>
-    <string name="recording_error_rtsp_unsupported">RTSP流不支持录制</string>
     <string name="recording_error_proxy_blocked">录制被阻止：所需的代理（Tor/自定义）不可用</string>
 
     

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -618,7 +618,6 @@
     <string name="recording_error_io">I/O error: %s</string>
     <string name="recording_error_generic">Error: %s</string>
     <string name="recording_error_hls_playlist">Unable to fetch HLS playlist</string>
-    <string name="recording_error_rtsp_unsupported">Recording isn\'t supported for RTSP streams</string>
     <string name="recording_error_proxy_blocked">Recording blocked: required proxy (Tor/custom) is not available</string>
 
     <!-- Custom Proxy Messages -->


### PR DESCRIPTION
removes rtsp support - was never implemented in 1.7.0

Literally 0 stations in radio browser use it as far as I can tell, and I don't want to waste time making sure it's secure 