### PR TITLE
i18n: translate Android Auto strings across 16 locales, bump to 1.8

### DIFF
--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -270,7 +270,7 @@
 
     
     <string name="settings_about">حول</string>
-    <string name="settings_version">الإصدار 1.7</string>
+    <string name="settings_version">الإصدار 1.8</string>
     <string name="settings_view_github">عرض على GitHub</string>
     <string name="settings_donate">تبرع</string>
     <string name="settings_donate_description">إذا ساعدك هذا التطبيق، فكر في التبرع</string>
@@ -679,6 +679,33 @@
     <string name="settings_disable_cover_art_description">منع تحميل صور المحطات من الخوادم الخارجية</string>
     <string name="settings_network_api_info">يتصل التطبيق فقط بـ: واجهة RadioBrowser لمحطات الإنترنت العادي، وواجهة Radio Registry لمحطات Tor/I2P، والخوادم الخارجية لصور الغلاف، والبث المباشر عند التشغيل.</string>
     <string name="settings_offline_mode_note">كلتا الواجهتين معطلتان: يعرض تبويب التصفح المكتبة المحلية فقط. يمكنك الاستمرار في تشغيل المحطات المحفوظة واستيراد محطات من الملفات.</string>
+
+    <!-- Integrations (Android Auto) -->
+    <string name="settings_integrations">عمليات الدمج</string>
+    <string name="settings_android_auto">دعم Android Auto</string>
+    <string name="settings_android_auto_description">اكشف محطاتك لتطبيق Android Auto من Google حتى تتمكن من تشغيلها من وحدة رأس السيارة. معطّل افتراضيًا.</string>
+    <string name="settings_android_auto_info">عند التفعيل، تظهر فقط المحطات غير المعتمدة على وكيل في Android Auto. المحطات التي تستخدم وكيلًا (Tor، I2P، إلخ) مخفية افتراضيًا من Android Auto للحفاظ على الخصوصية.</string>
+    <string name="settings_android_auto_blocked_force_proxy">تم تعطيل Android Auto لأن إعداد فرض الوكيل مفعّل (فرض Tor، أو فرض Tor باستثناء I2P، أو فرض الوكيل المخصص). يستخدم التشغيل من Android Auto خط صوتي منفصل لا يمر عبر تلك الوكلاء، لذا فإن تفعيله سيتجاوزها. أوقف فرض الوكيل لتفعيل Android Auto.</string>
+    <string name="android_auto_warning_title">تفعيل Android Auto؟</string>
+    <string name="android_auto_warning_message">قبل تفعيل هذا، إليك ما سيتغير:\n\n• ستظهر محطاتك على الإنترنت العادي في Android Auto.\n\n• ستشاهد عملية Android Auto من Google اسم المحطة والمقطع الحالي والغلاف أثناء التشغيل.\n\n• تبقى محطات Tor وI2P والوكيل المخصص مخفية افتراضيًا. بعد تفعيل Android Auto، يمكنك اختيار السماح بإظهارها أيضًا: ستحذرك الإعدادات من المساومة على الخصوصية قبل ذلك.\n\n• إذا فعّلت يومًا فرض Tor أو فرض الوكيل المخصص، سيتم تعطيل Android Auto تلقائيًا حتى تعيد إيقاف ذلك.\n\n• يمكنك إيقاف Android Auto مرة أخرى في أي وقت من الإعدادات.</string>
+    <string name="android_auto_warning_enable">تفعيل Android Auto</string>
+    <string name="android_auto_warning_cancel">إلغاء</string>
+    <string name="auto_node_favorites">المفضلة</string>
+    <string name="auto_node_all_stations">جميع المحطات</string>
+
+    <!-- AA: per-station proxy opt-in -->
+    <string name="settings_aa_allow_proxy_stations">إظهار محطات الوكيل في Android Auto</string>
+    <string name="settings_aa_allow_proxy_stations_description">معطّل افتراضيًا. عند التفعيل، ستظهر أيضًا محطات Tor / I2P / الوكيل المخصص في Android Auto وتُشغَّل عبر وكيلها. الصوت نفسه خاص، ولكن اسم المحطة والبيانات الوصفية مرئية لعملية Android Auto من Google.</string>
+    <string name="aa_allow_proxy_warning_title">إظهار محطات الوكيل في Android Auto؟</string>
+    <string name="aa_allow_proxy_warning_message">سيظل صوت هذه المحطات يمر عبر وكيل Tor / I2P / المخصص المكوَّن على هاتفك: يبقى التشغيل نفسه عبر الوكيل.\n\nولكن عملية Android Auto من Google ترى اسم المحطة والمقطع الحالي والغلاف. فبينما *ما تستمع إليه* لا يُرسل إلى Google، فإن *حقيقة استماعك إلى محطة معينة* ستكون مرئية لـ Google. إذا كانت الخصوصية ضرورية، فلا تستخدم Android Auto. </string>
+    <string name="aa_allow_proxy_warning_enable">إظهارها</string>
+    <string name="aa_allow_proxy_warning_cancel">إبقاؤها مخفية</string>
+
+    <!-- AA: first-connect notification (Moment 2) -->
+    <string name="aa_notification_channel_name">Android Auto</string>
+    <string name="aa_notification_channel_description">إشعارات لمرة واحدة حول إعداد Android Auto. لا يستخدم التطبيق هذه القناة للتشغيل المستمر.</string>
+    <string name="aa_first_connect_title">تم الاتصال بـ Android Auto</string>
+    <string name="aa_first_connect_text">تظهر محطات الإنترنت العادي في السيارة. اضغط لاختيار ما إذا كانت محطات Tor وI2P والوكيل المخصص يجب أن تظهر أيضًا.</string>
 
     <!-- Browse - Offline Mode -->
     <string name="browse_offline_mode_title">وضع عدم الاتصال</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -270,7 +270,7 @@
 
     
     <string name="settings_about">Über</string>
-    <string name="settings_version">Version 1.7</string>
+    <string name="settings_version">Version 1.8</string>
     <string name="settings_view_github">Auf GitHub ansehen</string>
     <string name="settings_donate">Spenden</string>
     <string name="settings_donate_description">Wenn Ihnen diese App geholfen hat, ziehen Sie eine Spende in Betracht</string>
@@ -680,6 +680,33 @@
     <string name="settings_disable_cover_art_description">Laden von Sender-Artwork von externen Servern verhindern</string>
     <string name="settings_network_api_info">Die App verbindet sich nur mit: RadioBrowser-API für Clearnet-Sender, Radio Registry-API für Tor/I2P-Sender, externen Servern für Sender-Cover-Art und Radiostreams beim Abspielen.</string>
     <string name="settings_offline_mode_note">Beide APIs deaktiviert: Der Durchsuchen-Tab zeigt nur die lokale Bibliothek. Sie können weiterhin gespeicherte Sender abspielen und Sender aus Dateien importieren.</string>
+
+    <!-- Integrations (Android Auto) -->
+    <string name="settings_integrations">Integrationen</string>
+    <string name="settings_android_auto">Android Auto-Unterstützung</string>
+    <string name="settings_android_auto_description">Geben Sie Ihre Sender für Googles Android Auto-App frei, damit Sie sie über das Autoradio wiedergeben können. Standardmäßig deaktiviert.</string>
+    <string name="settings_android_auto_info">Wenn aktiviert, werden in Android Auto nur nicht-proxied Sender angezeigt. Sender, die über einen Proxy (Tor, I2P usw.) laufen, werden aus Datenschutzgründen standardmäßig in Android Auto ausgeblendet.</string>
+    <string name="settings_android_auto_blocked_force_proxy">Android Auto ist deaktiviert, weil eine Proxy-Erzwingungseinstellung aktiv ist (Tor erzwingen, Tor erzwingen außer I2P oder Benutzerdefinierten Proxy erzwingen). Die Wiedergabe über Android Auto verwendet eine separate Audio-Pipeline, die nicht über diese Proxys geleitet wird, sodass die Aktivierung sie umgehen würde. Deaktivieren Sie die Proxy-Erzwingung, um Android Auto zu aktivieren.</string>
+    <string name="android_auto_warning_title">Android Auto aktivieren?</string>
+    <string name="android_auto_warning_message">Bevor Sie dies aktivieren, hier was sich ändert:\n\n• Ihre Clearnet-Sender werden in Android Auto angezeigt.\n\n• Googles Android Auto-Prozess sieht während der Wiedergabe den Sendernamen, den aktuellen Titel und das Cover.\n\n• Tor-, I2P- und benutzerdefinierte Proxy-Sender bleiben standardmäßig ausgeblendet. Nach der Aktivierung von Android Auto können Sie wählen, ob diese ebenfalls angezeigt werden sollen: Die Einstellungen warnen Sie zuvor über den Datenschutz-Kompromiss.\n\n• Wenn Sie jemals Tor erzwingen oder Benutzerdefinierten Proxy erzwingen aktivieren, wird Android Auto automatisch deaktiviert, bis Sie dies wieder ausschalten.\n\n• Sie können Android Auto jederzeit wieder über die Einstellungen deaktivieren.</string>
+    <string name="android_auto_warning_enable">Android Auto aktivieren</string>
+    <string name="android_auto_warning_cancel">Abbrechen</string>
+    <string name="auto_node_favorites">Favoriten</string>
+    <string name="auto_node_all_stations">Alle Sender</string>
+
+    <!-- AA: per-station proxy opt-in -->
+    <string name="settings_aa_allow_proxy_stations">Proxy-Sender in Android Auto anzeigen</string>
+    <string name="settings_aa_allow_proxy_stations_description">Standardmäßig deaktiviert. Wenn aktiviert, werden Ihre Tor- / I2P- / benutzerdefinierten Proxy-Sender ebenfalls in Android Auto angezeigt und über ihren Proxy wiedergegeben. Der Audiostream selbst bleibt privat, aber der Sendername und die Metadaten sind für Googles Android Auto-Prozess sichtbar.</string>
+    <string name="aa_allow_proxy_warning_title">Proxy-Sender in Android Auto anzeigen?</string>
+    <string name="aa_allow_proxy_warning_message">Das Audio dieser Sender wird weiterhin über den konfigurierten Tor- / I2P- / benutzerdefinierten Proxy auf Ihrem Telefon geleitet: Die Wiedergabe selbst bleibt proxied.\n\nAber Googles Android Auto-Prozess sieht den Sendernamen, den aktuellen Titel und das Cover. Während also *das, was Sie hören*, nicht an Google gesendet wird, ist *die Tatsache, dass Sie einen bestimmten Sender hören*, für Google sichtbar. Wenn Datenschutz ein Muss ist, verwenden Sie Android Auto nicht. </string>
+    <string name="aa_allow_proxy_warning_enable">Anzeigen</string>
+    <string name="aa_allow_proxy_warning_cancel">Ausgeblendet lassen</string>
+
+    <!-- AA: first-connect notification (Moment 2) -->
+    <string name="aa_notification_channel_name">Android Auto</string>
+    <string name="aa_notification_channel_description">Einmalige Benachrichtigungen zur Einrichtung von Android Auto. Die App verwendet diesen Kanal nicht für die laufende Wiedergabe.</string>
+    <string name="aa_first_connect_title">Android Auto ist jetzt verbunden</string>
+    <string name="aa_first_connect_text">Ihre Clearnet-Sender werden im Auto angezeigt. Tippen Sie, um auszuwählen, ob Tor-, I2P- und benutzerdefinierte Proxy-Sender ebenfalls erscheinen sollen.</string>
 
     <!-- Browse - Offline Mode -->
     <string name="browse_offline_mode_title">Offline-Modus</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -274,7 +274,7 @@
 
     
     <string name="settings_about">Acerca de</string>
-    <string name="settings_version">Versión 1.7</string>
+    <string name="settings_version">Versión 1.8</string>
     <string name="settings_view_github">Ver en GitHub</string>
     <string name="settings_donate">Donar</string>
     <string name="settings_donate_description">Si esta aplicación te ayudó, considera hacer una donación</string>
@@ -680,6 +680,33 @@
     <string name="settings_disable_cover_art_description">Evitar cargar imágenes de emisoras desde servidores externos</string>
     <string name="settings_network_api_info">La aplicación solo se conecta a: API de RadioBrowser para emisoras de clearnet, API de Radio Registry para emisoras Tor/I2P, servidores externos para carátulas y transmisiones de radio al reproducir.</string>
     <string name="settings_offline_mode_note">Ambas APIs desactivadas: La pestaña Explorar muestra solo la biblioteca local. Puedes seguir reproduciendo emisoras guardadas e importar emisoras desde archivos.</string>
+
+    <!-- Integrations (Android Auto) -->
+    <string name="settings_integrations">Integraciones</string>
+    <string name="settings_android_auto">Compatibilidad con Android Auto</string>
+    <string name="settings_android_auto_description">Expón tus emisoras a la aplicación Android Auto de Google para poder reproducirlas desde la unidad principal del coche. Desactivado por defecto.</string>
+    <string name="settings_android_auto_info">Cuando está activado, solo las emisoras sin proxy aparecen en Android Auto. Las emisoras que usan un proxy (Tor, I2P, etc.) están ocultas de Android Auto por defecto por privacidad.</string>
+    <string name="settings_android_auto_blocked_force_proxy">Android Auto está desactivado porque hay un ajuste de forzar proxy activado (Forzar Tor, Forzar Tor excepto I2P o Forzar proxy personalizado). La reproducción desde Android Auto usa una canalización de audio separada que no pasa por esos proxies, así que activarlo los eludiría. Desactiva forzar proxy para activar Android Auto.</string>
+    <string name="android_auto_warning_title">¿Activar Android Auto?</string>
+    <string name="android_auto_warning_message">Antes de activarlo, esto es lo que cambia:\n\n• Tus emisoras clearnet aparecerán en Android Auto.\n\n• El proceso de Android Auto de Google verá el nombre de la emisora, la pista actual y la carátula mientras reproduces.\n\n• Las emisoras Tor, I2P y de proxy personalizado permanecen ocultas por defecto. Después de activar Android Auto, puedes elegir que también se muestren: los ajustes te advertirán sobre el compromiso de privacidad antes de hacerlo.\n\n• Si alguna vez activas Forzar Tor o Forzar proxy personalizado, Android Auto se desactivará automáticamente hasta que vuelvas a apagarlo.\n\n• Puedes desactivar Android Auto de nuevo en cualquier momento desde Ajustes.</string>
+    <string name="android_auto_warning_enable">Activar Android Auto</string>
+    <string name="android_auto_warning_cancel">Cancelar</string>
+    <string name="auto_node_favorites">Favoritos</string>
+    <string name="auto_node_all_stations">Todas las emisoras</string>
+
+    <!-- AA: per-station proxy opt-in -->
+    <string name="settings_aa_allow_proxy_stations">Mostrar emisoras proxy en Android Auto</string>
+    <string name="settings_aa_allow_proxy_stations_description">Desactivado por defecto. Cuando está activado, tus emisoras Tor / I2P / proxy personalizado también aparecen en Android Auto y se reproducen a través de su proxy. El audio en sí es privado, pero el nombre de la emisora y los metadatos son visibles para el proceso de Android Auto de Google.</string>
+    <string name="aa_allow_proxy_warning_title">¿Mostrar emisoras proxy en Android Auto?</string>
+    <string name="aa_allow_proxy_warning_message">El audio de estas emisoras seguirá enrutándose a través de su proxy Tor / I2P / personalizado configurado en tu teléfono: la reproducción en sí permanece en el proxy.\n\nPero el proceso de Android Auto de Google ve el nombre de la emisora, la pista actual y la carátula. Así que aunque *lo que estás escuchando* no se envía a Google, *el hecho de que estás escuchando una emisora concreta* será visible para Google. Si la privacidad es imprescindible, no uses Android Auto. </string>
+    <string name="aa_allow_proxy_warning_enable">Mostrarlas</string>
+    <string name="aa_allow_proxy_warning_cancel">Mantenerlas ocultas</string>
+
+    <!-- AA: first-connect notification (Moment 2) -->
+    <string name="aa_notification_channel_name">Android Auto</string>
+    <string name="aa_notification_channel_description">Notificaciones únicas sobre la configuración de Android Auto. La aplicación no usa este canal para reproducción continua.</string>
+    <string name="aa_first_connect_title">Android Auto ya está conectado</string>
+    <string name="aa_first_connect_text">Tus emisoras clearnet se muestran en el coche. Toca para elegir si las emisoras Tor, I2P y de proxy personalizado también deben aparecer.</string>
 
     <!-- Browse - Offline Mode -->
     <string name="browse_offline_mode_title">Modo sin conexión</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -270,7 +270,7 @@
 
     
     <string name="settings_about">درباره</string>
-    <string name="settings_version">نسخه 1.7</string>
+    <string name="settings_version">نسخه 1.8</string>
     <string name="settings_view_github">مشاهده در GitHub</string>
     <string name="settings_donate">کمک مالی</string>
     <string name="settings_donate_description">اگر این برنامه به شما کمک کرد، کمک مالی را در نظر بگیرید</string>
@@ -680,6 +680,33 @@
     <string name="settings_disable_cover_art_description">جلوگیری از بارگذاری تصاویر ایستگاه از سرورهای خارجی</string>
     <string name="settings_network_api_info">برنامه فقط به این موارد متصل می‌شود: API رادیو براوزر برای ایستگاه‌های کلیرنت، API رجیستری رادیو برای ایستگاه‌های Tor/I2P، سرورهای خارجی برای تصاویر جلد، و پخش رادیو در هنگام پخش.</string>
     <string name="settings_offline_mode_note">هر دو API غیرفعال: زبانه مرور فقط کتابخانه محلی را نشان می‌دهد. می‌توانید همچنان ایستگاه‌های ذخیره شده را پخش کنید و ایستگاه‌ها را از فایل‌ها وارد کنید.</string>
+
+    <!-- Integrations (Android Auto) -->
+    <string name="settings_integrations">یکپارچه‌سازی‌ها</string>
+    <string name="settings_android_auto">پشتیبانی از Android Auto</string>
+    <string name="settings_android_auto_description">ایستگاه‌های خود را در معرض برنامه Android Auto گوگل قرار دهید تا بتوانید آن‌ها را از سیستم‌صوتی خودرو پخش کنید. به طور پیش‌فرض خاموش است.</string>
+    <string name="settings_android_auto_info">وقتی فعال باشد، فقط ایستگاه‌های بدون پراکسی در Android Auto نمایش داده می‌شوند. ایستگاه‌هایی که از پراکسی استفاده می‌کنند (Tor، I2P و غیره) به طور پیش‌فرض برای حفظ حریم خصوصی از Android Auto پنهان هستند.</string>
+    <string name="settings_android_auto_blocked_force_proxy">Android Auto غیرفعال است زیرا یک تنظیم اجبار-پراکسی روشن است (اجبار Tor، اجبار Tor به جز I2P، یا اجبار پراکسی سفارشی). پخش از Android Auto از یک خط صوتی جداگانه استفاده می‌کند که از آن پراکسی‌ها عبور نمی‌کند، بنابراین فعال کردن آن آن‌ها را دور می‌زند. اجبار-پراکسی را خاموش کنید تا Android Auto فعال شود.</string>
+    <string name="android_auto_warning_title">Android Auto فعال شود؟</string>
+    <string name="android_auto_warning_message">قبل از فعال کردن، آنچه تغییر می‌کند:\n\n• ایستگاه‌های کلیرنت شما در Android Auto ظاهر می‌شوند.\n\n• فرآیند Android Auto گوگل هنگام پخش، نام ایستگاه، قطعه فعلی و تصویر جلد را می‌بیند.\n\n• ایستگاه‌های Tor، I2P و پراکسی سفارشی به طور پیش‌فرض پنهان می‌مانند. پس از فعال کردن Android Auto، می‌توانید اجازه دهید آن‌ها نیز نمایش داده شوند: تنظیمات قبل از آن درباره معامله حریم خصوصی به شما هشدار می‌دهد.\n\n• اگر روزی اجبار Tor یا اجبار پراکسی سفارشی را روشن کنید، Android Auto به طور خودکار غیرفعال می‌شود تا زمانی که آن را خاموش کنید.\n\n• می‌توانید هر زمان بخواهید Android Auto را از تنظیمات خاموش کنید.</string>
+    <string name="android_auto_warning_enable">فعال کردن Android Auto</string>
+    <string name="android_auto_warning_cancel">لغو</string>
+    <string name="auto_node_favorites">موردعلاقه‌ها</string>
+    <string name="auto_node_all_stations">همه ایستگاه‌ها</string>
+
+    <!-- AA: per-station proxy opt-in -->
+    <string name="settings_aa_allow_proxy_stations">نمایش ایستگاه‌های پراکسی در Android Auto</string>
+    <string name="settings_aa_allow_proxy_stations_description">به طور پیش‌فرض خاموش. وقتی روشن باشد، ایستگاه‌های Tor / I2P / پراکسی سفارشی شما نیز در Android Auto ظاهر می‌شوند و از طریق پراکسی خود پخش می‌شوند. خود صدا خصوصی است، اما نام ایستگاه و فراداده‌ها برای فرآیند Android Auto گوگل قابل مشاهده است.</string>
+    <string name="aa_allow_proxy_warning_title">ایستگاه‌های پراکسی در Android Auto نمایش داده شوند؟</string>
+    <string name="aa_allow_proxy_warning_message">صدای این ایستگاه‌ها همچنان از طریق پراکسی Tor / I2P / سفارشی پیکربندی‌شده روی تلفن شما مسیریابی می‌شود: خود پخش پراکسی‌شده باقی می‌ماند.\n\nاما فرآیند Android Auto گوگل نام ایستگاه، قطعه فعلی و تصویر جلد را می‌بیند. بنابراین درحالی‌که *آنچه می‌شنوید* به گوگل ارسال نمی‌شود، *این واقعیت که به یک ایستگاه خاص گوش می‌دهید* برای گوگل قابل مشاهده خواهد بود. اگر حریم خصوصی ضروری است، از Android Auto استفاده نکنید. </string>
+    <string name="aa_allow_proxy_warning_enable">نمایش آن‌ها</string>
+    <string name="aa_allow_proxy_warning_cancel">پنهان نگه دارید</string>
+
+    <!-- AA: first-connect notification (Moment 2) -->
+    <string name="aa_notification_channel_name">Android Auto</string>
+    <string name="aa_notification_channel_description">اعلان‌های یک‌بار مصرف درباره راه‌اندازی Android Auto. برنامه از این کانال برای پخش مداوم استفاده نمی‌کند.</string>
+    <string name="aa_first_connect_title">Android Auto اکنون متصل شد</string>
+    <string name="aa_first_connect_text">ایستگاه‌های کلیرنت شما در خودرو نمایش داده می‌شوند. ضربه بزنید تا انتخاب کنید ایستگاه‌های Tor، I2P و پراکسی سفارشی نیز نمایش داده شوند یا نه.</string>
 
     <!-- Browse - Offline Mode -->
     <string name="browse_offline_mode_title">حالت آفلاین</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -270,7 +270,7 @@
 
     
     <string name="settings_about">À propos</string>
-    <string name="settings_version">Version 1.7</string>
+    <string name="settings_version">Version 1.8</string>
     <string name="settings_view_github">Voir sur GitHub</string>
     <string name="settings_donate">Faire un don</string>
     <string name="settings_donate_description">Si cette application vous a aidé, envisagez de faire un don</string>
@@ -679,6 +679,33 @@
     <string name="settings_disable_cover_art_description">Empêcher le chargement des images de stations depuis des serveurs externes</string>
     <string name="settings_network_api_info">L\'application se connecte uniquement à : l\'API RadioBrowser pour les stations clearnet, l\'API Radio Registry pour les stations Tor/I2P, les serveurs externes pour les pochettes et les flux radio lors de la lecture.</string>
     <string name="settings_offline_mode_note">Les deux APIs désactivées : l\'onglet Parcourir affiche uniquement la bibliothèque locale. Vous pouvez toujours lire les stations enregistrées et importer des stations depuis des fichiers.</string>
+
+    <!-- Integrations (Android Auto) -->
+    <string name="settings_integrations">Intégrations</string>
+    <string name="settings_android_auto">Prise en charge d\'Android Auto</string>
+    <string name="settings_android_auto_description">Exposez vos stations à l\'application Android Auto de Google pour pouvoir les lire depuis une unité de tête de voiture. Désactivé par défaut.</string>
+    <string name="settings_android_auto_info">Lorsque cette option est activée, seules les stations non proxyfiées apparaissent dans Android Auto. Les stations qui passent par un proxy (Tor, I2P, etc.) sont masquées d\'Android Auto par défaut pour des raisons de confidentialité.</string>
+    <string name="settings_android_auto_blocked_force_proxy">Android Auto est désactivé car un paramètre de forçage de proxy est activé (Forcer Tor, Forcer Tor sauf I2P ou Forcer un proxy personnalisé). La lecture depuis Android Auto utilise un pipeline audio distinct qui ne passe pas par ces proxys, donc l\'activer contournerait ceux-ci. Désactivez le forçage de proxy pour activer Android Auto.</string>
+    <string name="android_auto_warning_title">Activer Android Auto ?</string>
+    <string name="android_auto_warning_message">Avant d\'activer cette option, voici ce qui change :\n\n• Vos stations clearnet apparaîtront dans Android Auto.\n\n• Le processus Android Auto de Google verra le nom de la station, la piste en cours et la pochette pendant la lecture.\n\n• Les stations Tor, I2P et à proxy personnalisé restent masquées par défaut. Après avoir activé Android Auto, vous pouvez choisir de les laisser apparaître aussi : les Paramètres vous avertiront du compromis de confidentialité avant de le faire.\n\n• Si vous activez un jour Forcer Tor ou Forcer le proxy personnalisé, Android Auto sera automatiquement désactivé jusqu\'à ce que vous le désactiviez à nouveau.\n\n• Vous pouvez désactiver Android Auto à tout moment depuis les Paramètres.</string>
+    <string name="android_auto_warning_enable">Activer Android Auto</string>
+    <string name="android_auto_warning_cancel">Annuler</string>
+    <string name="auto_node_favorites">Favoris</string>
+    <string name="auto_node_all_stations">Toutes les stations</string>
+
+    <!-- AA: per-station proxy opt-in -->
+    <string name="settings_aa_allow_proxy_stations">Afficher les stations proxy dans Android Auto</string>
+    <string name="settings_aa_allow_proxy_stations_description">Désactivé par défaut. Lorsqu\'il est activé, vos stations Tor / I2P / proxy personnalisé apparaissent également dans Android Auto et sont lues via leur proxy. L\'audio lui-même est privé, mais le nom de la station et les métadonnées sont visibles par le processus Android Auto de Google.</string>
+    <string name="aa_allow_proxy_warning_title">Afficher les stations proxy dans Android Auto ?</string>
+    <string name="aa_allow_proxy_warning_message">L\'audio de ces stations sera toujours acheminé via leur proxy Tor / I2P / personnalisé configuré sur votre téléphone : la lecture elle-même reste proxyfiée.\n\nMais le processus Android Auto de Google voit le nom de la station, la piste en cours et la pochette. Donc, bien que *ce que vous écoutez* ne soit pas envoyé à Google, *le fait que vous écoutiez une station spécifique* sera visible par Google. Si la confidentialité est indispensable, n\'utilisez pas Android Auto. </string>
+    <string name="aa_allow_proxy_warning_enable">Les afficher</string>
+    <string name="aa_allow_proxy_warning_cancel">Les garder masquées</string>
+
+    <!-- AA: first-connect notification (Moment 2) -->
+    <string name="aa_notification_channel_name">Android Auto</string>
+    <string name="aa_notification_channel_description">Notifications uniques concernant la configuration d\'Android Auto. L\'application n\'utilise pas ce canal pour la lecture en cours.</string>
+    <string name="aa_first_connect_title">Android Auto est maintenant connecté</string>
+    <string name="aa_first_connect_text">Vos stations clearnet s\'affichent dans la voiture. Appuyez pour choisir si les stations Tor, I2P et à proxy personnalisé doivent également apparaître.</string>
 
     <!-- Browse - Offline Mode -->
     <string name="browse_offline_mode_title">Mode hors ligne</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -270,7 +270,7 @@
 
     
     <string name="settings_about">के बारे में</string>
-    <string name="settings_version">संस्करण 1.7</string>
+    <string name="settings_version">संस्करण 1.8</string>
     <string name="settings_view_github">GitHub पर देखें</string>
     <string name="settings_donate">दान करें</string>
     <string name="settings_donate_description">यदि इस ऐप ने आपकी मदद की, तो दान करने पर विचार करें</string>
@@ -679,6 +679,33 @@
     <string name="settings_disable_cover_art_description">बाहरी सर्वरों से स्टेशन आर्टवर्क लोड होने से रोकें</string>
     <string name="settings_network_api_info">ऐप केवल इनसे कनेक्ट होता है: क्लियरनेट स्टेशनों के लिए RadioBrowser API, Tor/I2P स्टेशनों के लिए Radio Registry API, कवर आर्ट के लिए बाहरी सर्वर, और चलाते समय रेडियो स्ट्रीम।</string>
     <string name="settings_offline_mode_note">दोनों APIs अक्षम: ब्राउज़ टैब केवल स्थानीय लाइब्रेरी दिखाता है। आप अभी भी सहेजे गए स्टेशन चला सकते हैं और फ़ाइलों से स्टेशन आयात कर सकते हैं।</string>
+
+    <!-- Integrations (Android Auto) -->
+    <string name="settings_integrations">एकीकरण</string>
+    <string name="settings_android_auto">Android Auto समर्थन</string>
+    <string name="settings_android_auto_description">अपने स्टेशन Google के Android Auto ऐप को उजागर करें ताकि आप उन्हें कार हेड यूनिट से चला सकें। डिफ़ॉल्ट रूप से बंद।</string>
+    <string name="settings_android_auto_info">सक्षम होने पर, केवल गैर-प्रॉक्सी स्टेशन Android Auto में दिखाई देते हैं। प्रॉक्सी वाले स्टेशन (Tor, I2P, आदि) गोपनीयता के लिए Android Auto से डिफ़ॉल्ट रूप से छिपे रहते हैं।</string>
+    <string name="settings_android_auto_blocked_force_proxy">Android Auto अक्षम है क्योंकि एक फ़ोर्स-प्रॉक्सी सेटिंग चालू है (फ़ोर्स Tor, I2P को छोड़कर फ़ोर्स Tor, या फ़ोर्स कस्टम प्रॉक्सी)। Android Auto से प्लेबैक एक अलग ऑडियो पाइपलाइन का उपयोग करता है जो उन प्रॉक्सियों से नहीं गुज़रती, इसलिए इसे सक्षम करना उन्हें बायपास कर देगा। Android Auto सक्षम करने के लिए फ़ोर्स-प्रॉक्सी बंद करें।</string>
+    <string name="android_auto_warning_title">Android Auto सक्षम करें?</string>
+    <string name="android_auto_warning_message">इसे चालू करने से पहले, यहां क्या बदलता है:\n\n• आपके क्लियरनेट स्टेशन Android Auto में दिखाई देंगे।\n\n• Google की Android Auto प्रक्रिया आपके चलाते समय स्टेशन का नाम, वर्तमान ट्रैक और आर्टवर्क देखेगी।\n\n• Tor, I2P और कस्टम-प्रॉक्सी स्टेशन डिफ़ॉल्ट रूप से छिपे रहते हैं। Android Auto सक्षम करने के बाद, आप उन्हें भी दिखाने की अनुमति दे सकते हैं: पहले सेटिंग्स आपको गोपनीयता समझौते के बारे में चेतावनी देगी।\n\n• यदि आप कभी फ़ोर्स Tor या फ़ोर्स कस्टम प्रॉक्सी चालू करते हैं, तो Android Auto स्वचालित रूप से अक्षम हो जाएगा जब तक आप इसे वापस बंद नहीं करते।\n\n• आप किसी भी समय सेटिंग्स से Android Auto को फिर से बंद कर सकते हैं।</string>
+    <string name="android_auto_warning_enable">Android Auto सक्षम करें</string>
+    <string name="android_auto_warning_cancel">रद्द करें</string>
+    <string name="auto_node_favorites">पसंदीदा</string>
+    <string name="auto_node_all_stations">सभी स्टेशन</string>
+
+    <!-- AA: per-station proxy opt-in -->
+    <string name="settings_aa_allow_proxy_stations">Android Auto में प्रॉक्सी स्टेशन दिखाएं</string>
+    <string name="settings_aa_allow_proxy_stations_description">डिफ़ॉल्ट रूप से बंद। चालू होने पर, आपके Tor / I2P / कस्टम-प्रॉक्सी स्टेशन भी Android Auto में दिखाई देते हैं और अपने प्रॉक्सी के माध्यम से चलते हैं। ऑडियो स्वयं निजी है, लेकिन स्टेशन का नाम और मेटाडेटा Google की Android Auto प्रक्रिया को दिखाई देते हैं।</string>
+    <string name="aa_allow_proxy_warning_title">Android Auto में प्रॉक्सी स्टेशन दिखाएं?</string>
+    <string name="aa_allow_proxy_warning_message">इन स्टेशनों के लिए ऑडियो अभी भी आपके फ़ोन पर कॉन्फ़िगर किए गए Tor / I2P / कस्टम प्रॉक्सी के माध्यम से रूट होगा: प्लेबैक स्वयं प्रॉक्सीकृत रहता है।\n\nलेकिन Google की Android Auto प्रक्रिया स्टेशन का नाम, वर्तमान ट्रैक और आर्टवर्क देखती है। तो जबकि *आप जो सुन रहे हैं* वह Google को नहीं भेजा जाता है, *यह तथ्य कि आप एक विशिष्ट स्टेशन सुन रहे हैं* Google को दिखाई देगा। यदि गोपनीयता अनिवार्य है, तो Android Auto का उपयोग न करें। </string>
+    <string name="aa_allow_proxy_warning_enable">दिखाएं</string>
+    <string name="aa_allow_proxy_warning_cancel">छिपा रखें</string>
+
+    <!-- AA: first-connect notification (Moment 2) -->
+    <string name="aa_notification_channel_name">Android Auto</string>
+    <string name="aa_notification_channel_description">Android Auto सेटअप के बारे में एक बार की सूचनाएं। ऐप चल रहे प्लेबैक के लिए इस चैनल का उपयोग नहीं करता है।</string>
+    <string name="aa_first_connect_title">Android Auto अब कनेक्ट है</string>
+    <string name="aa_first_connect_text">आपके क्लियरनेट स्टेशन कार में दिख रहे हैं। Tor, I2P और कस्टम-प्रॉक्सी स्टेशन भी दिखने चाहिए या नहीं यह चुनने के लिए टैप करें।</string>
 
     <!-- Browse - Offline Mode -->
     <string name="browse_offline_mode_title">ऑफ़लाइन मोड</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -270,7 +270,7 @@
 
     
     <string name="settings_about">Informazioni</string>
-    <string name="settings_version">Versione 1.7</string>
+    <string name="settings_version">Versione 1.8</string>
     <string name="settings_view_github">Visualizza su GitHub</string>
     <string name="settings_donate">Dona</string>
     <string name="settings_donate_description">Se questa app ti ha aiutato, considera di donare</string>
@@ -679,6 +679,33 @@
     <string name="settings_disable_cover_art_description">Impedisci il caricamento delle immagini delle stazioni da server esterni</string>
     <string name="settings_network_api_info">L\'app si connette solo a: API RadioBrowser per stazioni clearnet, API Radio Registry per stazioni Tor/I2P, server esterni per copertine e streaming radio durante la riproduzione.</string>
     <string name="settings_offline_mode_note">Entrambe le API disabilitate: la scheda Sfoglia mostra solo la libreria locale. Puoi comunque riprodurre stazioni salvate e importare stazioni da file.</string>
+
+    <!-- Integrations (Android Auto) -->
+    <string name="settings_integrations">Integrazioni</string>
+    <string name="settings_android_auto">Supporto Android Auto</string>
+    <string name="settings_android_auto_description">Esponi le tue stazioni all\'app Android Auto di Google per poterle riprodurre dall\'unità principale dell\'auto. Disattivato per impostazione predefinita.</string>
+    <string name="settings_android_auto_info">Quando abilitato, in Android Auto appaiono solo le stazioni senza proxy. Le stazioni che usano un proxy (Tor, I2P, ecc.) sono nascoste da Android Auto per impostazione predefinita per motivi di privacy.</string>
+    <string name="settings_android_auto_blocked_force_proxy">Android Auto è disabilitato perché è attiva un\'impostazione di forzatura proxy (Forza Tor, Forza Tor eccetto I2P o Forza proxy personalizzato). La riproduzione da Android Auto utilizza una pipeline audio separata che non viene instradata attraverso quei proxy, quindi abilitarlo li aggirerebbe. Disattiva la forzatura proxy per abilitare Android Auto.</string>
+    <string name="android_auto_warning_title">Abilitare Android Auto?</string>
+    <string name="android_auto_warning_message">Prima di attivarlo, ecco cosa cambia:\n\n• Le tue stazioni clearnet appariranno in Android Auto.\n\n• Il processo Android Auto di Google vedrà il nome della stazione, il brano corrente e la copertina durante la riproduzione.\n\n• Le stazioni Tor, I2P e con proxy personalizzato rimangono nascoste per impostazione predefinita. Dopo aver abilitato Android Auto, puoi scegliere di mostrarle anche: le Impostazioni ti avviseranno del compromesso sulla privacy prima di farlo.\n\n• Se mai attivi Forza Tor o Forza proxy personalizzato, Android Auto verrà disabilitato automaticamente finché non lo riattivi.\n\n• Puoi disattivare Android Auto in qualsiasi momento dalle Impostazioni.</string>
+    <string name="android_auto_warning_enable">Abilita Android Auto</string>
+    <string name="android_auto_warning_cancel">Annulla</string>
+    <string name="auto_node_favorites">Preferiti</string>
+    <string name="auto_node_all_stations">Tutte le stazioni</string>
+
+    <!-- AA: per-station proxy opt-in -->
+    <string name="settings_aa_allow_proxy_stations">Mostra stazioni proxy in Android Auto</string>
+    <string name="settings_aa_allow_proxy_stations_description">Disattivato per impostazione predefinita. Quando attivato, le tue stazioni Tor / I2P / con proxy personalizzato appaiono anche in Android Auto e vengono riprodotte attraverso il loro proxy. L\'audio in sé è privato, ma il nome della stazione e i metadati sono visibili al processo Android Auto di Google.</string>
+    <string name="aa_allow_proxy_warning_title">Mostrare stazioni proxy in Android Auto?</string>
+    <string name="aa_allow_proxy_warning_message">L\'audio di queste stazioni verrà comunque instradato attraverso il proxy Tor / I2P / personalizzato configurato sul telefono: la riproduzione stessa rimane proxied.\n\nMa il processo Android Auto di Google vede il nome della stazione, il brano corrente e la copertina. Quindi, mentre *ciò che stai ascoltando* non viene inviato a Google, *il fatto che tu stia ascoltando una stazione specifica* sarà visibile a Google. Se la privacy è indispensabile, non usare Android Auto. </string>
+    <string name="aa_allow_proxy_warning_enable">Mostrale</string>
+    <string name="aa_allow_proxy_warning_cancel">Mantienile nascoste</string>
+
+    <!-- AA: first-connect notification (Moment 2) -->
+    <string name="aa_notification_channel_name">Android Auto</string>
+    <string name="aa_notification_channel_description">Notifiche una tantum sulla configurazione di Android Auto. L\'app non usa questo canale per la riproduzione continua.</string>
+    <string name="aa_first_connect_title">Android Auto è ora connesso</string>
+    <string name="aa_first_connect_text">Le tue stazioni clearnet sono visibili in auto. Tocca per scegliere se far apparire anche le stazioni Tor, I2P e con proxy personalizzato.</string>
 
     <!-- Browse - Offline Mode -->
     <string name="browse_offline_mode_title">Modalità offline</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -270,7 +270,7 @@
 
     
     <string name="settings_about">このアプリについて</string>
-    <string name="settings_version">バージョン 1.7</string>
+    <string name="settings_version">バージョン 1.8</string>
     <string name="settings_view_github">GitHubで見る</string>
     <string name="settings_donate">寄付</string>
     <string name="settings_donate_description">このアプリが役に立った場合は、寄付をご検討ください</string>
@@ -679,6 +679,33 @@
     <string name="settings_disable_cover_art_description">外部サーバーからのステーションアートワークの読み込みを防止</string>
     <string name="settings_network_api_info">アプリは次にのみ接続します: クリアネットステーション用のRadioBrowser API、Tor/I2Pステーション用のRadio Registry API、カバーアート用の外部サーバー、再生時のラジオストリーム。</string>
     <string name="settings_offline_mode_note">両方のAPIが無効: 参照タブはローカルライブラリのみを表示します。保存されたステーションの再生やファイルからのステーションのインポートは引き続き可能です。</string>
+
+    <!-- Integrations (Android Auto) -->
+    <string name="settings_integrations">統合</string>
+    <string name="settings_android_auto">Android Auto サポート</string>
+    <string name="settings_android_auto_description">Google の Android Auto アプリにステーションを公開し、車のヘッドユニットから再生できるようにします。デフォルトはオフです。</string>
+    <string name="settings_android_auto_info">有効にすると、プロキシされていないステーションのみが Android Auto に表示されます。プロキシされたステーション (Tor、I2P など) は、プライバシー保護のためデフォルトで Android Auto から非表示になります。</string>
+    <string name="settings_android_auto_blocked_force_proxy">強制プロキシ設定 (Tor を強制、I2P 以外に Tor を強制、またはカスタムプロキシを強制) が有効になっているため、Android Auto は無効になっています。Android Auto からの再生は、これらのプロキシを経由しない別のオーディオパイプラインを使用するため、有効にするとそれらをバイパスすることになります。Android Auto を有効にするには、強制プロキシをオフにしてください。</string>
+    <string name="android_auto_warning_title">Android Auto を有効にしますか？</string>
+    <string name="android_auto_warning_message">オンにする前に、以下の変更点をご確認ください:\n\n• クリアネットのステーションが Android Auto に表示されます。\n\n• 再生中、Google の Android Auto プロセスはステーション名、現在のトラック、アートワークを参照します。\n\n• Tor、I2P、カスタムプロキシのステーションはデフォルトで非表示のままです。Android Auto を有効にした後、それらも表示するかどうかを選択できます。実行前に設定でプライバシーのトレードオフについて警告が表示されます。\n\n• Tor を強制またはカスタムプロキシを強制をオンにした場合、再度オフにするまで Android Auto は自動的に無効になります。\n\n• Android Auto は、いつでも設定から再びオフにできます。</string>
+    <string name="android_auto_warning_enable">Android Auto を有効にする</string>
+    <string name="android_auto_warning_cancel">キャンセル</string>
+    <string name="auto_node_favorites">お気に入り</string>
+    <string name="auto_node_all_stations">すべてのステーション</string>
+
+    <!-- AA: per-station proxy opt-in -->
+    <string name="settings_aa_allow_proxy_stations">Android Auto にプロキシステーションを表示</string>
+    <string name="settings_aa_allow_proxy_stations_description">デフォルトではオフです。オンにすると、Tor / I2P / カスタムプロキシのステーションも Android Auto に表示され、それぞれのプロキシ経由で再生されます。オーディオ自体はプライベートですが、ステーション名とメタデータは Google の Android Auto プロセスから見えます。</string>
+    <string name="aa_allow_proxy_warning_title">Android Auto にプロキシステーションを表示しますか？</string>
+    <string name="aa_allow_proxy_warning_message">これらのステーションのオーディオは、引き続き端末上で設定された Tor / I2P / カスタムプロキシ経由でルーティングされます。再生自体はプロキシ経由のままです。\n\nしかし、Google の Android Auto プロセスはステーション名、現在のトラック、アートワークを参照します。つまり、*聴いている音声自体* は Google に送信されませんが、*特定のステーションを聴いているという事実* は Google から見えます。プライバシーが必須の場合は、Android Auto を使用しないでください。 </string>
+    <string name="aa_allow_proxy_warning_enable">表示する</string>
+    <string name="aa_allow_proxy_warning_cancel">非表示のままにする</string>
+
+    <!-- AA: first-connect notification (Moment 2) -->
+    <string name="aa_notification_channel_name">Android Auto</string>
+    <string name="aa_notification_channel_description">Android Auto のセットアップに関する 1 回限りの通知。アプリは継続的な再生にこのチャンネルを使用しません。</string>
+    <string name="aa_first_connect_title">Android Auto が接続されました</string>
+    <string name="aa_first_connect_text">クリアネットのステーションが車に表示されています。タップして、Tor、I2P、カスタムプロキシのステーションも表示するかどうかを選択してください。</string>
 
     <!-- Browse - Offline Mode -->
     <string name="browse_offline_mode_title">オフラインモード</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -270,7 +270,7 @@
 
     
     <string name="settings_about">정보</string>
-    <string name="settings_version">버전 1.7</string>
+    <string name="settings_version">버전 1.8</string>
     <string name="settings_view_github">GitHub에서 보기</string>
     <string name="settings_donate">기부</string>
     <string name="settings_donate_description">이 앱이 도움이 되었다면 기부를 고려해주세요</string>
@@ -679,6 +679,33 @@
     <string name="settings_disable_cover_art_description">외부 서버에서 방송국 아트워크 로드 방지</string>
     <string name="settings_network_api_info">앱은 다음에만 연결됩니다: 클리어넷 방송국용 RadioBrowser API, Tor/I2P 방송국용 Radio Registry API, 커버 아트용 외부 서버, 재생 시 라디오 스트림.</string>
     <string name="settings_offline_mode_note">두 API 모두 비활성화됨: 탐색 탭에 로컬 라이브러리만 표시됩니다. 저장된 방송국을 재생하고 파일에서 방송국을 가져올 수 있습니다.</string>
+
+    <!-- Integrations (Android Auto) -->
+    <string name="settings_integrations">통합</string>
+    <string name="settings_android_auto">Android Auto 지원</string>
+    <string name="settings_android_auto_description">Google의 Android Auto 앱에 방송국을 노출하여 차량 헤드 유닛에서 재생할 수 있도록 합니다. 기본값은 꺼짐입니다.</string>
+    <string name="settings_android_auto_info">활성화되면 프록시되지 않은 방송국만 Android Auto에 표시됩니다. 프록시된 방송국(Tor, I2P 등)은 프라이버시를 위해 기본적으로 Android Auto에서 숨겨집니다.</string>
+    <string name="settings_android_auto_blocked_force_proxy">강제 프록시 설정(Tor 강제, I2P 제외 Tor 강제 또는 사용자 지정 프록시 강제)이 활성화되어 있기 때문에 Android Auto가 비활성화되었습니다. Android Auto에서의 재생은 해당 프록시를 거치지 않는 별도의 오디오 파이프라인을 사용하므로 활성화하면 이를 우회하게 됩니다. Android Auto를 활성화하려면 강제 프록시를 끄세요.</string>
+    <string name="android_auto_warning_title">Android Auto를 활성화하시겠습니까?</string>
+    <string name="android_auto_warning_message">이를 켜기 전에 다음 변경 사항을 확인하세요:\n\n• 클리어넷 방송국이 Android Auto에 표시됩니다.\n\n• 재생 중 Google의 Android Auto 프로세스가 방송국 이름, 현재 트랙 및 아트워크를 볼 수 있습니다.\n\n• Tor, I2P 및 사용자 지정 프록시 방송국은 기본적으로 숨겨진 상태로 유지됩니다. Android Auto를 활성화한 후 해당 방송국도 표시할지 선택할 수 있으며, 설정에서 실행 전에 프라이버시 트레이드오프에 대해 경고합니다.\n\n• Tor 강제 또는 사용자 지정 프록시 강제를 켜면 다시 끌 때까지 Android Auto가 자동으로 비활성화됩니다.\n\n• 설정에서 언제든지 Android Auto를 다시 끌 수 있습니다.</string>
+    <string name="android_auto_warning_enable">Android Auto 활성화</string>
+    <string name="android_auto_warning_cancel">취소</string>
+    <string name="auto_node_favorites">즐겨찾기</string>
+    <string name="auto_node_all_stations">모든 방송국</string>
+
+    <!-- AA: per-station proxy opt-in -->
+    <string name="settings_aa_allow_proxy_stations">Android Auto에 프록시 방송국 표시</string>
+    <string name="settings_aa_allow_proxy_stations_description">기본적으로 꺼져 있습니다. 켜면 Tor / I2P / 사용자 지정 프록시 방송국도 Android Auto에 표시되며 해당 프록시를 통해 재생됩니다. 오디오 자체는 비공개이지만, 방송국 이름과 메타데이터는 Google의 Android Auto 프로세스에 표시됩니다.</string>
+    <string name="aa_allow_proxy_warning_title">Android Auto에 프록시 방송국을 표시하시겠습니까?</string>
+    <string name="aa_allow_proxy_warning_message">이 방송국의 오디오는 휴대전화에서 구성된 Tor / I2P / 사용자 지정 프록시를 통해 계속 라우팅됩니다: 재생 자체는 프록시된 상태로 유지됩니다.\n\n하지만 Google의 Android Auto 프로세스는 방송국 이름, 현재 트랙 및 아트워크를 볼 수 있습니다. 따라서 *듣고 있는 것* 은 Google에 전송되지 않지만, *특정 방송국을 듣고 있다는 사실* 은 Google에서 볼 수 있습니다. 프라이버시가 꼭 필요하다면 Android Auto를 사용하지 마세요. </string>
+    <string name="aa_allow_proxy_warning_enable">표시하기</string>
+    <string name="aa_allow_proxy_warning_cancel">숨긴 상태로 유지</string>
+
+    <!-- AA: first-connect notification (Moment 2) -->
+    <string name="aa_notification_channel_name">Android Auto</string>
+    <string name="aa_notification_channel_description">Android Auto 설정에 대한 일회성 알림입니다. 앱은 지속적인 재생에는 이 채널을 사용하지 않습니다.</string>
+    <string name="aa_first_connect_title">Android Auto가 연결되었습니다</string>
+    <string name="aa_first_connect_text">클리어넷 방송국이 자동차에 표시되고 있습니다. Tor, I2P 및 사용자 지정 프록시 방송국도 표시할지 선택하려면 탭하세요.</string>
 
     <!-- Browse - Offline Mode -->
     <string name="browse_offline_mode_title">오프라인 모드</string>

--- a/app/src/main/res/values-my/strings.xml
+++ b/app/src/main/res/values-my/strings.xml
@@ -270,7 +270,7 @@
 
     
     <string name="settings_about">အကြောင်း</string>
-    <string name="settings_version">ဗားရှင်း 1.7</string>
+    <string name="settings_version">ဗားရှင်း 1.8</string>
     <string name="settings_view_github">GitHub တွင် ကြည့်ရန်</string>
     <string name="settings_donate">လှူဒါန်းရန်</string>
     <string name="settings_donate_description">ဒီအက်ပ်က သင့်ကို ကူညီခဲ့ရင် လှူဒါန်းရန် စဉ်းစားပါ</string>
@@ -680,6 +680,33 @@
     <string name="settings_disable_cover_art_description">ပြင်ပဆာဗာများမှ စတေးရှင်းပုံများ တင်ခြင်း တားဆီးရန်</string>
     <string name="settings_network_api_info">အက်ပ်သည် ဤအရာများနှင့်သာ ချိတ်ဆက်သည်: clearnet စတေးရှင်းများအတွက် RadioBrowser API၊ Tor/I2P စတေးရှင်းများအတွက် Radio Registry API၊ cover art အတွက် ပြင်ပဆာဗာများနှင့် ဖွင့်သည့်အခါ ရေဒီယိုစတရိမ်များ။</string>
     <string name="settings_offline_mode_note">API နှစ်ခုလုံး ပိတ်ထားသည်: Browse တက်ဘ်တွင် ဒေသတွင်း စာကြည့်တိုက်သာ ပြသသည်။ သိမ်းဆည်းထားသော စတေးရှင်းများကို ဖွင့်နိုင်ပြီး ဖိုင်များမှ တင်သွင်းနိုင်ပါသည်။</string>
+
+    <!-- Integrations (Android Auto) -->
+    <string name="settings_integrations">ပေါင်းစပ်မှုများ</string>
+    <string name="settings_android_auto">Android Auto ပံ့ပိုးမှု</string>
+    <string name="settings_android_auto_description">သင်၏ စတေးရှင်းများကို Google ၏ Android Auto အက်ပ်သို့ ထုတ်ဖော်ပြသကာ ကားခေါင်းယူနစ်မှ ဖွင့်နိုင်စေသည်။ ပုံသေအားဖြင့် ပိတ်ထားသည်။</string>
+    <string name="settings_android_auto_info">ဖွင့်ထားသည့်အခါ၊ proxy မပါသော စတေးရှင်းများသာ Android Auto တွင် ပြသသည်။ Proxy ပါသော စတေးရှင်းများ (Tor၊ I2P စသည်) ကို ကိုယ်ရေးကာကွယ်မှုအတွက် Android Auto မှ ပုံသေအားဖြင့် ဖျောက်ထားသည်။</string>
+    <string name="settings_android_auto_blocked_force_proxy">Force-proxy ဆက်တင် (Force Tor၊ I2P မှလွဲ၍ Force Tor သို့မဟုတ် Force စိတ်ကြိုက် proxy) ဖွင့်ထားသောကြောင့် Android Auto ပိတ်ထားသည်။ Android Auto မှ ဖွင့်ခြင်းသည် အဆိုပါ proxy များကို မဖြတ်သော သီးခြား audio pipeline ကို အသုံးပြုသောကြောင့် ၎င်းကို ဖွင့်ခြင်းသည် ၎င်းတို့ကို ကျော်သွားမည်။ Android Auto ဖွင့်ရန် force-proxy ကို ပိတ်ပါ။</string>
+    <string name="android_auto_warning_title">Android Auto ဖွင့်မည်လား?</string>
+    <string name="android_auto_warning_message">၎င်းကို မဖွင့်မီ၊ ဤသည်မှာ ပြောင်းလဲသွားမည့်အရာများ:\n\n• သင်၏ clearnet စတေးရှင်းများသည် Android Auto တွင် ပြသလာမည်။\n\n• Google ၏ Android Auto လုပ်ငန်းစဉ်သည် သင်ဖွင့်နေစဉ် စတေးရှင်းအမည်၊ လက်ရှိသီချင်းနှင့် artwork ကို မြင်မည်။\n\n• Tor၊ I2P နှင့် စိတ်ကြိုက်-proxy စတေးရှင်းများသည် ပုံသေအားဖြင့် ဖျောက်ထားသည်။ Android Auto ဖွင့်ပြီးနောက် သူတို့လည်း ပြသရန် ရွေးချယ်နိုင်သည်: မရွေးချယ်မီ ဆက်တင်များမှ ကိုယ်ရေးကာကွယ်မှုဆိုင်ရာ အပြန်အလှန် သတိပေးလိမ့်မည်။\n\n• Force Tor သို့မဟုတ် Force စိတ်ကြိုက် proxy ကို ဖွင့်လျှင်၊ ၎င်းကို ပြန်ပိတ်သည်အထိ Android Auto ကို အလိုအလျောက် ပိတ်သွားမည်။\n\n• Android Auto ကို အချိန်မရွေး ဆက်တင်များမှ ပြန်ပိတ်နိုင်သည်။</string>
+    <string name="android_auto_warning_enable">Android Auto ဖွင့်မည်</string>
+    <string name="android_auto_warning_cancel">ပယ်ဖျက်မည်</string>
+    <string name="auto_node_favorites">အကြိုက်ဆုံးများ</string>
+    <string name="auto_node_all_stations">စတေးရှင်းအားလုံး</string>
+
+    <!-- AA: per-station proxy opt-in -->
+    <string name="settings_aa_allow_proxy_stations">Android Auto တွင် proxy စတေးရှင်းများ ပြရန်</string>
+    <string name="settings_aa_allow_proxy_stations_description">ပုံသေအားဖြင့် ပိတ်ထားသည်။ ဖွင့်သောအခါ၊ သင်၏ Tor / I2P / စိတ်ကြိုက်-proxy စတေးရှင်းများသည်လည်း Android Auto တွင် ပြသပြီး သူတို့၏ proxy မှ ဖွင့်မည်။ အသံကိုယ်တိုင်သည် သီးသန့်ဖြစ်သော်လည်း၊ စတေးရှင်းအမည်နှင့် metadata သည် Google ၏ Android Auto လုပ်ငန်းစဉ်တွင် မြင်နိုင်သည်။</string>
+    <string name="aa_allow_proxy_warning_title">Android Auto တွင် proxy စတေးရှင်းများ ပြမည်လား?</string>
+    <string name="aa_allow_proxy_warning_message">ဤစတေးရှင်းများအတွက် အသံသည် သင်၏ ဖုန်းရှိ ကွန်ဖီဂါရေးရှင်းလုပ်ထားသော Tor / I2P / စိတ်ကြိုက် proxy မှ ဆက်လက်သွားမည်: ဖွင့်ခြင်းကိုယ်တိုင် proxy ဖြင့် ဆက်ရှိနေသည်။\n\nသို့သော် Google ၏ Android Auto လုပ်ငန်းစဉ်သည် စတေးရှင်းအမည်၊ လက်ရှိသီချင်းနှင့် artwork ကို မြင်သည်။ ထို့ကြောင့် *သင်ကြားနေရသည့်အရာ* ကို Google သို့ မပို့သော်လည်း၊ *သင်သည် တိကျသော စတေးရှင်းတစ်ခုကို နားထောင်နေသည် ဆိုသည့်အချက်* ကို Google မြင်နိုင်မည်။ ကိုယ်ရေးကာကွယ်မှုသည် မလွဲသာဖြစ်ပါက၊ Android Auto ကို မသုံးပါနှင့်။ </string>
+    <string name="aa_allow_proxy_warning_enable">ပြမည်</string>
+    <string name="aa_allow_proxy_warning_cancel">ဖျောက်ထားမည်</string>
+
+    <!-- AA: first-connect notification (Moment 2) -->
+    <string name="aa_notification_channel_name">Android Auto</string>
+    <string name="aa_notification_channel_description">Android Auto တပ်ဆင်ခြင်းအကြောင်း တစ်ကြိမ်တည်း အကြောင်းကြားချက်များ။ အက်ပ်သည် ဤချန်နယ်ကို ဆက်လက်ဖွင့်ခြင်းအတွက် အသုံးမပြုပါ။</string>
+    <string name="aa_first_connect_title">Android Auto ယခု ချိတ်ဆက်ပြီးပါပြီ</string>
+    <string name="aa_first_connect_text">သင်၏ clearnet စတေးရှင်းများကို ကားတွင် ပြနေသည်။ Tor၊ I2P နှင့် စိတ်ကြိုက်-proxy စတေးရှင်းများကိုလည်း ပြသင့်မပြသင့် ရွေးချယ်ရန် တို့ပါ။</string>
 
     <!-- Browse - Offline Mode -->
     <string name="browse_offline_mode_title">အော့ဖ်လိုင်းမုဒ်</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -270,7 +270,7 @@
 
     
     <string name="settings_about">Sobre</string>
-    <string name="settings_version">Versão 1.7</string>
+    <string name="settings_version">Versão 1.8</string>
     <string name="settings_view_github">Ver no GitHub</string>
     <string name="settings_donate">Doar</string>
     <string name="settings_donate_description">Se este aplicativo ajudou você, considere fazer uma doação</string>
@@ -680,6 +680,33 @@
     <string name="settings_disable_cover_art_description">Impedir carregamento de imagens de estações de servidores externos</string>
     <string name="settings_network_api_info">O aplicativo conecta-se apenas a: API RadioBrowser para estações clearnet, API Radio Registry para estações Tor/I2P, servidores externos para capas e streams de rádio ao reproduzir.</string>
     <string name="settings_offline_mode_note">Ambas APIs desativadas: A aba Explorar mostra apenas a biblioteca local. Você ainda pode reproduzir estações salvas e importar estações de arquivos.</string>
+
+    <!-- Integrations (Android Auto) -->
+    <string name="settings_integrations">Integrações</string>
+    <string name="settings_android_auto">Suporte a Android Auto</string>
+    <string name="settings_android_auto_description">Exponha suas estações ao aplicativo Android Auto do Google para que você possa reproduzi-las a partir do central multimídia do carro. Desativado por padrão.</string>
+    <string name="settings_android_auto_info">Quando ativado, apenas estações sem proxy aparecem no Android Auto. Estações com proxy (Tor, I2P, etc) ficam ocultas do Android Auto por padrão, por privacidade.</string>
+    <string name="settings_android_auto_blocked_force_proxy">O Android Auto está desativado porque uma configuração de proxy forçado está ligada (Forçar Tor, Forçar Tor exceto I2P ou Forçar proxy personalizado). A reprodução pelo Android Auto usa um pipeline de áudio separado que não passa por esses proxies, então ativá-lo os contornaria. Desligue o proxy forçado para ativar o Android Auto.</string>
+    <string name="android_auto_warning_title">Ativar o Android Auto?</string>
+    <string name="android_auto_warning_message">Antes de ativar, veja o que muda:\n\n• Suas estações clearnet aparecerão no Android Auto.\n\n• O processo Android Auto do Google verá o nome da estação, a faixa atual e a capa enquanto você estiver reproduzindo.\n\n• Estações Tor, I2P e com proxy personalizado permanecem ocultas por padrão. Depois de ativar o Android Auto, você pode escolher permitir que elas também apareçam: as Configurações o avisarão sobre o compromisso de privacidade antes.\n\n• Se você algum dia ativar Forçar Tor ou Forçar proxy personalizado, o Android Auto será desativado automaticamente até que você desligue isso.\n\n• Você pode desativar o Android Auto novamente a qualquer momento nas Configurações.</string>
+    <string name="android_auto_warning_enable">Ativar Android Auto</string>
+    <string name="android_auto_warning_cancel">Cancelar</string>
+    <string name="auto_node_favorites">Favoritas</string>
+    <string name="auto_node_all_stations">Todas as estações</string>
+
+    <!-- AA: per-station proxy opt-in -->
+    <string name="settings_aa_allow_proxy_stations">Mostrar estações com proxy no Android Auto</string>
+    <string name="settings_aa_allow_proxy_stations_description">Desativado por padrão. Quando ativado, suas estações Tor / I2P / com proxy personalizado também aparecem no Android Auto e tocam através do seu proxy. O áudio em si é privado, mas o nome da estação e os metadados ficam visíveis ao processo Android Auto do Google.</string>
+    <string name="aa_allow_proxy_warning_title">Mostrar estações com proxy no Android Auto?</string>
+    <string name="aa_allow_proxy_warning_message">O áudio dessas estações continuará sendo roteado através do Tor / I2P / proxy personalizado configurado no seu telefone: a reprodução em si permanece com proxy.\n\nMas o processo Android Auto do Google vê o nome da estação, a faixa atual e a capa. Então, embora *o que você está ouvindo* não seja enviado ao Google, *o fato de você estar ouvindo uma estação específica* ficará visível para o Google. Se privacidade for essencial, não use Android Auto. </string>
+    <string name="aa_allow_proxy_warning_enable">Mostrar</string>
+    <string name="aa_allow_proxy_warning_cancel">Mantê-las ocultas</string>
+
+    <!-- AA: first-connect notification (Moment 2) -->
+    <string name="aa_notification_channel_name">Android Auto</string>
+    <string name="aa_notification_channel_description">Notificações únicas sobre a configuração do Android Auto. O aplicativo não usa este canal para reprodução contínua.</string>
+    <string name="aa_first_connect_title">Android Auto conectado</string>
+    <string name="aa_first_connect_text">Suas estações clearnet estão aparecendo no carro. Toque para escolher se as estações Tor, I2P e com proxy personalizado também devem aparecer.</string>
 
     <!-- Browse - Offline Mode -->
     <string name="browse_offline_mode_title">Modo offline</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -270,7 +270,7 @@
 
     
     <string name="settings_about">О программе</string>
-    <string name="settings_version">Версия 1.7</string>
+    <string name="settings_version">Версия 1.8</string>
     <string name="settings_view_github">Посмотреть на GitHub</string>
     <string name="settings_donate">Поддержать</string>
     <string name="settings_donate_description">Если это приложение вам помогло, рассмотрите возможность поддержки</string>
@@ -679,6 +679,33 @@
     <string name="settings_disable_cover_art_description">Запретить загрузку изображений станций с внешних серверов</string>
     <string name="settings_network_api_info">Приложение подключается только к: API RadioBrowser для clearnet-станций, API Radio Registry для Tor/I2P-станций, внешним серверам для обложек и радиопотокам при воспроизведении.</string>
     <string name="settings_offline_mode_note">Оба API отключены: вкладка «Обзор» показывает только локальную библиотеку. Вы по-прежнему можете воспроизводить сохранённые станции и импортировать станции из файлов.</string>
+
+    <!-- Integrations (Android Auto) -->
+    <string name="settings_integrations">Интеграции</string>
+    <string name="settings_android_auto">Поддержка Android Auto</string>
+    <string name="settings_android_auto_description">Предоставляет ваши станции приложению Google Android Auto, чтобы вы могли воспроизводить их через автомобильную магнитолу. По умолчанию отключено.</string>
+    <string name="settings_android_auto_info">Когда включено, в Android Auto отображаются только станции без прокси. Станции с прокси (Tor, I2P и т.д.) по умолчанию скрыты из Android Auto для защиты конфиденциальности.</string>
+    <string name="settings_android_auto_blocked_force_proxy">Android Auto отключён, потому что включена настройка принудительного прокси (Принудительный Tor, Принудительный Tor кроме I2P или Принудительный пользовательский прокси). Воспроизведение через Android Auto использует отдельный аудиоконвейер, который не проходит через эти прокси, поэтому его включение обошло бы их. Отключите принудительный прокси, чтобы включить Android Auto.</string>
+    <string name="android_auto_warning_title">Включить Android Auto?</string>
+    <string name="android_auto_warning_message">Прежде чем включить, вот что изменится:\n\n• Ваши clearnet-станции появятся в Android Auto.\n\n• Процесс Google Android Auto увидит название станции, текущий трек и обложку во время воспроизведения.\n\n• Станции Tor, I2P и с пользовательским прокси по умолчанию остаются скрытыми. После включения Android Auto вы можете разрешить их отображение: Настройки предупредят вас о компромиссе конфиденциальности.\n\n• Если вы включите Принудительный Tor или Принудительный пользовательский прокси, Android Auto будет автоматически отключён, пока вы не выключите эту настройку.\n\n• Вы можете снова отключить Android Auto в любое время в Настройках.</string>
+    <string name="android_auto_warning_enable">Включить Android Auto</string>
+    <string name="android_auto_warning_cancel">Отмена</string>
+    <string name="auto_node_favorites">Избранное</string>
+    <string name="auto_node_all_stations">Все станции</string>
+
+    <!-- AA: per-station proxy opt-in -->
+    <string name="settings_aa_allow_proxy_stations">Показывать прокси-станции в Android Auto</string>
+    <string name="settings_aa_allow_proxy_stations_description">По умолчанию отключено. Когда включено, ваши станции Tor / I2P / с пользовательским прокси также отображаются в Android Auto и воспроизводятся через свой прокси. Сам звук остаётся приватным, но название станции и метаданные видны процессу Google Android Auto.</string>
+    <string name="aa_allow_proxy_warning_title">Показывать прокси-станции в Android Auto?</string>
+    <string name="aa_allow_proxy_warning_message">Звук этих станций по-прежнему будет проходить через настроенный Tor / I2P / пользовательский прокси на вашем телефоне: само воспроизведение остаётся проксированным.\n\nНо процесс Google Android Auto видит название станции, текущий трек и обложку. Так что хотя *то, что вы слышите*, не отправляется в Google, *факт того, что вы слушаете определённую станцию*, будет виден Google. Если конфиденциальность обязательна, не используйте Android Auto. </string>
+    <string name="aa_allow_proxy_warning_enable">Показать</string>
+    <string name="aa_allow_proxy_warning_cancel">Оставить скрытыми</string>
+
+    <!-- AA: first-connect notification (Moment 2) -->
+    <string name="aa_notification_channel_name">Android Auto</string>
+    <string name="aa_notification_channel_description">Одноразовые уведомления о настройке Android Auto. Приложение не использует этот канал для текущего воспроизведения.</string>
+    <string name="aa_first_connect_title">Android Auto подключён</string>
+    <string name="aa_first_connect_text">Ваши clearnet-станции отображаются в автомобиле. Нажмите, чтобы выбрать, должны ли также появиться станции Tor, I2P и с пользовательским прокси.</string>
 
     <!-- Browse - Offline Mode -->
     <string name="browse_offline_mode_title">Автономный режим</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -270,7 +270,7 @@
 
     
     <string name="settings_about">Hakkında</string>
-    <string name="settings_version">Sürüm 1.7</string>
+    <string name="settings_version">Sürüm 1.8</string>
     <string name="settings_view_github">GitHub\'da Görüntüle</string>
     <string name="settings_donate">Bağış Yap</string>
     <string name="settings_donate_description">Bu uygulama işinize yaradıysa bağış yapmayı düşünün</string>
@@ -680,6 +680,33 @@
     <string name="settings_disable_cover_art_description">Harici sunuculardan istasyon görsellerinin yüklenmesini engelle</string>
     <string name="settings_network_api_info">Uygulama yalnızca şunlara bağlanır: clearnet istasyonları için RadioBrowser API, Tor/I2P istasyonları için Radio Registry API, kapak resimleri için harici sunucular ve oynatırken radyo akışları.</string>
     <string name="settings_offline_mode_note">Her iki API de devre dışı: Gözat sekmesi yalnızca yerel kütüphaneyi gösterir. Kayıtlı istasyonları çalmaya ve dosyalardan istasyon içe aktarmaya devam edebilirsiniz.</string>
+
+    <!-- Integrations (Android Auto) -->
+    <string name="settings_integrations">Entegrasyonlar</string>
+    <string name="settings_android_auto">Android Auto desteği</string>
+    <string name="settings_android_auto_description">İstasyonlarınızı Google\'ın Android Auto uygulamasına sunarak araç ünitesinden oynatmanıza olanak tanır. Varsayılan olarak kapalı.</string>
+    <string name="settings_android_auto_info">Etkinleştirildiğinde, Android Auto\'da yalnızca proxy kullanmayan istasyonlar görünür. Proxy kullanan istasyonlar (Tor, I2P vb.) gizlilik için Android Auto\'dan varsayılan olarak gizlenir.</string>
+    <string name="settings_android_auto_blocked_force_proxy">Android Auto devre dışı çünkü bir zorla-proxy ayarı açık (Tor\'u Zorla, I2P Hariç Tor\'u Zorla veya Özel Proxy\'yi Zorla). Android Auto\'dan oynatma, bu proxy\'lerden geçmeyen ayrı bir ses hattı kullanır, bu yüzden etkinleştirmek onları atlatır. Android Auto\'yu etkinleştirmek için zorla-proxy\'yi kapatın.</string>
+    <string name="android_auto_warning_title">Android Auto etkinleştirilsin mi?</string>
+    <string name="android_auto_warning_message">Bunu açmadan önce, işte neler değişecek:\n\n• Clearnet istasyonlarınız Android Auto\'da görünecek.\n\n• Google\'ın Android Auto süreci, siz oynatırken istasyon adını, mevcut parçayı ve kapak görselini görecek.\n\n• Tor, I2P ve özel proxy istasyonları varsayılan olarak gizli kalır. Android Auto\'yu etkinleştirdikten sonra, onların da görünmesine izin vermeyi seçebilirsiniz: Ayarlar sizi önce gizlilik ödünü hakkında uyaracak.\n\n• Tor\'u Zorla veya Özel Proxy\'yi Zorla\'yı açarsanız, onu tekrar kapatana kadar Android Auto otomatik olarak devre dışı bırakılır.\n\n• Android Auto\'yu istediğiniz zaman Ayarlar\'dan tekrar kapatabilirsiniz.</string>
+    <string name="android_auto_warning_enable">Android Auto\'yu etkinleştir</string>
+    <string name="android_auto_warning_cancel">İptal</string>
+    <string name="auto_node_favorites">Favoriler</string>
+    <string name="auto_node_all_stations">Tüm istasyonlar</string>
+
+    <!-- AA: per-station proxy opt-in -->
+    <string name="settings_aa_allow_proxy_stations">Android Auto\'da proxy istasyonlarını göster</string>
+    <string name="settings_aa_allow_proxy_stations_description">Varsayılan olarak kapalı. Açıldığında, Tor / I2P / özel proxy istasyonlarınız da Android Auto\'da görünür ve proxy\'leri üzerinden çalınır. Sesin kendisi özeldir, ancak istasyon adı ve meta veriler Google\'ın Android Auto süreci tarafından görülebilir.</string>
+    <string name="aa_allow_proxy_warning_title">Android Auto\'da proxy istasyonları gösterilsin mi?</string>
+    <string name="aa_allow_proxy_warning_message">Bu istasyonların sesi, telefonunuzdaki yapılandırılmış Tor / I2P / özel proxy üzerinden yönlendirilmeye devam edecek: oynatma proxy\'li kalır.\n\nAncak Google\'ın Android Auto süreci istasyon adını, mevcut parçayı ve kapak görselini görür. Yani *duyduğunuz şey* Google\'a gönderilmese de, *belirli bir istasyonu dinlediğiniz gerçeği* Google\'a görünür olacak. Gizlilik şartsa, Android Auto kullanmayın. </string>
+    <string name="aa_allow_proxy_warning_enable">Göster</string>
+    <string name="aa_allow_proxy_warning_cancel">Gizli tut</string>
+
+    <!-- AA: first-connect notification (Moment 2) -->
+    <string name="aa_notification_channel_name">Android Auto</string>
+    <string name="aa_notification_channel_description">Android Auto kurulumu hakkında tek seferlik bildirimler. Uygulama bu kanalı sürekli oynatma için kullanmaz.</string>
+    <string name="aa_first_connect_title">Android Auto şimdi bağlandı</string>
+    <string name="aa_first_connect_text">Clearnet istasyonlarınız araçta görünüyor. Tor, I2P ve özel proxy istasyonlarının da görünüp görünmeyeceğini seçmek için dokunun.</string>
 
     <!-- Browse - Offline Mode -->
     <string name="browse_offline_mode_title">Çevrimdışı Mod</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -270,7 +270,7 @@
 
     
     <string name="settings_about">Про програму</string>
-    <string name="settings_version">Версія 1.7</string>
+    <string name="settings_version">Версія 1.8</string>
     <string name="settings_view_github">Переглянути на GitHub</string>
     <string name="settings_donate">Підтримати</string>
     <string name="settings_donate_description">Якщо цей додаток вам допоміг, розгляньте можливість підтримки</string>
@@ -680,6 +680,33 @@
     <string name="settings_disable_cover_art_description">Заборонити завантаження зображень станцій із зовнішніх серверів</string>
     <string name="settings_network_api_info">Додаток підключається лише до: API RadioBrowser для clearnet-станцій, API Radio Registry для Tor/I2P-станцій, зовнішніх серверів для обкладинок та радіопотоків під час відтворення.</string>
     <string name="settings_offline_mode_note">Обидва API вимкнено: вкладка «Огляд» показує лише локальну бібліотеку. Ви можете відтворювати збережені станції та імпортувати станції з файлів.</string>
+
+    <!-- Integrations (Android Auto) -->
+    <string name="settings_integrations">Інтеграції</string>
+    <string name="settings_android_auto">Підтримка Android Auto</string>
+    <string name="settings_android_auto_description">Надає ваші станції додатку Google Android Auto, щоб ви могли відтворювати їх через автомобільну магнітолу. За замовчуванням вимкнено.</string>
+    <string name="settings_android_auto_info">Коли увімкнено, в Android Auto відображаються лише станції без проксі. Станції з проксі (Tor, I2P тощо) за замовчуванням приховані з Android Auto для захисту конфіденційності.</string>
+    <string name="settings_android_auto_blocked_force_proxy">Android Auto вимкнено, оскільки увімкнено налаштування примусового проксі (Примусовий Tor, Примусовий Tor крім I2P або Примусовий користувацький проксі). Відтворення через Android Auto використовує окремий аудіоконвеєр, який не проходить через ці проксі, тож його увімкнення обійшло б їх. Вимкніть примусовий проксі, щоб увімкнути Android Auto.</string>
+    <string name="android_auto_warning_title">Увімкнути Android Auto?</string>
+    <string name="android_auto_warning_message">Перш ніж увімкнути, ось що зміниться:\n\n• Ваші clearnet-станції з\'являться в Android Auto.\n\n• Процес Google Android Auto побачить назву станції, поточний трек та обкладинку під час відтворення.\n\n• Станції Tor, I2P та з користувацьким проксі за замовчуванням залишаються прихованими. Після увімкнення Android Auto ви можете дозволити їх відображення: Налаштування попередять вас про компроміс конфіденційності перед цим.\n\n• Якщо ви коли-небудь увімкнете Примусовий Tor або Примусовий користувацький проксі, Android Auto буде автоматично вимкнено, доки ви це не вимкнете.\n\n• Ви можете знову вимкнути Android Auto у будь-який час у Налаштуваннях.</string>
+    <string name="android_auto_warning_enable">Увімкнути Android Auto</string>
+    <string name="android_auto_warning_cancel">Скасувати</string>
+    <string name="auto_node_favorites">Улюблені</string>
+    <string name="auto_node_all_stations">Усі станції</string>
+
+    <!-- AA: per-station proxy opt-in -->
+    <string name="settings_aa_allow_proxy_stations">Показувати проксі-станції в Android Auto</string>
+    <string name="settings_aa_allow_proxy_stations_description">За замовчуванням вимкнено. Коли увімкнено, ваші станції Tor / I2P / з користувацьким проксі також відображаються в Android Auto і відтворюються через свій проксі. Сам звук залишається приватним, але назва станції та метадані видимі процесу Google Android Auto.</string>
+    <string name="aa_allow_proxy_warning_title">Показувати проксі-станції в Android Auto?</string>
+    <string name="aa_allow_proxy_warning_message">Звук цих станцій все одно проходитиме через налаштований Tor / I2P / користувацький проксі на вашому телефоні: саме відтворення залишається проксованим.\n\nАле процес Google Android Auto бачить назву станції, поточний трек та обкладинку. Тож хоча *те, що ви чуєте*, не надсилається до Google, *факт того, що ви слухаєте певну станцію*, буде видимий Google. Якщо конфіденційність обов\'язкова, не використовуйте Android Auto. </string>
+    <string name="aa_allow_proxy_warning_enable">Показати</string>
+    <string name="aa_allow_proxy_warning_cancel">Залишити прихованими</string>
+
+    <!-- AA: first-connect notification (Moment 2) -->
+    <string name="aa_notification_channel_name">Android Auto</string>
+    <string name="aa_notification_channel_description">Одноразові сповіщення про налаштування Android Auto. Додаток не використовує цей канал для поточного відтворення.</string>
+    <string name="aa_first_connect_title">Android Auto підключено</string>
+    <string name="aa_first_connect_text">Ваші clearnet-станції відображаються в автомобілі. Натисніть, щоб обрати, чи повинні також з\'явитися станції Tor, I2P та з користувацьким проксі.</string>
 
     <!-- Browse - Offline Mode -->
     <string name="browse_offline_mode_title">Автономний режим</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -270,7 +270,7 @@
 
     
     <string name="settings_about">Giới thiệu</string>
-    <string name="settings_version">Phiên bản 1.7</string>
+    <string name="settings_version">Phiên bản 1.8</string>
     <string name="settings_view_github">Xem trên GitHub</string>
     <string name="settings_donate">Quyên góp</string>
     <string name="settings_donate_description">Nếu ứng dụng này hữu ích cho bạn, hãy xem xét quyên góp</string>
@@ -680,6 +680,33 @@
     <string name="settings_disable_cover_art_description">Ngăn tải hình ảnh đài từ máy chủ bên ngoài</string>
     <string name="settings_network_api_info">Ứng dụng chỉ kết nối với: API RadioBrowser cho các đài clearnet, API Radio Registry cho các đài Tor/I2P, máy chủ bên ngoài cho ảnh bìa và luồng radio khi phát.</string>
     <string name="settings_offline_mode_note">Cả hai API đã tắt: Tab Duyệt chỉ hiển thị thư viện cục bộ. Bạn vẫn có thể phát các đài đã lưu và nhập đài từ tệp.</string>
+
+    <!-- Integrations (Android Auto) -->
+    <string name="settings_integrations">Tích hợp</string>
+    <string name="settings_android_auto">Hỗ trợ Android Auto</string>
+    <string name="settings_android_auto_description">Hiển thị các đài của bạn cho ứng dụng Android Auto của Google để bạn có thể phát chúng từ đầu điều khiển trên xe hơi. Mặc định tắt.</string>
+    <string name="settings_android_auto_info">Khi bật, chỉ các đài không qua proxy mới xuất hiện trong Android Auto. Các đài qua proxy (Tor, I2P, v.v.) được ẩn khỏi Android Auto theo mặc định để bảo vệ quyền riêng tư.</string>
+    <string name="settings_android_auto_blocked_force_proxy">Android Auto bị tắt vì cài đặt bắt buộc proxy đang bật (Bắt buộc Tor, Bắt buộc Tor trừ I2P, hoặc Bắt buộc proxy tùy chỉnh). Việc phát từ Android Auto sử dụng một đường dẫn âm thanh riêng không đi qua các proxy đó, vì vậy bật nó sẽ bỏ qua chúng. Tắt bắt buộc proxy để bật Android Auto.</string>
+    <string name="android_auto_warning_title">Bật Android Auto?</string>
+    <string name="android_auto_warning_message">Trước khi bật tính năng này, đây là những gì sẽ thay đổi:\n\n• Các đài clearnet của bạn sẽ xuất hiện trong Android Auto.\n\n• Tiến trình Android Auto của Google sẽ thấy tên đài, bản nhạc hiện tại và ảnh bìa trong khi bạn đang phát.\n\n• Các đài Tor, I2P và proxy tùy chỉnh vẫn ẩn theo mặc định. Sau khi bật Android Auto, bạn có thể chọn hiển thị chúng: Cài đặt sẽ cảnh báo bạn về sự đánh đổi quyền riêng tư trước khi bạn thực hiện.\n\n• Nếu bạn bật Bắt buộc Tor hoặc Bắt buộc proxy tùy chỉnh, Android Auto sẽ tự động bị tắt cho đến khi bạn tắt chúng trở lại.\n\n• Bạn có thể tắt Android Auto bất kỳ lúc nào từ Cài đặt.</string>
+    <string name="android_auto_warning_enable">Bật Android Auto</string>
+    <string name="android_auto_warning_cancel">Hủy</string>
+    <string name="auto_node_favorites">Yêu thích</string>
+    <string name="auto_node_all_stations">Tất cả các đài</string>
+
+    <!-- AA: per-station proxy opt-in -->
+    <string name="settings_aa_allow_proxy_stations">Hiển thị các đài proxy trong Android Auto</string>
+    <string name="settings_aa_allow_proxy_stations_description">Mặc định tắt. Khi bật, các đài Tor / I2P / proxy tùy chỉnh của bạn cũng sẽ xuất hiện trong Android Auto và phát qua proxy của chúng. Bản thân âm thanh vẫn riêng tư, nhưng tên đài và siêu dữ liệu sẽ hiển thị cho tiến trình Android Auto của Google.</string>
+    <string name="aa_allow_proxy_warning_title">Hiển thị các đài proxy trong Android Auto?</string>
+    <string name="aa_allow_proxy_warning_message">Âm thanh của các đài này vẫn sẽ được định tuyến qua Tor / I2P / proxy tùy chỉnh đã cấu hình trên điện thoại của bạn: bản thân việc phát vẫn đi qua proxy.\n\nTuy nhiên, tiến trình Android Auto của Google sẽ thấy tên đài, bản nhạc hiện tại và ảnh bìa. Vì vậy, trong khi *những gì bạn đang nghe* không được gửi cho Google, *việc bạn đang nghe một đài cụ thể* sẽ hiển thị cho Google. Nếu quyền riêng tư là bắt buộc, đừng sử dụng Android Auto. </string>
+    <string name="aa_allow_proxy_warning_enable">Hiển thị chúng</string>
+    <string name="aa_allow_proxy_warning_cancel">Giữ ẩn</string>
+
+    <!-- AA: first-connect notification (Moment 2) -->
+    <string name="aa_notification_channel_name">Android Auto</string>
+    <string name="aa_notification_channel_description">Thông báo một lần về thiết lập Android Auto. Ứng dụng không sử dụng kênh này cho việc phát liên tục.</string>
+    <string name="aa_first_connect_title">Android Auto đã được kết nối</string>
+    <string name="aa_first_connect_text">Các đài clearnet của bạn đang hiển thị trong xe. Nhấn để chọn xem các đài Tor, I2P và proxy tùy chỉnh có nên xuất hiện hay không.</string>
 
     <!-- Browse - Offline Mode -->
     <string name="browse_offline_mode_title">Chế độ ngoại tuyến</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -270,7 +270,7 @@
 
     
     <string name="settings_about">关于</string>
-    <string name="settings_version">版本 1.7</string>
+    <string name="settings_version">版本 1.8</string>
     <string name="settings_view_github">在 GitHub 上查看</string>
     <string name="settings_donate">捐赠</string>
     <string name="settings_donate_description">如果此应用对您有帮助，请考虑捐赠</string>
@@ -680,6 +680,33 @@
     <string name="settings_disable_cover_art_description">阻止从外部服务器加载电台图片</string>
     <string name="settings_network_api_info">应用仅连接到：用于明网电台的 RadioBrowser API、用于 Tor/I2P 电台的 Radio Registry API、用于封面的外部服务器以及播放时的广播流。</string>
     <string name="settings_offline_mode_note">两个 API 均已禁用：浏览标签页仅显示本地库。您仍可以播放已保存的电台并从文件导入电台。</string>
+
+    <!-- Integrations (Android Auto) -->
+    <string name="settings_integrations">集成</string>
+    <string name="settings_android_auto">Android Auto 支持</string>
+    <string name="settings_android_auto_description">将您的电台公开给 Google 的 Android Auto 应用，以便您可以在汽车主机上播放。默认关闭。</string>
+    <string name="settings_android_auto_info">启用后，仅非代理电台会出现在 Android Auto 中。为保护隐私，代理电台（Tor、I2P 等）默认不会在 Android Auto 中显示。</string>
+    <string name="settings_android_auto_blocked_force_proxy">由于强制代理设置已启用（强制 Tor、强制 Tor 除 I2P 之外，或强制自定义代理），Android Auto 已被禁用。Android Auto 的播放使用独立的音频管道，不会通过这些代理，因此启用它会绕过代理。请关闭强制代理以启用 Android Auto。</string>
+    <string name="android_auto_warning_title">启用 Android Auto？</string>
+    <string name="android_auto_warning_message">在开启此功能之前，请注意以下变化：\n\n• 您的明网电台将出现在 Android Auto 中。\n\n• 播放时，Google 的 Android Auto 进程将看到电台名称、当前曲目和封面图片。\n\n• Tor、I2P 和自定义代理电台默认保持隐藏。启用 Android Auto 后，您可以选择让它们也显示：设置会在您操作前警告您有关隐私权衡的问题。\n\n• 如果您启用强制 Tor 或强制自定义代理，Android Auto 将自动被禁用，直到您将其关闭。\n\n• 您可以随时从设置中再次关闭 Android Auto。</string>
+    <string name="android_auto_warning_enable">启用 Android Auto</string>
+    <string name="android_auto_warning_cancel">取消</string>
+    <string name="auto_node_favorites">收藏</string>
+    <string name="auto_node_all_stations">所有电台</string>
+
+    <!-- AA: per-station proxy opt-in -->
+    <string name="settings_aa_allow_proxy_stations">在 Android Auto 中显示代理电台</string>
+    <string name="settings_aa_allow_proxy_stations_description">默认关闭。开启后，您的 Tor / I2P / 自定义代理电台也会显示在 Android Auto 中，并通过其代理播放。音频本身是私密的，但电台名称和元数据对 Google 的 Android Auto 进程可见。</string>
+    <string name="aa_allow_proxy_warning_title">在 Android Auto 中显示代理电台？</string>
+    <string name="aa_allow_proxy_warning_message">这些电台的音频仍将通过您手机上配置的 Tor / I2P / 自定义代理路由：播放本身保持代理状态。\n\n但 Google 的 Android Auto 进程会看到电台名称、当前曲目和封面图片。因此，虽然*您所听到的内容*不会发送给 Google，但*您正在收听特定电台这一事实*将对 Google 可见。如果隐私是必须的，请勿使用 Android Auto。 </string>
+    <string name="aa_allow_proxy_warning_enable">显示它们</string>
+    <string name="aa_allow_proxy_warning_cancel">保持隐藏</string>
+
+    <!-- AA: first-connect notification (Moment 2) -->
+    <string name="aa_notification_channel_name">Android Auto</string>
+    <string name="aa_notification_channel_description">有关 Android Auto 设置的一次性通知。本应用不会将此通道用于持续播放。</string>
+    <string name="aa_first_connect_title">Android Auto 已连接</string>
+    <string name="aa_first_connect_text">您的明网电台正在汽车中显示。点击选择是否也显示 Tor、I2P 和自定义代理电台。</string>
 
     <!-- Browse - Offline Mode -->
     <string name="browse_offline_mode_title">离线模式</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -343,7 +343,7 @@
 
     <!-- Settings - About -->
     <string name="settings_about">About</string>
-    <string name="settings_version">Version 1.7</string>
+    <string name="settings_version">Version 1.8</string>
     <string name="settings_view_github">View on GitHub</string>
     <string name="settings_donate">Donate</string>
     <string name="settings_donate_description">If this app helped you out, consider donating</string>


### PR DESCRIPTION
Translates the 21 new Android Auto strings (integrations toggle, enable warning, per-station proxy opt-in, first-connect notification) into all 16 supported locales and bumps the in-app version label to 1.8.