### PR TITLE
Add missing import-replace strings to 16 locales

### DIFF
--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -547,6 +547,11 @@
     <string name="warnings_header">تحذيرات:\n</string>
     <string name="more_warnings">• ...و %d أخرى\n</string>
     <string name="import_confirmation">هل تريد استيراد هذه المحطات؟</string>
+    <string name="import_replace_existing">استبدال المحطات الحالية</string>
+    <string name="import_replace_hint">يمسح مكتبتك بالكامل قبل الاستيراد</string>
+    <string name="import_replace_confirm_title">استبدال جميع المحطات؟</string>
+    <string name="import_replace_confirm_message">سيؤدي هذا إلى حذف جميع المحطات الحالية البالغ عددها %1$d نهائيًا (بما في ذلك المحطات المفضلة والمعدة مسبقًا) قبل الاستيراد. لا يمكن التراجع عن هذا الإجراء.</string>
+    <string name="button_replace_and_import">استبدال واستيراد</string>
     <string name="import_error_message">خطأ في الاستيراد: %s</string>
     <string name="imported_stations_success">تم استيراد %d محطة</string>
     <string name="no_stations_to_export">لا توجد محطات للتصدير</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -548,6 +548,11 @@
     <string name="warnings_header">Warnungen:\n</string>
     <string name="more_warnings">• ...und %d weitere\n</string>
     <string name="import_confirmation">Möchten Sie diese Sender importieren?</string>
+    <string name="import_replace_existing">Vorhandene Sender ersetzen</string>
+    <string name="import_replace_hint">Löscht vor dem Import Ihre gesamte Bibliothek</string>
+    <string name="import_replace_confirm_title">Alle Sender ersetzen?</string>
+    <string name="import_replace_confirm_message">Dadurch werden alle %1$d vorhandenen Sender (einschließlich favorisierter und voreingestellter Sender) vor dem Import dauerhaft gelöscht. Dies kann nicht rückgängig gemacht werden.</string>
+    <string name="button_replace_and_import">Ersetzen &amp; Importieren</string>
     <string name="import_error_message">Importfehler: %s</string>
     <string name="imported_stations_success">%d Sender importiert</string>
     <string name="no_stations_to_export">Keine Sender zum Exportieren</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -552,6 +552,11 @@
     <string name="warnings_header">Advertencias:\n</string>
     <string name="more_warnings">• ...y %d más\n</string>
     <string name="import_confirmation">¿Quieres importar estas estaciones?</string>
+    <string name="import_replace_existing">Reemplazar estaciones existentes</string>
+    <string name="import_replace_hint">Borra toda tu biblioteca antes de importar</string>
+    <string name="import_replace_confirm_title">¿Reemplazar todas las estaciones?</string>
+    <string name="import_replace_confirm_message">Esto eliminará permanentemente las %1$d estación(es) existentes (incluidas las favoritas y predeterminadas) antes de importar. Esta acción no se puede deshacer.</string>
+    <string name="button_replace_and_import">Reemplazar e importar</string>
     <string name="import_error_message">Error de importación: %s</string>
     <string name="imported_stations_success">Se importaron %d estación(es)</string>
     <string name="no_stations_to_export">No hay estaciones para exportar</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -548,6 +548,11 @@
     <string name="warnings_header">هشدارها:\n</string>
     <string name="more_warnings">• ...و %d مورد دیگر\n</string>
     <string name="import_confirmation">آیا می‌خواهید این ایستگاه‌ها را وارد کنید؟</string>
+    <string name="import_replace_existing">جایگزینی ایستگاه‌های موجود</string>
+    <string name="import_replace_hint">قبل از وارد کردن، تمام کتابخانه شما را پاک می‌کند</string>
+    <string name="import_replace_confirm_title">جایگزینی همه ایستگاه‌ها؟</string>
+    <string name="import_replace_confirm_message">این کار تمام %1$d ایستگاه موجود (از جمله ایستگاه‌های مورد علاقه و پیش‌تنظیم‌شده) را قبل از وارد کردن برای همیشه حذف می‌کند. این عمل قابل بازگشت نیست.</string>
+    <string name="button_replace_and_import">جایگزینی و وارد کردن</string>
     <string name="import_error_message">خطای وارد کردن: %s</string>
     <string name="imported_stations_success">%d ایستگاه وارد شد</string>
     <string name="no_stations_to_export">هیچ ایستگاهی برای صادر کردن وجود ندارد</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -547,6 +547,11 @@
     <string name="warnings_header">Avertissements :\n</string>
     <string name="more_warnings">• ...et %d de plus\n</string>
     <string name="import_confirmation">Voulez-vous importer ces stations ?</string>
+    <string name="import_replace_existing">Remplacer les stations existantes</string>
+    <string name="import_replace_hint">Efface toute votre bibliothèque avant l'importation</string>
+    <string name="import_replace_confirm_title">Remplacer toutes les stations ?</string>
+    <string name="import_replace_confirm_message">Cela supprimera définitivement les %1$d station(s) existante(s) (y compris les stations favorites et prédéfinies) avant l'importation. Cette action est irréversible.</string>
+    <string name="button_replace_and_import">Remplacer et importer</string>
     <string name="import_error_message">Erreur d\'importation : %s</string>
     <string name="imported_stations_success">%d station(s) importée(s)</string>
     <string name="no_stations_to_export">Aucune station à exporter</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -548,9 +548,9 @@
     <string name="more_warnings">• ...et %d de plus\n</string>
     <string name="import_confirmation">Voulez-vous importer ces stations ?</string>
     <string name="import_replace_existing">Remplacer les stations existantes</string>
-    <string name="import_replace_hint">Efface toute votre bibliothèque avant l'importation</string>
+    <string name="import_replace_hint">Efface toute votre bibliothèque avant l\'importation</string>
     <string name="import_replace_confirm_title">Remplacer toutes les stations ?</string>
-    <string name="import_replace_confirm_message">Cela supprimera définitivement les %1$d station(s) existante(s) (y compris les stations favorites et prédéfinies) avant l'importation. Cette action est irréversible.</string>
+    <string name="import_replace_confirm_message">Cela supprimera définitivement les %1$d station(s) existante(s) (y compris les stations favorites et prédéfinies) avant l\'importation. Cette action est irréversible.</string>
     <string name="button_replace_and_import">Remplacer et importer</string>
     <string name="import_error_message">Erreur d\'importation : %s</string>
     <string name="imported_stations_success">%d station(s) importée(s)</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -547,6 +547,11 @@
     <string name="warnings_header">चेतावनियां:\n</string>
     <string name="more_warnings">• ...और %d और\n</string>
     <string name="import_confirmation">क्या आप इन स्टेशनों को आयात करना चाहते हैं?</string>
+    <string name="import_replace_existing">मौजूदा स्टेशन बदलें</string>
+    <string name="import_replace_hint">आयात से पहले आपकी पूरी लाइब्रेरी साफ़ कर देगा</string>
+    <string name="import_replace_confirm_title">सभी स्टेशन बदलें?</string>
+    <string name="import_replace_confirm_message">यह आयात से पहले %1$d मौजूदा स्टेशन(स्टेशनों) को स्थायी रूप से हटा देगा (पसंदीदा और प्रीसेट स्टेशनों सहित)। इसे पूर्ववत नहीं किया जा सकता।</string>
+    <string name="button_replace_and_import">बदलें और आयात करें</string>
     <string name="import_error_message">आयात त्रुटि: %s</string>
     <string name="imported_stations_success">%d स्टेशन आयात किए गए</string>
     <string name="no_stations_to_export">निर्यात करने के लिए कोई स्टेशन नहीं</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -548,9 +548,9 @@
     <string name="more_warnings">• ...e altri %d\n</string>
     <string name="import_confirmation">Vuoi importare queste stazioni?</string>
     <string name="import_replace_existing">Sostituisci stazioni esistenti</string>
-    <string name="import_replace_hint">Cancella l'intera libreria prima dell'importazione</string>
+    <string name="import_replace_hint">Cancella l\'intera libreria prima dell\'importazione</string>
     <string name="import_replace_confirm_title">Sostituire tutte le stazioni?</string>
-    <string name="import_replace_confirm_message">Questa operazione eliminerà definitivamente tutte le %1$d stazioni esistenti (incluse quelle preferite e preimpostate) prima dell'importazione. Questa azione non può essere annullata.</string>
+    <string name="import_replace_confirm_message">Questa operazione eliminerà definitivamente tutte le %1$d stazioni esistenti (incluse quelle preferite e preimpostate) prima dell\'importazione. Questa azione non può essere annullata.</string>
     <string name="button_replace_and_import">Sostituisci e importa</string>
     <string name="import_error_message">Errore di importazione: %s</string>
     <string name="imported_stations_success">%d stazione/i importata/e</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -547,6 +547,11 @@
     <string name="warnings_header">Avvisi:\n</string>
     <string name="more_warnings">• ...e altri %d\n</string>
     <string name="import_confirmation">Vuoi importare queste stazioni?</string>
+    <string name="import_replace_existing">Sostituisci stazioni esistenti</string>
+    <string name="import_replace_hint">Cancella l'intera libreria prima dell'importazione</string>
+    <string name="import_replace_confirm_title">Sostituire tutte le stazioni?</string>
+    <string name="import_replace_confirm_message">Questa operazione eliminerà definitivamente tutte le %1$d stazioni esistenti (incluse quelle preferite e preimpostate) prima dell'importazione. Questa azione non può essere annullata.</string>
+    <string name="button_replace_and_import">Sostituisci e importa</string>
     <string name="import_error_message">Errore di importazione: %s</string>
     <string name="imported_stations_success">%d stazione/i importata/e</string>
     <string name="no_stations_to_export">Nessuna stazione da esportare</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -547,6 +547,11 @@
     <string name="warnings_header">警告:\n</string>
     <string name="more_warnings">• ...他%d件\n</string>
     <string name="import_confirmation">これらのステーションをインポートしますか？</string>
+    <string name="import_replace_existing">既存のステーションを置き換える</string>
+    <string name="import_replace_hint">インポート前にライブラリ全体を消去します</string>
+    <string name="import_replace_confirm_title">すべてのステーションを置き換えますか？</string>
+    <string name="import_replace_confirm_message">これにより、インポート前に既存の %1$d 件のステーション（お気に入りやプリセットを含む）がすべて完全に削除されます。この操作は元に戻せません。</string>
+    <string name="button_replace_and_import">置き換えてインポート</string>
     <string name="import_error_message">インポートエラー: %s</string>
     <string name="imported_stations_success">%d個のステーションをインポートしました</string>
     <string name="no_stations_to_export">エクスポートするステーションがありません</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -547,6 +547,11 @@
     <string name="warnings_header">경고:\n</string>
     <string name="more_warnings">• ...외 %d개\n</string>
     <string name="import_confirmation">이 스테이션들을 가져오시겠습니까?</string>
+    <string name="import_replace_existing">기존 스테이션 교체</string>
+    <string name="import_replace_hint">가져오기 전에 전체 라이브러리를 지웁니다</string>
+    <string name="import_replace_confirm_title">모든 스테이션을 교체하시겠습니까?</string>
+    <string name="import_replace_confirm_message">가져오기 전에 기존의 %1$d개 스테이션(좋아요 및 프리셋 스테이션 포함)이 모두 영구적으로 삭제됩니다. 이 작업은 취소할 수 없습니다.</string>
+    <string name="button_replace_and_import">교체 후 가져오기</string>
     <string name="import_error_message">가져오기 오류: %s</string>
     <string name="imported_stations_success">%d개의 스테이션을 가져왔습니다</string>
     <string name="no_stations_to_export">내보낼 스테이션이 없습니다</string>

--- a/app/src/main/res/values-my/strings.xml
+++ b/app/src/main/res/values-my/strings.xml
@@ -548,6 +548,11 @@
     <string name="warnings_header">သတိပေးချက်များ:\n</string>
     <string name="more_warnings">• ...နှင့် နောက်ထပ် %d ခု\n</string>
     <string name="import_confirmation">ဤဘူတာများကို တင်သွင်းမလား?</string>
+    <string name="import_replace_existing">ရှိပြီးသား ဘူတာများကို အစားထိုးမည်</string>
+    <string name="import_replace_hint">တင်သွင်းခြင်းမပြုမီ သင်၏စာကြည့်တိုက်တစ်ခုလုံးကို ရှင်းလင်းသည်</string>
+    <string name="import_replace_confirm_title">ဘူတာအားလုံးကို အစားထိုးမလား?</string>
+    <string name="import_replace_confirm_message">ဤလုပ်ဆောင်ချက်သည် တင်သွင်းခြင်းမပြုမီ ရှိပြီးသား ဘူတာ %1$d ခုလုံး (နှစ်သက်ထားသည့်နှင့် ကြိုတင်သတ်မှတ်ထားသည့် ဘူတာများအပါအဝင်) ကို အပြီးတိုင် ဖျက်ပစ်ပါမည်။ ဤလုပ်ဆောင်ချက်ကို ပြန်ပြင်၍မရပါ။</string>
+    <string name="button_replace_and_import">အစားထိုးပြီး တင်သွင်းမည်</string>
     <string name="import_error_message">တင်သွင်းမှု အမှား: %s</string>
     <string name="imported_stations_success">ဘူတာ %d ခု တင်သွင်းပြီး</string>
     <string name="no_stations_to_export">တင်ပို့ရန် ဘူတာများ မရှိပါ</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -548,6 +548,11 @@
     <string name="warnings_header">Avisos:\n</string>
     <string name="more_warnings">• ...e mais %d\n</string>
     <string name="import_confirmation">Deseja importar estas estações?</string>
+    <string name="import_replace_existing">Substituir estações existentes</string>
+    <string name="import_replace_hint">Limpa toda a sua biblioteca antes de importar</string>
+    <string name="import_replace_confirm_title">Substituir todas as estações?</string>
+    <string name="import_replace_confirm_message">Isto excluirá permanentemente todas as %1$d estação(ões) existentes (incluindo favoritas e predefinidas) antes de importar. Esta ação não pode ser desfeita.</string>
+    <string name="button_replace_and_import">Substituir e importar</string>
     <string name="import_error_message">Erro de importação: %s</string>
     <string name="imported_stations_success">%d estação(ões) importada(s)</string>
     <string name="no_stations_to_export">Nenhuma estação para exportar</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -547,6 +547,11 @@
     <string name="warnings_header">Предупреждения:\n</string>
     <string name="more_warnings">• ...и ещё %d\n</string>
     <string name="import_confirmation">Вы хотите импортировать эти станции?</string>
+    <string name="import_replace_existing">Заменить существующие станции</string>
+    <string name="import_replace_hint">Очищает всю вашу библиотеку перед импортом</string>
+    <string name="import_replace_confirm_title">Заменить все станции?</string>
+    <string name="import_replace_confirm_message">Это навсегда удалит все %1$d существующих станций (включая избранные и предустановленные) перед импортом. Это действие нельзя отменить.</string>
+    <string name="button_replace_and_import">Заменить и импортировать</string>
     <string name="import_error_message">Ошибка импорта: %s</string>
     <string name="imported_stations_success">Импортировано %d станций</string>
     <string name="no_stations_to_export">Нет станций для экспорта</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -548,6 +548,11 @@
     <string name="warnings_header">Uyarılar:\n</string>
     <string name="more_warnings">• ...ve %d tane daha\n</string>
     <string name="import_confirmation">Bu istasyonları içe aktarmak istiyor musunuz?</string>
+    <string name="import_replace_existing">Mevcut istasyonları değiştir</string>
+    <string name="import_replace_hint">İçe aktarmadan önce tüm kitaplığınızı temizler</string>
+    <string name="import_replace_confirm_title">Tüm istasyonlar değiştirilsin mi?</string>
+    <string name="import_replace_confirm_message">Bu işlem, içe aktarmadan önce mevcut %1$d istasyonu (beğenilen ve önceden ayarlanmış istasyonlar dahil) kalıcı olarak silecektir. Bu işlem geri alınamaz.</string>
+    <string name="button_replace_and_import">Değiştir ve İçe Aktar</string>
     <string name="import_error_message">İçe aktarma hatası: %s</string>
     <string name="imported_stations_success">%d istasyon içe aktarıldı</string>
     <string name="no_stations_to_export">Dışa aktarılacak istasyon yok</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -548,6 +548,11 @@
     <string name="warnings_header">Попередження:\n</string>
     <string name="more_warnings">• ...і ще %d\n</string>
     <string name="import_confirmation">Ви хочете імпортувати ці станції?</string>
+    <string name="import_replace_existing">Замінити наявні станції</string>
+    <string name="import_replace_hint">Очищає всю вашу бібліотеку перед імпортом</string>
+    <string name="import_replace_confirm_title">Замінити всі станції?</string>
+    <string name="import_replace_confirm_message">Це назавжди видалить усі %1$d наявних станцій (включно з улюбленими та попередньо встановленими) перед імпортом. Цю дію неможливо скасувати.</string>
+    <string name="button_replace_and_import">Замінити та імпортувати</string>
     <string name="import_error_message">Помилка імпорту: %s</string>
     <string name="imported_stations_success">Імпортовано %d станцій</string>
     <string name="no_stations_to_export">Немає станцій для експорту</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -548,6 +548,11 @@
     <string name="warnings_header">Cảnh báo:\n</string>
     <string name="more_warnings">• ...và %d cảnh báo khác\n</string>
     <string name="import_confirmation">Bạn có muốn nhập các đài này không?</string>
+    <string name="import_replace_existing">Thay thế các đài hiện có</string>
+    <string name="import_replace_hint">Xóa toàn bộ thư viện của bạn trước khi nhập</string>
+    <string name="import_replace_confirm_title">Thay thế tất cả các đài?</string>
+    <string name="import_replace_confirm_message">Điều này sẽ xóa vĩnh viễn tất cả %1$d đài hiện có (bao gồm cả các đài yêu thích và cài đặt sẵn) trước khi nhập. Không thể hoàn tác thao tác này.</string>
+    <string name="button_replace_and_import">Thay thế và nhập</string>
     <string name="import_error_message">Lỗi nhập: %s</string>
     <string name="imported_stations_success">Đã nhập %d đài</string>
     <string name="no_stations_to_export">Không có đài để xuất</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -548,6 +548,11 @@
     <string name="warnings_header">警告：\n</string>
     <string name="more_warnings">• ...还有 %d 个\n</string>
     <string name="import_confirmation">要导入这些电台吗？</string>
+    <string name="import_replace_existing">替换现有电台</string>
+    <string name="import_replace_hint">导入前清空整个媒体库</string>
+    <string name="import_replace_confirm_title">替换所有电台？</string>
+    <string name="import_replace_confirm_message">这将在导入前永久删除所有 %1$d 个现有电台（包括喜欢的和预设的电台）。此操作无法撤销。</string>
+    <string name="button_replace_and_import">替换并导入</string>
     <string name="import_error_message">导入错误：%s</string>
     <string name="imported_stations_success">已导入 %d 个电台</string>
     <string name="no_stations_to_export">没有要导出的电台</string>


### PR DESCRIPTION
All locales were missing 5 strings introduced with the replace-library import flow: import_replace_existing, import_replace_hint, import_replace_confirm_title, import_replace_confirm_message, and button_replace_and_import.

https://claude.ai/code/session_01AMsX1FeyDh2isw2SCiwcjf