### PR TITLE
feat: add "Replace existing stations" option on file import

### DIFF
--- a/app/src/main/java/com/opensource/i2pradio/data/RadioDao.kt
+++ b/app/src/main/java/com/opensource/i2pradio/data/RadioDao.kt
@@ -71,6 +71,9 @@ interface RadioDao {
     @Query("DELETE FROM radio_stations WHERE id IN (:ids)")
     suspend fun deleteStationsByIds(ids: List<Long>)
 
+    @Query("DELETE FROM radio_stations")
+    suspend fun deleteAllStations()
+
     // Toggle like status
     @Query("UPDATE radio_stations SET isLiked = NOT isLiked WHERE id = :id")
     suspend fun toggleLike(id: Long)

--- a/app/src/main/java/com/opensource/i2pradio/data/RadioRepository.kt
+++ b/app/src/main/java/com/opensource/i2pradio/data/RadioRepository.kt
@@ -79,6 +79,12 @@ class RadioRepository(context: Context) {
         }
     }
 
+    suspend fun deleteAllStations() {
+        withContext(Dispatchers.IO) {
+            radioDao.deleteAllStations()
+        }
+    }
+
     suspend fun getStationById(id: Long): RadioStation? {
         return withContext(Dispatchers.IO) {
             radioDao.getStationById(id)

--- a/app/src/main/java/com/opensource/i2pradio/ui/SettingsFragment.kt
+++ b/app/src/main/java/com/opensource/i2pradio/ui/SettingsFragment.kt
@@ -32,6 +32,7 @@ import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import android.widget.LinearLayout
 import com.google.android.material.button.MaterialButton
+import com.google.android.material.checkbox.MaterialCheckBox
 import com.google.android.material.materialswitch.MaterialSwitch
 import com.google.android.material.slider.Slider
 import com.google.android.material.textfield.TextInputEditText
@@ -1610,14 +1611,7 @@ class SettingsFragment : Fragment() {
                         append(getString(R.string.import_confirmation))
                     }
 
-                    MaterialAlertDialogBuilder(requireContext())
-                        .setTitle(getString(R.string.dialog_import_stations))
-                        .setMessage(message)
-                        .setPositiveButton(getString(R.string.button_import)) { _, _ ->
-                            performImport(result.stations)
-                        }
-                        .setNegativeButton(getString(R.string.button_cancel), null)
-                        .show()
+                    showImportConfirmationDialog(message, result.stations)
                 }
             } catch (e: Exception) {
                 withContext(Dispatchers.Main) {
@@ -1636,10 +1630,61 @@ class SettingsFragment : Fragment() {
         }
     }
 
-    private fun performImport(stations: List<com.opensource.i2pradio.data.RadioStation>) {
+    private fun showImportConfirmationDialog(
+        message: String,
+        stations: List<com.opensource.i2pradio.data.RadioStation>
+    ) {
+        val context = requireContext()
+        val dialogView = LayoutInflater.from(context)
+            .inflate(R.layout.dialog_import_confirmation, null)
+        val messageView = dialogView.findViewById<TextView>(R.id.importMessage)
+        val replaceCheckbox = dialogView.findViewById<MaterialCheckBox>(R.id.replaceExistingCheckbox)
+        messageView.text = message
+
+        MaterialAlertDialogBuilder(context)
+            .setTitle(getString(R.string.dialog_import_stations))
+            .setView(dialogView)
+            .setPositiveButton(getString(R.string.button_import)) { _, _ ->
+                if (replaceCheckbox.isChecked) {
+                    confirmReplaceAndImport(stations)
+                } else {
+                    performImport(stations, replaceExisting = false)
+                }
+            }
+            .setNegativeButton(getString(R.string.button_cancel), null)
+            .show()
+    }
+
+    private fun confirmReplaceAndImport(stations: List<com.opensource.i2pradio.data.RadioStation>) {
+        val context = requireContext()
+        lifecycleScope.launch {
+            val existingCount = withContext(Dispatchers.IO) {
+                repository.getAllStationsSync().size
+            }
+            if (!isAdded) return@launch
+
+            MaterialAlertDialogBuilder(context)
+                .setTitle(getString(R.string.import_replace_confirm_title))
+                .setMessage(getString(R.string.import_replace_confirm_message, existingCount))
+                .setPositiveButton(getString(R.string.button_replace_and_import)) { _, _ ->
+                    performImport(stations, replaceExisting = true)
+                }
+                .setNegativeButton(getString(R.string.button_cancel), null)
+                .show()
+        }
+    }
+
+    private fun performImport(
+        stations: List<com.opensource.i2pradio.data.RadioStation>,
+        replaceExisting: Boolean = false
+    ) {
         // Capture context early to avoid crashes if Fragment is destroyed during async operation
         val context = requireContext()
         lifecycleScope.launch(Dispatchers.IO) {
+            if (replaceExisting) {
+                repository.deleteAllStations()
+            }
+
             var imported = 0
             for (station in stations) {
                 try {

--- a/app/src/main/res/layout/dialog_import_confirmation.xml
+++ b/app/src/main/res/layout/dialog_import_confirmation.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:paddingStart="24dp"
+    android:paddingEnd="24dp"
+    android:paddingTop="16dp"
+    android:paddingBottom="8dp">
+
+    <TextView
+        android:id="@+id/importMessage"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:textAppearance="?attr/textAppearanceBodyMedium"
+        android:textColor="?attr/colorOnSurface" />
+
+    <com.google.android.material.checkbox.MaterialCheckBox
+        android:id="@+id/replaceExistingCheckbox"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:text="@string/import_replace_existing" />
+
+    <TextView
+        android:id="@+id/replaceHint"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="48dp"
+        android:layout_marginTop="-4dp"
+        android:text="@string/import_replace_hint"
+        android:textAppearance="?attr/textAppearanceBodySmall"
+        android:textColor="?attr/colorOnSurfaceVariant" />
+
+</LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -626,6 +626,11 @@
     <string name="warnings_header">Warnings:\n</string>
     <string name="more_warnings">• ...and %d more\n</string>
     <string name="import_confirmation">Do you want to import these stations?</string>
+    <string name="import_replace_existing">Replace existing stations</string>
+    <string name="import_replace_hint">Clears your entire library before importing</string>
+    <string name="import_replace_confirm_title">Replace all stations?</string>
+    <string name="import_replace_confirm_message">This will permanently delete all %1$d existing station(s) (including liked and preset stations) before importing. This cannot be undone.</string>
+    <string name="button_replace_and_import">Replace &amp; Import</string>
     <string name="import_error_message">Import error: %s</string>
     <string name="imported_stations_success">Imported %d station(s)</string>
     <string name="no_stations_to_export">No stations to export</string>


### PR DESCRIPTION
The file import flow previously only appended and silently skipped duplicates. This adds a checkbox to the import confirmation dialog that wipes the existing library before importing, gated behind a second destructive-action confirmation.

https://claude.ai/code/session_01Dvt7wCUitSaWDmWHB3m3WP